### PR TITLE
fix: use long for timestamp in table version

### DIFF
--- a/docs/src/client/operations/models/TableVersion.md
+++ b/docs/src/client/operations/models/TableVersion.md
@@ -11,7 +11,7 @@
 |**manifestPath** | **String** | Path to the manifest file for this version. |  |
 |**manifestSize** | **Long** | Size of the manifest file in bytes |  [optional] |
 |**eTag** | **String** | Optional ETag for optimistic concurrency control. Useful for S3 and similar object stores.  |  [optional] |
-|**timestamp** | **OffsetDateTime** | Timestamp when the version was created |  [optional] |
+|**timestampMillis** | **Long** | Timestamp when the version was created, in milliseconds since epoch (Unix time) |  [optional] |
 |**metadata** | **Map&lt;String, String&gt;** | Optional key-value pairs of metadata |  [optional] |
 
 

--- a/docs/src/rest.yaml
+++ b/docs/src/rest.yaml
@@ -4058,10 +4058,10 @@ components:
           description: |
             Optional ETag for optimistic concurrency control.
             Useful for S3 and similar object stores.
-        timestamp:
-          type: string
-          format: date-time
-          description: Timestamp when the version was created
+        timestamp_millis:
+          type: integer
+          format: int64
+          description: Timestamp when the version was created, in milliseconds since epoch (Unix time)
         metadata:
           type: object
           additionalProperties:

--- a/java/lance-namespace-apache-client/api/openapi.yaml
+++ b/java/lance-namespace-apache-client/api/openapi.yaml
@@ -5685,17 +5685,17 @@ components:
         - metadata:
             key: metadata
           manifest_path: manifest_path
+          timestamp_millis: 1
           manifest_size: 0
           e_tag: e_tag
           version: 0
-          timestamp: 2000-01-23T04:56:07.000+00:00
         - metadata:
             key: metadata
           manifest_path: manifest_path
+          timestamp_millis: 1
           manifest_size: 0
           e_tag: e_tag
           version: 0
-          timestamp: 2000-01-23T04:56:07.000+00:00
         page_token: page_token
       properties:
         versions:
@@ -5810,10 +5810,10 @@ components:
           metadata:
             key: metadata
           manifest_path: manifest_path
+          timestamp_millis: 1
           manifest_size: 0
           e_tag: e_tag
           version: 0
-          timestamp: 2000-01-23T04:56:07.000+00:00
       properties:
         transaction_id:
           description: Optional transaction identifier
@@ -5863,10 +5863,10 @@ components:
           metadata:
             key: metadata
           manifest_path: manifest_path
+          timestamp_millis: 1
           manifest_size: 0
           e_tag: e_tag
           version: 0
-          timestamp: 2000-01-23T04:56:07.000+00:00
       properties:
         version:
           $ref: '#/components/schemas/TableVersion'
@@ -5961,10 +5961,10 @@ components:
         metadata:
           key: metadata
         manifest_path: manifest_path
+        timestamp_millis: 1
         manifest_size: 0
         e_tag: e_tag
         version: 0
-        timestamp: 2000-01-23T04:56:07.000+00:00
       properties:
         version:
           description: Version number
@@ -5984,10 +5984,11 @@ components:
             Optional ETag for optimistic concurrency control.
             Useful for S3 and similar object stores.
           type: string
-        timestamp:
-          description: Timestamp when the version was created
-          format: date-time
-          type: string
+        timestamp_millis:
+          description: "Timestamp when the version was created, in milliseconds since\
+            \ epoch (Unix time)"
+          format: int64
+          type: integer
         metadata:
           additionalProperties:
             type: string

--- a/java/lance-namespace-apache-client/docs/TableVersion.md
+++ b/java/lance-namespace-apache-client/docs/TableVersion.md
@@ -11,7 +11,7 @@
 |**manifestPath** | **String** | Path to the manifest file for this version. |  |
 |**manifestSize** | **Long** | Size of the manifest file in bytes |  [optional] |
 |**eTag** | **String** | Optional ETag for optimistic concurrency control. Useful for S3 and similar object stores.  |  [optional] |
