### PR TITLE
fix: escape special regex characters in ObjectIdentifier delimiter

### DIFF
--- a/java/lance-namespace-core/src/main/java/com/lancedb/lance/namespace/ObjectIdentifier.java
+++ b/java/lance-namespace-core/src/main/java/com/lancedb/lance/namespace/ObjectIdentifier.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.regex.Pattern;
 
 public class ObjectIdentifier {
 
@@ -51,7 +52,8 @@ public class ObjectIdentifier {
     if (id.equals(delimiter)) {
       return new ObjectIdentifier(new String[0]);
     }
-    return new ObjectIdentifier(id.split(delimiter));
+    // Split by the delimiter literally(i.e., escape any regex special characters)
+    return new ObjectIdentifier(id.split(Pattern.quote(delimiter)));
   }
 
   public String levelAtListPos(int pos) {

--- a/java/lance-namespace-core/src/test/java/com/lancedb/lance/namespace/TestObjectIdentifier.java
+++ b/java/lance-namespace-core/src/test/java/com/lancedb/lance/namespace/TestObjectIdentifier.java
@@ -67,5 +67,15 @@ public class TestObjectIdentifier {
 
     oid = ObjectIdentifier.of(Lists.newArrayList("a", "b", "c"));
     assertEquals(Lists.newArrayList("a", "b"), oid.parent());
+
+    // Case 5: parse from string
+    oid = ObjectIdentifier.of(".");
+    assertEquals(0, oid.levels());
+
+    oid = ObjectIdentifier.of("a.b.c");
+    assertEquals(3, oid.levels());
+    assertEquals("a", oid.levelAtListPos(0));
+    assertEquals("b", oid.levelAtListPos(1));
+    assertEquals("c", oid.levelAtListPos(2));
   }
 }


### PR DESCRIPTION
## Description
Fixed a bug in `ObjectIdentifier.of()` method where delimiters containing regex special characters (like `.`) were not handled correctly.

## Changes
- Wrapped the delimiter parameter with `Pattern.quote()` in the `split()` call
- This ensures special regex characters are treated as literal strings

## Issue
When using `"."` as delimiter, `split()` would treat it as a regex pattern (matching any character) instead of a literal dot, causing incorrect splitting behavior.

## Example
Before: `"db.tb".split(".")` → `[]`
After: `"db.tb".split(Pattern.quote("."))` → `["db", "tb"]`