### PR TITLE
fix: configure maven-compiler-plugin in the root pom.xml only

### DIFF
--- a/java/lance-namespace-apache-client/pom.xml
+++ b/java/lance-namespace-apache-client/pom.xml
@@ -41,10 +41,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.10.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
                     <fork>true</fork>
                     <meminitial>128m</meminitial>
                     <maxmem>512m</maxmem>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -86,6 +86,7 @@
 
         <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
         <maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
+        <maven-compiler-plugin.version>3.10.1</maven-compiler-plugin.version>
     </properties>
 
     <modules>
@@ -164,6 +165,15 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin.version}</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
             </plugin>
         </plugins>
 


### PR DESCRIPTION
For Java part, direct compilation using Maven should also be supported.

This PR moves `maven-compiler-plugin` configuration in one place in the root `pom.xml`, and set `source` and `target` options for the plugin to `1.8`.

Without these changes there are related errors during compilation of Java part using Maven:

```text
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile (default-compile) on project lance-namespace-springboot-server: Compilation failure: Compilation failure: 
[ERROR] Source option 5 is no longer supported. Use 7 or later.
[ERROR] Target option 5 is no longer supported. Use 7 or later.
```