-|**timestamp** | **OffsetDateTime** | Timestamp when the version was created |  [optional] |
+|**timestampMillis** | **Long** | Timestamp when the version was created, in milliseconds since epoch (Unix time) |  [optional] |
 |**metadata** | **Map&lt;String, String&gt;** | Optional key-value pairs of metadata |  [optional] |
 
 

--- a/java/lance-namespace-apache-client/src/main/java/org/lance/namespace/model/TableVersion.java
+++ b/java/lance-namespace-apache-client/src/main/java/org/lance/namespace/model/TableVersion.java
@@ -19,7 +19,6 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
-import java.time.OffsetDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -31,7 +30,7 @@ import java.util.StringJoiner;
   TableVersion.JSON_PROPERTY_MANIFEST_PATH,
   TableVersion.JSON_PROPERTY_MANIFEST_SIZE,
   TableVersion.JSON_PROPERTY_E_TAG,
-  TableVersion.JSON_PROPERTY_TIMESTAMP,
+  TableVersion.JSON_PROPERTY_TIMESTAMP_MILLIS,
   TableVersion.JSON_PROPERTY_METADATA
 })
 @javax.annotation.Generated(
@@ -50,8 +49,8 @@ public class TableVersion {
   public static final String JSON_PROPERTY_E_TAG = "e_tag";
   @javax.annotation.Nullable private String eTag;
 
-  public static final String JSON_PROPERTY_TIMESTAMP = "timestamp";
-  @javax.annotation.Nullable private OffsetDateTime timestamp;
+  public static final String JSON_PROPERTY_TIMESTAMP_MILLIS = "timestamp_millis";
+  @javax.annotation.Nullable private Long timestampMillis;
 
   public static final String JSON_PROPERTY_METADATA = "metadata";
   @javax.annotation.Nullable private Map<String, String> metadata = new HashMap<>();
@@ -154,28 +153,28 @@ public class TableVersion {
     this.eTag = eTag;
   }
 
-  public TableVersion timestamp(@javax.annotation.Nullable OffsetDateTime timestamp) {
+  public TableVersion timestampMillis(@javax.annotation.Nullable Long timestampMillis) {
 
-    this.timestamp = timestamp;
+    this.timestampMillis = timestampMillis;
     return this;
   }
 
   /**
-   * Timestamp when the version was created
+   * Timestamp when the version was created, in milliseconds since epoch (Unix time)
    *
-   * @return timestamp
+   * @return timestampMillis
    */
   @javax.annotation.Nullable
-  @JsonProperty(JSON_PROPERTY_TIMESTAMP)
+  @JsonProperty(JSON_PROPERTY_TIMESTAMP_MILLIS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
-  public OffsetDateTime getTimestamp() {
-    return timestamp;
+  public Long getTimestampMillis() {
+    return timestampMillis;
   }
 
-  @JsonProperty(JSON_PROPERTY_TIMESTAMP)
+  @JsonProperty(JSON_PROPERTY_TIMESTAMP_MILLIS)
   @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
-  public void setTimestamp(@javax.annotation.Nullable OffsetDateTime timestamp) {
-    this.timestamp = timestamp;
+  public void setTimestampMillis(@javax.annotation.Nullable Long timestampMillis) {
+    this.timestampMillis = timestampMillis;
   }
 
   public TableVersion metadata(@javax.annotation.Nullable Map<String, String> metadata) {
@@ -223,13 +222,13 @@ public class TableVersion {
         && Objects.equals(this.manifestPath, tableVersion.manifestPath)
         && Objects.equals(this.manifestSize, tableVersion.manifestSize)
         && Objects.equals(this.eTag, tableVersion.eTag)
-        && Objects.equals(this.timestamp, tableVersion.timestamp)
+        && Objects.equals(this.timestampMillis, tableVersion.timestampMillis)
         && Objects.equals(this.metadata, tableVersion.metadata);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(version, manifestPath, manifestSize, eTag, timestamp, metadata);
+    return Objects.hash(version, manifestPath, manifestSize, eTag, timestampMillis, metadata);
   }
 
   @Override
@@ -240,7 +239,7 @@ public class TableVersion {
     sb.append("    manifestPath: ").append(toIndentedString(manifestPath)).append("\n");
     sb.append("    manifestSize: ").append(toIndentedString(manifestSize)).append("\n");
     sb.append("    eTag: ").append(toIndentedString(eTag)).append("\n");
-    sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+    sb.append("    timestampMillis: ").append(toIndentedString(timestampMillis)).append("\n");
     sb.append("    metadata: ").append(toIndentedString(metadata)).append("\n");
     sb.append("}");
     return sb.toString();
@@ -350,15 +349,15 @@ public class TableVersion {
       }
     }
 
-    // add `timestamp` to the URL query string
-    if (getTimestamp() != null) {
+    // add `timestamp_millis` to the URL query string
+    if (getTimestampMillis() != null) {
       try {
         joiner.add(
             String.format(
-                "%stimestamp%s=%s",
+                "%stimestamp_millis%s=%s",
                 prefix,
                 suffix,
-                URLEncoder.encode(String.valueOf(getTimestamp()), "UTF-8")
+                URLEncoder.encode(String.valueOf(getTimestampMillis()), "UTF-8")
                     .replaceAll("\\+", "%20")));
       } catch (UnsupportedEncodingException e) {
         // Should never happen, UTF-8 is always supported

--- a/java/lance-namespace-springboot-server/src/main/java/org/lance/namespace/server/springboot/api/TableApi.java
+++ b/java/lance-namespace-springboot-server/src/main/java/org/lance/namespace/server/springboot/api/TableApi.java
@@ -2217,7 +2217,7 @@ public interface TableApi {
               for (MediaType mediaType : MediaType.parseMediaTypes(request.getHeader("Accept"))) {
                 if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
                   String exampleString =
-                      "{ \"transaction_id\" : \"transaction_id\", \"version\" : { \"metadata\" : { \"key\" : \"metadata\" }, \"manifest_path\" : \"manifest_path\", \"manifest_size\" : 0, \"e_tag\" : \"e_tag\", \"version\" : 0, \"timestamp\" : \"2000-01-23T04:56:07.000+00:00\" } }";
+                      "{ \"transaction_id\" : \"transaction_id\", \"version\" : { \"metadata\" : { \"key\" : \"metadata\" }, \"manifest_path\" : \"manifest_path\", \"timestamp_millis\" : 1, \"manifest_size\" : 0, \"e_tag\" : \"e_tag\", \"version\" : 0 } }";
                   ApiUtil.setExampleResponse(request, "application/json", exampleString);
                   break;
                 }
@@ -3497,7 +3497,7 @@ public interface TableApi {
               for (MediaType mediaType : MediaType.parseMediaTypes(request.getHeader("Accept"))) {
                 if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
                   String exampleString =
-                      "{ \"version\" : { \"metadata\" : { \"key\" : \"metadata\" }, \"manifest_path\" : \"manifest_path\", \"manifest_size\" : 0, \"e_tag\" : \"e_tag\", \"version\" : 0, \"timestamp\" : \"2000-01-23T04:56:07.000+00:00\" } }";
+                      "{ \"version\" : { \"metadata\" : { \"key\" : \"metadata\" }, \"manifest_path\" : \"manifest_path\", \"timestamp_millis\" : 1, \"manifest_size\" : 0, \"e_tag\" : \"e_tag\", \"version\" : 0 } }";
                   ApiUtil.setExampleResponse(request, "application/json", exampleString);
                   break;
                 }
@@ -5288,7 +5288,7 @@ public interface TableApi {
               for (MediaType mediaType : MediaType.parseMediaTypes(request.getHeader("Accept"))) {
                 if (mediaType.isCompatibleWith(MediaType.valueOf("application/json"))) {
                   String exampleString =
-                      "{ \"versions\" : [ { \"metadata\" : { \"key\" : \"metadata\" }, \"manifest_path\" : \"manifest_path\", \"manifest_size\" : 0, \"e_tag\" : \"e_tag\", \"version\" : 0, \"timestamp\" : \"2000-01-23T04:56:07.000+00:00\" }, { \"metadata\" : { \"key\" : \"metadata\" }, \"manifest_path\" : \"manifest_path\", \"manifest_size\" : 0, \"e_tag\" : \"e_tag\", \"version\" : 0, \"timestamp\" : \"2000-01-23T04:56:07.000+00:00\" } ], \"page_token\" : \"page_token\" }";
+                      "{ \"versions\" : [ { \"metadata\" : { \"key\" : \"metadata\" }, \"manifest_path\" : \"manifest_path\", \"timestamp_millis\" : 1, \"manifest_size\" : 0, \"e_tag\" : \"e_tag\", \"version\" : 0 }, { \"metadata\" : { \"key\" : \"metadata\" }, \"manifest_path\" : \"manifest_path\", \"timestamp_millis\" : 1, \"manifest_size\" : 0, \"e_tag\" : \"e_tag\", \"version\" : 0 } ], \"page_token\" : \"page_token\" }";
                   ApiUtil.setExampleResponse(request, "application/json", exampleString);
                   break;
                 }

--- a/java/lance-namespace-springboot-server/src/main/java/org/lance/namespace/server/springboot/model/TableVersion.java
+++ b/java/lance-namespace-springboot-server/src/main/java/org/lance/namespace/server/springboot/model/TableVersion.java
@@ -18,9 +18,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.*;
-import org.springframework.format.annotation.DateTimeFormat;
 
-import java.time.OffsetDateTime;
 import java.util.*;
 import java.util.HashMap;
 import java.util.Map;
@@ -40,8 +38,7 @@ public class TableVersion {
 
   private String eTag;
 
-  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-  private OffsetDateTime timestamp;
+  private Long timestampMillis;
 
   @Valid private Map<String, String> metadata = new HashMap<>();
 
@@ -152,28 +149,28 @@ public class TableVersion {
     this.eTag = eTag;
   }
 
-  public TableVersion timestamp(OffsetDateTime timestamp) {
-    this.timestamp = timestamp;
+  public TableVersion timestampMillis(Long timestampMillis) {
+    this.timestampMillis = timestampMillis;
     return this;
   }
 
   /**
-   * Timestamp when the version was created
+   * Timestamp when the version was created, in milliseconds since epoch (Unix time)
    *
-   * @return timestamp
+   * @return timestampMillis
    */
-  @Valid
   @Schema(
-      name = "timestamp",
-      description = "Timestamp when the version was created",
+      name = "timestamp_millis",
+      description =
+          "Timestamp when the version was created, in milliseconds since epoch (Unix time)",
       requiredMode = Schema.RequiredMode.NOT_REQUIRED)
-  @JsonProperty("timestamp")
-  public OffsetDateTime getTimestamp() {
-    return timestamp;
+  @JsonProperty("timestamp_millis")
+  public Long getTimestampMillis() {
+    return timestampMillis;
   }
 
-  public void setTimestamp(OffsetDateTime timestamp) {
-    this.timestamp = timestamp;
+  public void setTimestampMillis(Long timestampMillis) {
+    this.timestampMillis = timestampMillis;
   }
 
   public TableVersion metadata(Map<String, String> metadata) {
@@ -220,13 +217,13 @@ public class TableVersion {
         && Objects.equals(this.manifestPath, tableVersion.manifestPath)
         && Objects.equals(this.manifestSize, tableVersion.manifestSize)
         && Objects.equals(this.eTag, tableVersion.eTag)
-        && Objects.equals(this.timestamp, tableVersion.timestamp)
+        && Objects.equals(this.timestampMillis, tableVersion.timestampMillis)
         && Objects.equals(this.metadata, tableVersion.metadata);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(version, manifestPath, manifestSize, eTag, timestamp, metadata);
+    return Objects.hash(version, manifestPath, manifestSize, eTag, timestampMillis, metadata);
   }
 
   @Override
@@ -237,7 +234,7 @@ public class TableVersion {
     sb.append("    manifestPath: ").append(toIndentedString(manifestPath)).append("\n");
     sb.append("    manifestSize: ").append(toIndentedString(manifestSize)).append("\n");
     sb.append("    eTag: ").append(toIndentedString(eTag)).append("\n");
-    sb.append("    timestamp: ").append(toIndentedString(timestamp)).append("\n");
+    sb.append("    timestampMillis: ").append(toIndentedString(timestampMillis)).append("\n");
     sb.append("    metadata: ").append(toIndentedString(metadata)).append("\n");
     sb.append("}");
     return sb.toString();

--- a/python/lance_namespace_urllib3_client/docs/TableVersion.md
+++ b/python/lance_namespace_urllib3_client/docs/TableVersion.md
@@ -9,7 +9,7 @@ Name | Type | Description | Notes
 **manifest_path** | **str** | Path to the manifest file for this version. | 
 **manifest_size** | **int** | Size of the manifest file in bytes | [optional] 
 **e_tag** | **str** | Optional ETag for optimistic concurrency control. Useful for S3 and similar object stores.  | [optional] 
-**timestamp** | **datetime** | Timestamp when the version was created | [optional] 
+**timestamp_millis** | **int** | Timestamp when the version was created, in milliseconds since epoch (Unix time) | [optional] 
 **metadata** | **Dict[str, str]** | Optional key-value pairs of metadata | [optional] 
 
 ## Example

--- a/python/lance_namespace_urllib3_client/lance_namespace_urllib3_client/models/table_version.py
+++ b/python/lance_namespace_urllib3_client/lance_namespace_urllib3_client/models/table_version.py
@@ -17,8 +17,7 @@ import pprint
 import re  # noqa: F401
 import json
 
-from datetime import datetime
-from pydantic import BaseModel, ConfigDict, Field, StrictStr
+from pydantic import BaseModel, ConfigDict, Field, StrictInt, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional
 from typing_extensions import Annotated
 from typing import Optional, Set
@@ -32,9 +31,9 @@ class TableVersion(BaseModel):
     manifest_path: StrictStr = Field(description="Path to the manifest file for this version.")
     manifest_size: Optional[Annotated[int, Field(strict=True, ge=0)]] = Field(default=None, description="Size of the manifest file in bytes")
     e_tag: Optional[StrictStr] = Field(default=None, description="Optional ETag for optimistic concurrency control. Useful for S3 and similar object stores. ")
-    timestamp: Optional[datetime] = Field(default=None, description="Timestamp when the version was created")
+    timestamp_millis: Optional[StrictInt] = Field(default=None, description="Timestamp when the version was created, in milliseconds since epoch (Unix time)")
     metadata: Optional[Dict[str, StrictStr]] = Field(default=None, description="Optional key-value pairs of metadata")
-    __properties: ClassVar[List[str]] = ["version", "manifest_path", "manifest_size", "e_tag", "timestamp", "metadata"]
+    __properties: ClassVar[List[str]] = ["version", "manifest_path", "manifest_size", "e_tag", "timestamp_millis", "metadata"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -91,7 +90,7 @@ class TableVersion(BaseModel):
             "manifest_path": obj.get("manifest_path"),
             "manifest_size": obj.get("manifest_size"),
             "e_tag": obj.get("e_tag"),
-            "timestamp": obj.get("timestamp"),
+            "timestamp_millis": obj.get("timestamp_millis"),
             "metadata": obj.get("metadata")
         })
         return _obj

--- a/python/lance_namespace_urllib3_client/test/test_create_table_version_response.py
+++ b/python/lance_namespace_urllib3_client/test/test_create_table_version_response.py
@@ -41,7 +41,7 @@ class TestCreateTableVersionResponse(unittest.TestCase):
                     manifest_path = '', 
                     manifest_size = 0, 
                     e_tag = '', 
-                    timestamp = datetime.datetime.strptime('2013-10-20 19:20:30.00', '%Y-%m-%d %H:%M:%S.%f'), 
+                    timestamp_millis = 56, 
                     metadata = {
                         'key' : ''
                         }, )

--- a/python/lance_namespace_urllib3_client/test/test_describe_table_version_response.py
+++ b/python/lance_namespace_urllib3_client/test/test_describe_table_version_response.py
@@ -40,7 +40,7 @@ class TestDescribeTableVersionResponse(unittest.TestCase):
                     manifest_path = '', 
                     manifest_size = 0, 
                     e_tag = '', 
-                    timestamp = datetime.datetime.strptime('2013-10-20 19:20:30.00', '%Y-%m-%d %H:%M:%S.%f'), 
+                    timestamp_millis = 56, 
                     metadata = {
                         'key' : ''
                         }, )
@@ -52,7 +52,7 @@ class TestDescribeTableVersionResponse(unittest.TestCase):
                     manifest_path = '', 
                     manifest_size = 0, 
                     e_tag = '', 
-                    timestamp = datetime.datetime.strptime('2013-10-20 19:20:30.00', '%Y-%m-%d %H:%M:%S.%f'), 
+                    timestamp_millis = 56, 
                     metadata = {
                         'key' : ''
                         }, ),

--- a/python/lance_namespace_urllib3_client/test/test_list_table_versions_response.py
+++ b/python/lance_namespace_urllib3_client/test/test_list_table_versions_response.py
@@ -41,7 +41,7 @@ class TestListTableVersionsResponse(unittest.TestCase):
                         manifest_path = '', 
                         manifest_size = 0, 
                         e_tag = '', 
-                        timestamp = datetime.datetime.strptime('2013-10-20 19:20:30.00', '%Y-%m-%d %H:%M:%S.%f'), 
+                        timestamp_millis = 56, 
                         metadata = {
                             'key' : ''
                             }, )
@@ -56,7 +56,7 @@ class TestListTableVersionsResponse(unittest.TestCase):
                         manifest_path = '', 
                         manifest_size = 0, 
                         e_tag = '', 
-                        timestamp = datetime.datetime.strptime('2013-10-20 19:20:30.00', '%Y-%m-%d %H:%M:%S.%f'), 
+                        timestamp_millis = 56, 
                         metadata = {
                             'key' : ''
                             }, )

--- a/python/lance_namespace_urllib3_client/test/test_table_version.py
+++ b/python/lance_namespace_urllib3_client/test/test_table_version.py
@@ -39,7 +39,7 @@ class TestTableVersion(unittest.TestCase):
                 manifest_path = '',
                 manifest_size = 0,
                 e_tag = '',
-                timestamp = datetime.datetime.strptime('2013-10-20 19:20:30.00', '%Y-%m-%d %H:%M:%S.%f'),
+                timestamp_millis = 56,
                 metadata = {
                     'key' : ''
                     }

--- a/rust/lance-namespace-reqwest-client/docs/TableVersion.md
+++ b/rust/lance-namespace-reqwest-client/docs/TableVersion.md
@@ -8,7 +8,7 @@ Name | Type | Description | Notes
 **manifest_path** | **String** | Path to the manifest file for this version. | 
 **manifest_size** | Option<**i64**> | Size of the manifest file in bytes | [optional]
 **e_tag** | Option<**String**> | Optional ETag for optimistic concurrency control. Useful for S3 and similar object stores.  | [optional]
-**timestamp** | Option<**String**> | Timestamp when the version was created | [optional]
+**timestamp_millis** | Option<**i64**> | Timestamp when the version was created, in milliseconds since epoch (Unix time) | [optional]
 **metadata** | Option<**std::collections::HashMap<String, String>**> | Optional key-value pairs of metadata | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/rust/lance-namespace-reqwest-client/src/models/table_version.rs
+++ b/rust/lance-namespace-reqwest-client/src/models/table_version.rs
@@ -25,9 +25,9 @@ pub struct TableVersion {
     /// Optional ETag for optimistic concurrency control. Useful for S3 and similar object stores. 
     #[serde(rename = "e_tag", skip_serializing_if = "Option::is_none")]
     pub e_tag: Option<String>,
-    /// Timestamp when the version was created
-    #[serde(rename = "timestamp", skip_serializing_if = "Option::is_none")]
-    pub timestamp: Option<String>,
+    /// Timestamp when the version was created, in milliseconds since epoch (Unix time)
+    #[serde(rename = "timestamp_millis", skip_serializing_if = "Option::is_none")]
+    pub timestamp_millis: Option<i64>,
     /// Optional key-value pairs of metadata
     #[serde(rename = "metadata", skip_serializing_if = "Option::is_none")]
     pub metadata: Option<std::collections::HashMap<String, String>>,
@@ -40,7 +40,7 @@ impl TableVersion {
             manifest_path,
             manifest_size: None,
             e_tag: None,
-            timestamp: None,
+            timestamp_millis: None,
             metadata: None,
         }
     }


### PR DESCRIPTION
Using datetime causes Jackson to have to install additional modules which complicates things a lot