### PR TITLE
feat: default include_declared to true in ListTables

### DIFF
--- a/docs/src/client/operations/models/ListTablesRequest.md
+++ b/docs/src/client/operations/models/ListTablesRequest.md
@@ -12,7 +12,7 @@
 |**id** | **List&lt;String&gt;** |  |  [optional] |
 |**pageToken** | **String** | An opaque token that allows pagination for list operations (e.g. ListNamespaces).  For an initial request of a list operation, if the implementation cannot return all items in one response, or if there are more items than the page limit specified in the request, the implementation must return a page token in the response, indicating there are more results available.  After the initial request, the value of the page token from each response must be used as the page token value for the next request.  Caller must interpret either &#x60;null&#x60;, missing value or empty string value of the page token from the implementation&#39;s response as the end of the listing results.  |  [optional] |
 |**limit** | **Integer** | An inclusive upper bound of the number of results that a caller will receive.  |  [optional] |
-|**includeDeclared** | **Boolean** | When true, includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false or not set, only tables with storage components are returned.  |  [optional] |
+|**includeDeclared** | **Boolean** | When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned.  |  [optional] |
 
 
 

--- a/docs/src/rest.yaml
+++ b/docs/src/rest.yaml
@@ -275,6 +275,7 @@ paths:
       - $ref: "#/components/parameters/delimiter"
       - $ref: "#/components/parameters/page_token"
       - $ref: "#/components/parameters/limit"
+      - $ref: "#/components/parameters/include_declared"
     get:
       tags:
         - Namespace
@@ -291,6 +292,7 @@ paths:
         - `id`: pass through path parameter of the same name
         - `page_token`: pass through query parameter of the same name
         - `limit`: pass through query parameter of the same name
+        - `include_declared`: pass through query parameter of the same name
       responses:
         200:
           $ref: "#/components/responses/ListTablesResponse"
@@ -326,10 +328,12 @@ paths:
         - `page_token`: pass through query parameter of the same name
         - `limit`: pass through query parameter of the same name
         - `delimiter`: pass through query parameter of the same name
+        - `include_declared`: pass through query parameter of the same name
       parameters:
         - $ref: "#/components/parameters/delimiter"
         - $ref: "#/components/parameters/page_token"
         - $ref: "#/components/parameters/limit"
+        - $ref: "#/components/parameters/include_declared"
       responses:
         200:
           $ref: "#/components/responses/ListTablesResponse"
@@ -2042,6 +2046,18 @@ components:
       schema:
         type: boolean
         default: false
+    include_declared:
+      name: include_declared
+      description: |
+        When true (default), includes tables that have been declared in the namespace
+        but not yet created on storage, in addition to tables that have
+        been created. When false, only tables with storage
+        components are returned.
+      in: query
+      required: false
+      schema:
+        type: boolean
+        default: true
     load_detailed_metadata:
       name: load_detailed_metadata
       description: |
@@ -2387,10 +2403,11 @@ components:
           $ref: "#/components/schemas/PageLimit"
         include_declared:
           type: boolean
+          default: true
           description: |
-            When true, includes tables that have been declared in the namespace
+            When true (default), includes tables that have been declared in the namespace
             but not yet created on storage, in addition to tables that have
-            been created. When false or not set, only tables with storage
+            been created. When false, only tables with storage
             components are returned.
 
     ListTablesResponse:

--- a/java/lance-namespace-apache-client/api/openapi.yaml
+++ b/java/lance-namespace-apache-client/api/openapi.yaml
@@ -288,12 +288,14 @@ paths:
         - `id`: pass through path parameter of the same name
         - `page_token`: pass through query parameter of the same name
         - `limit`: pass through query parameter of the same name
+        - `include_declared`: pass through query parameter of the same name
       operationId: ListTables
       parameters:
       - $ref: '#/components/parameters/id'
       - $ref: '#/components/parameters/delimiter'
       - $ref: '#/components/parameters/page_token'
       - $ref: '#/components/parameters/limit'
+      - $ref: '#/components/parameters/include_declared'
       responses:
         "200":
           $ref: '#/components/responses/ListTablesResponse'
@@ -323,6 +325,7 @@ paths:
     - $ref: '#/components/parameters/delimiter'
     - $ref: '#/components/parameters/page_token'
     - $ref: '#/components/parameters/limit'
+    - $ref: '#/components/parameters/include_declared'
   /v1/table:
     get:
       description: |
@@ -334,11 +337,13 @@ paths:
         - `page_token`: pass through query parameter of the same name
         - `limit`: pass through query parameter of the same name
         - `delimiter`: pass through query parameter of the same name
+        - `include_declared`: pass through query parameter of the same name
       operationId: ListAllTables
       parameters:
       - $ref: '#/components/parameters/delimiter'
       - $ref: '#/components/parameters/page_token'
       - $ref: '#/components/parameters/limit'
+      - $ref: '#/components/parameters/include_declared'
       responses:
         "200":
           $ref: '#/components/responses/ListTablesResponse'
@@ -2440,6 +2445,20 @@ components:
         default: false
         type: boolean
       style: form
+    include_declared:
+      description: |
+        When true (default), includes tables that have been declared in the namespace
+        but not yet created on storage, in addition to tables that have
+        been created. When false, only tables with storage
+        components are returned.
+      explode: true
+      in: query
+      name: include_declared
+      required: false
+      schema:
+        default: true
+        type: boolean
+      style: form
     load_detailed_metadata:
       description: |
         Whether to load detailed metadata that requires opening the dataset.
@@ -3331,10 +3350,11 @@ components:
           type: integer
           nullable: true
         include_declared:
+          default: true
           description: |
-            When true, includes tables that have been declared in the namespace
+            When true (default), includes tables that have been declared in the namespace
             but not yet created on storage, in addition to tables that have
-            been created. When false or not set, only tables with storage
+            been created. When false, only tables with storage
             components are returned.
           type: boolean
     ListTablesResponse:

--- a/java/lance-namespace-apache-client/docs/ListTablesRequest.md
+++ b/java/lance-namespace-apache-client/docs/ListTablesRequest.md
@@ -12,7 +12,7 @@
 |**id** | **List&lt;String&gt;** |  |  [optional] |
 |**pageToken** | **String** | An opaque token that allows pagination for list operations (e.g. ListNamespaces).  For an initial request of a list operation, if the implementation cannot return all items in one response, or if there are more items than the page limit specified in the request, the implementation must return a page token in the response, indicating there are more results available.  After the initial request, the value of the page token from each response must be used as the page token value for the next request.  Caller must interpret either &#x60;null&#x60;, missing value or empty string value of the page token from the implementation&#39;s response as the end of the listing results.  |  [optional] |
 |**limit** | **Integer** | An inclusive upper bound of the number of results that a caller will receive.  |  [optional] |
-|**includeDeclared** | **Boolean** | When true, includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false or not set, only tables with storage components are returned.  |  [optional] |
+|**includeDeclared** | **Boolean** | When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned.  |  [optional] |
 
 
 

--- a/java/lance-namespace-apache-client/docs/MetadataApi.md
+++ b/java/lance-namespace-apache-client/docs/MetadataApi.md
@@ -2611,11 +2611,11 @@ public class Example {
 
 ## listTables
 
-> ListTablesResponse listTables(id, delimiter, pageToken, limit)
+> ListTablesResponse listTables(id, delimiter, pageToken, limit, includeDeclared)
 
 List tables in a namespace
 
-List all child table names of the parent namespace &#x60;id&#x60;.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the &#x60;ListTablesRequest&#x60; information in the following way: - &#x60;id&#x60;: pass through path parameter of the same name - &#x60;page_token&#x60;: pass through query parameter of the same name - &#x60;limit&#x60;: pass through query parameter of the same name 
+List all child table names of the parent namespace &#x60;id&#x60;.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the &#x60;ListTablesRequest&#x60; information in the following way: - &#x60;id&#x60;: pass through path parameter of the same name - &#x60;page_token&#x60;: pass through query parameter of the same name - &#x60;limit&#x60;: pass through query parameter of the same name - &#x60;include_declared&#x60;: pass through query parameter of the same name 
 
 ### Example
 
@@ -2652,8 +2652,9 @@ public class Example {
         String delimiter = "delimiter_example"; // String | An optional delimiter of the `string identifier`, following the Lance Namespace spec. When not specified, the `$` delimiter must be used. 
         String pageToken = "pageToken_example"; // String | Pagination token from a previous request
         Integer limit = 56; // Integer | Maximum number of items to return
+        Boolean includeDeclared = true; // Boolean | When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned. 
         try {
-            ListTablesResponse result = apiInstance.listTables(id, delimiter, pageToken, limit);
+            ListTablesResponse result = apiInstance.listTables(id, delimiter, pageToken, limit, includeDeclared);
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling MetadataApi#listTables");
@@ -2675,6 +2676,7 @@ public class Example {
 | **delimiter** | **String**| An optional delimiter of the &#x60;string identifier&#x60;, following the Lance Namespace spec. When not specified, the &#x60;$&#x60; delimiter must be used.  | [optional] |
 | **pageToken** | **String**| Pagination token from a previous request | [optional] |
 | **limit** | **Integer**| Maximum number of items to return | [optional] |
+| **includeDeclared** | **Boolean**| When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned.  | [optional] [default to true] |
 
 ### Return type
 

--- a/java/lance-namespace-apache-client/docs/NamespaceApi.md
+++ b/java/lance-namespace-apache-client/docs/NamespaceApi.md
@@ -385,11 +385,11 @@ public class Example {
 
 ## listTables
 
-> ListTablesResponse listTables(id, delimiter, pageToken, limit)
+> ListTablesResponse listTables(id, delimiter, pageToken, limit, includeDeclared)
 
 List tables in a namespace
 
-List all child table names of the parent namespace &#x60;id&#x60;.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the &#x60;ListTablesRequest&#x60; information in the following way: - &#x60;id&#x60;: pass through path parameter of the same name - &#x60;page_token&#x60;: pass through query parameter of the same name - &#x60;limit&#x60;: pass through query parameter of the same name 
+List all child table names of the parent namespace &#x60;id&#x60;.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the &#x60;ListTablesRequest&#x60; information in the following way: - &#x60;id&#x60;: pass through path parameter of the same name - &#x60;page_token&#x60;: pass through query parameter of the same name - &#x60;limit&#x60;: pass through query parameter of the same name - &#x60;include_declared&#x60;: pass through query parameter of the same name 
 
 ### Example
 
@@ -426,8 +426,9 @@ public class Example {
         String delimiter = "delimiter_example"; // String | An optional delimiter of the `string identifier`, following the Lance Namespace spec. When not specified, the `$` delimiter must be used. 
         String pageToken = "pageToken_example"; // String | Pagination token from a previous request
         Integer limit = 56; // Integer | Maximum number of items to return
+        Boolean includeDeclared = true; // Boolean | When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned. 
         try {
-            ListTablesResponse result = apiInstance.listTables(id, delimiter, pageToken, limit);
+            ListTablesResponse result = apiInstance.listTables(id, delimiter, pageToken, limit, includeDeclared);
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling NamespaceApi#listTables");
@@ -449,6 +450,7 @@ public class Example {
 | **delimiter** | **String**| An optional delimiter of the &#x60;string identifier&#x60;, following the Lance Namespace spec. When not specified, the &#x60;$&#x60; delimiter must be used.  | [optional] |
 | **pageToken** | **String**| Pagination token from a previous request | [optional] |
 | **limit** | **Integer**| Maximum number of items to return | [optional] |
+| **includeDeclared** | **Boolean**| When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned.  | [optional] [default to true] |
 
 ### Return type
 

--- a/java/lance-namespace-apache-client/docs/TableApi.md
+++ b/java/lance-namespace-apache-client/docs/TableApi.md
@@ -2429,11 +2429,11 @@ public class Example {
 
 ## listAllTables
 
-> ListTablesResponse listAllTables(delimiter, pageToken, limit)
+> ListTablesResponse listAllTables(delimiter, pageToken, limit, includeDeclared)
 
 List all tables
 
-List all tables across all namespaces.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the &#x60;ListAllTablesRequest&#x60; information in the following way: - &#x60;page_token&#x60;: pass through query parameter of the same name - &#x60;limit&#x60;: pass through query parameter of the same name - &#x60;delimiter&#x60;: pass through query parameter of the same name 
+List all tables across all namespaces.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the &#x60;ListAllTablesRequest&#x60; information in the following way: - &#x60;page_token&#x60;: pass through query parameter of the same name - &#x60;limit&#x60;: pass through query parameter of the same name - &#x60;delimiter&#x60;: pass through query parameter of the same name - &#x60;include_declared&#x60;: pass through query parameter of the same name 
 
 ### Example
 
@@ -2469,8 +2469,9 @@ public class Example {
         String delimiter = "delimiter_example"; // String | An optional delimiter of the `string identifier`, following the Lance Namespace spec. When not specified, the `$` delimiter must be used. 
         String pageToken = "pageToken_example"; // String | Pagination token from a previous request
         Integer limit = 56; // Integer | Maximum number of items to return
+        Boolean includeDeclared = true; // Boolean | When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned. 
         try {
-            ListTablesResponse result = apiInstance.listAllTables(delimiter, pageToken, limit);
+            ListTablesResponse result = apiInstance.listAllTables(delimiter, pageToken, limit, includeDeclared);
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling TableApi#listAllTables");
@@ -2491,6 +2492,7 @@ public class Example {
 | **delimiter** | **String**| An optional delimiter of the &#x60;string identifier&#x60;, following the Lance Namespace spec. When not specified, the &#x60;$&#x60; delimiter must be used.  | [optional] |
 | **pageToken** | **String**| Pagination token from a previous request | [optional] |
 | **limit** | **Integer**| Maximum number of items to return | [optional] |
+| **includeDeclared** | **Boolean**| When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned.  | [optional] [default to true] |
 
 ### Return type
 
@@ -2798,11 +2800,11 @@ public class Example {
 
 ## listTables
 
-> ListTablesResponse listTables(id, delimiter, pageToken, limit)
+> ListTablesResponse listTables(id, delimiter, pageToken, limit, includeDeclared)
 
 List tables in a namespace
 
-List all child table names of the parent namespace &#x60;id&#x60;.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the &#x60;ListTablesRequest&#x60; information in the following way: - &#x60;id&#x60;: pass through path parameter of the same name - &#x60;page_token&#x60;: pass through query parameter of the same name - &#x60;limit&#x60;: pass through query parameter of the same name 
+List all child table names of the parent namespace &#x60;id&#x60;.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the &#x60;ListTablesRequest&#x60; information in the following way: - &#x60;id&#x60;: pass through path parameter of the same name - &#x60;page_token&#x60;: pass through query parameter of the same name - &#x60;limit&#x60;: pass through query parameter of the same name - &#x60;include_declared&#x60;: pass through query parameter of the same name 
 
 ### Example
 
@@ -2839,8 +2841,9 @@ public class Example {
         String delimiter = "delimiter_example"; // String | An optional delimiter of the `string identifier`, following the Lance Namespace spec. When not specified, the `$` delimiter must be used. 
         String pageToken = "pageToken_example"; // String | Pagination token from a previous request
         Integer limit = 56; // Integer | Maximum number of items to return
+        Boolean includeDeclared = true; // Boolean | When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned. 
         try {
-            ListTablesResponse result = apiInstance.listTables(id, delimiter, pageToken, limit);
+            ListTablesResponse result = apiInstance.listTables(id, delimiter, pageToken, limit, includeDeclared);
             System.out.println(result);
         } catch (ApiException e) {
             System.err.println("Exception when calling TableApi#listTables");
@@ -2862,6 +2865,7 @@ public class Example {
 | **delimiter** | **String**| An optional delimiter of the &#x60;string identifier&#x60;, following the Lance Namespace spec. When not specified, the &#x60;$&#x60; delimiter must be used.  | [optional] |
 | **pageToken** | **String**| Pagination token from a previous request | [optional] |
 | **limit** | **Integer**| Maximum number of items to return | [optional] |
+| **includeDeclared** | **Boolean**| When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned.  | [optional] [default to true] |
 
 ### Return type
 

--- a/java/lance-namespace-apache-client/src/main/java/org/lance/namespace/client/apache/api/MetadataApi.java
+++ b/java/lance-namespace-apache-client/src/main/java/org/lance/namespace/client/apache/api/MetadataApi.java
@@ -3024,7 +3024,7 @@ public class MetadataApi extends BaseApi {
    * It passes in the &#x60;ListTablesRequest&#x60; information in the following way: -
    * &#x60;id&#x60;: pass through path parameter of the same name - &#x60;page_token&#x60;: pass
    * through query parameter of the same name - &#x60;limit&#x60;: pass through query parameter of
-   * the same name
+   * the same name - &#x60;include_declared&#x60;: pass through query parameter of the same name
    *
    * @param id &#x60;string identifier&#x60; of an object in a namespace, following the Lance
    *     Namespace spec. When the value is equal to the delimiter, it represents the root namespace.
@@ -3035,12 +3035,17 @@ public class MetadataApi extends BaseApi {
    *     (optional)
    * @param pageToken Pagination token from a previous request (optional)
    * @param limit Maximum number of items to return (optional)
+   * @param includeDeclared When true (default), includes tables that have been declared in the
+   *     namespace but not yet created on storage, in addition to tables that have been created.
+   *     When false, only tables with storage components are returned. (optional, default to true)
    * @return ListTablesResponse
    * @throws ApiException if fails to make API call
    */
-  public ListTablesResponse listTables(String id, String delimiter, String pageToken, Integer limit)
+  public ListTablesResponse listTables(
+      String id, String delimiter, String pageToken, Integer limit, Boolean includeDeclared)
       throws ApiException {
-    return this.listTables(id, delimiter, pageToken, limit, Collections.emptyMap());
+    return this.listTables(
+        id, delimiter, pageToken, limit, includeDeclared, Collections.emptyMap());
   }
 
   /**
@@ -3049,7 +3054,7 @@ public class MetadataApi extends BaseApi {
    * It passes in the &#x60;ListTablesRequest&#x60; information in the following way: -
    * &#x60;id&#x60;: pass through path parameter of the same name - &#x60;page_token&#x60;: pass
    * through query parameter of the same name - &#x60;limit&#x60;: pass through query parameter of
-   * the same name
+   * the same name - &#x60;include_declared&#x60;: pass through query parameter of the same name
    *
    * @param id &#x60;string identifier&#x60; of an object in a namespace, following the Lance
    *     Namespace spec. When the value is equal to the delimiter, it represents the root namespace.
@@ -3060,6 +3065,9 @@ public class MetadataApi extends BaseApi {
    *     (optional)
    * @param pageToken Pagination token from a previous request (optional)
    * @param limit Maximum number of items to return (optional)
+   * @param includeDeclared When true (default), includes tables that have been declared in the
+   *     namespace but not yet created on storage, in addition to tables that have been created.
+   *     When false, only tables with storage components are returned. (optional, default to true)
    * @param additionalHeaders additionalHeaders for this call
    * @return ListTablesResponse
    * @throws ApiException if fails to make API call
@@ -3069,6 +3077,7 @@ public class MetadataApi extends BaseApi {
       String delimiter,
       String pageToken,
       Integer limit,
+      Boolean includeDeclared,
       Map<String, String> additionalHeaders)
       throws ApiException {
     Object localVarPostBody = null;
@@ -3095,6 +3104,7 @@ public class MetadataApi extends BaseApi {
     localVarQueryParams.addAll(apiClient.parameterToPair("delimiter", delimiter));
     localVarQueryParams.addAll(apiClient.parameterToPair("page_token", pageToken));
     localVarQueryParams.addAll(apiClient.parameterToPair("limit", limit));
+    localVarQueryParams.addAll(apiClient.parameterToPair("include_declared", includeDeclared));
 
     localVarHeaderParams.putAll(additionalHeaders);
 

--- a/java/lance-namespace-apache-client/src/main/java/org/lance/namespace/client/apache/api/NamespaceApi.java
+++ b/java/lance-namespace-apache-client/src/main/java/org/lance/namespace/client/apache/api/NamespaceApi.java
@@ -467,7 +467,7 @@ public class NamespaceApi extends BaseApi {
    * It passes in the &#x60;ListTablesRequest&#x60; information in the following way: -
    * &#x60;id&#x60;: pass through path parameter of the same name - &#x60;page_token&#x60;: pass
    * through query parameter of the same name - &#x60;limit&#x60;: pass through query parameter of
-   * the same name
+   * the same name - &#x60;include_declared&#x60;: pass through query parameter of the same name
    *
    * @param id &#x60;string identifier&#x60; of an object in a namespace, following the Lance
    *     Namespace spec. When the value is equal to the delimiter, it represents the root namespace.
@@ -478,12 +478,17 @@ public class NamespaceApi extends BaseApi {
    *     (optional)
    * @param pageToken Pagination token from a previous request (optional)
    * @param limit Maximum number of items to return (optional)
+   * @param includeDeclared When true (default), includes tables that have been declared in the
+   *     namespace but not yet created on storage, in addition to tables that have been created.
+   *     When false, only tables with storage components are returned. (optional, default to true)
    * @return ListTablesResponse
    * @throws ApiException if fails to make API call
    */
-  public ListTablesResponse listTables(String id, String delimiter, String pageToken, Integer limit)
+  public ListTablesResponse listTables(
+      String id, String delimiter, String pageToken, Integer limit, Boolean includeDeclared)
       throws ApiException {
-    return this.listTables(id, delimiter, pageToken, limit, Collections.emptyMap());
+    return this.listTables(
+        id, delimiter, pageToken, limit, includeDeclared, Collections.emptyMap());
   }
 
   /**
@@ -492,7 +497,7 @@ public class NamespaceApi extends BaseApi {
    * It passes in the &#x60;ListTablesRequest&#x60; information in the following way: -
    * &#x60;id&#x60;: pass through path parameter of the same name - &#x60;page_token&#x60;: pass
    * through query parameter of the same name - &#x60;limit&#x60;: pass through query parameter of
-   * the same name
+   * the same name - &#x60;include_declared&#x60;: pass through query parameter of the same name
    *
    * @param id &#x60;string identifier&#x60; of an object in a namespace, following the Lance
    *     Namespace spec. When the value is equal to the delimiter, it represents the root namespace.
@@ -503,6 +508,9 @@ public class NamespaceApi extends BaseApi {
    *     (optional)
    * @param pageToken Pagination token from a previous request (optional)
    * @param limit Maximum number of items to return (optional)
+   * @param includeDeclared When true (default), includes tables that have been declared in the
+   *     namespace but not yet created on storage, in addition to tables that have been created.
+   *     When false, only tables with storage components are returned. (optional, default to true)
    * @param additionalHeaders additionalHeaders for this call
    * @return ListTablesResponse
    * @throws ApiException if fails to make API call
@@ -512,6 +520,7 @@ public class NamespaceApi extends BaseApi {
       String delimiter,
       String pageToken,
       Integer limit,
+      Boolean includeDeclared,
       Map<String, String> additionalHeaders)
       throws ApiException {
     Object localVarPostBody = null;
@@ -538,6 +547,7 @@ public class NamespaceApi extends BaseApi {
     localVarQueryParams.addAll(apiClient.parameterToPair("delimiter", delimiter));
     localVarQueryParams.addAll(apiClient.parameterToPair("page_token", pageToken));
     localVarQueryParams.addAll(apiClient.parameterToPair("limit", limit));
+    localVarQueryParams.addAll(apiClient.parameterToPair("include_declared", includeDeclared));
 
     localVarHeaderParams.putAll(additionalHeaders);
 

--- a/java/lance-namespace-apache-client/src/main/java/org/lance/namespace/client/apache/api/TableApi.java
+++ b/java/lance-namespace-apache-client/src/main/java/org/lance/namespace/client/apache/api/TableApi.java
@@ -2864,19 +2864,24 @@ public class TableApi extends BaseApi {
    * GET to perform this operation without a request body. It passes in the
    * &#x60;ListAllTablesRequest&#x60; information in the following way: - &#x60;page_token&#x60;:
    * pass through query parameter of the same name - &#x60;limit&#x60;: pass through query parameter
-   * of the same name - &#x60;delimiter&#x60;: pass through query parameter of the same name
+   * of the same name - &#x60;delimiter&#x60;: pass through query parameter of the same name -
+   * &#x60;include_declared&#x60;: pass through query parameter of the same name
    *
    * @param delimiter An optional delimiter of the &#x60;string identifier&#x60;, following the
    *     Lance Namespace spec. When not specified, the &#x60;$&#x60; delimiter must be used.
    *     (optional)
    * @param pageToken Pagination token from a previous request (optional)
    * @param limit Maximum number of items to return (optional)
+   * @param includeDeclared When true (default), includes tables that have been declared in the
+   *     namespace but not yet created on storage, in addition to tables that have been created.
+   *     When false, only tables with storage components are returned. (optional, default to true)
    * @return ListTablesResponse
    * @throws ApiException if fails to make API call
    */
-  public ListTablesResponse listAllTables(String delimiter, String pageToken, Integer limit)
+  public ListTablesResponse listAllTables(
+      String delimiter, String pageToken, Integer limit, Boolean includeDeclared)
       throws ApiException {
-    return this.listAllTables(delimiter, pageToken, limit, Collections.emptyMap());
+    return this.listAllTables(delimiter, pageToken, limit, includeDeclared, Collections.emptyMap());
   }
 
   /**
@@ -2884,19 +2889,27 @@ public class TableApi extends BaseApi {
    * GET to perform this operation without a request body. It passes in the
    * &#x60;ListAllTablesRequest&#x60; information in the following way: - &#x60;page_token&#x60;:
    * pass through query parameter of the same name - &#x60;limit&#x60;: pass through query parameter
-   * of the same name - &#x60;delimiter&#x60;: pass through query parameter of the same name
+   * of the same name - &#x60;delimiter&#x60;: pass through query parameter of the same name -
+   * &#x60;include_declared&#x60;: pass through query parameter of the same name
    *
    * @param delimiter An optional delimiter of the &#x60;string identifier&#x60;, following the
    *     Lance Namespace spec. When not specified, the &#x60;$&#x60; delimiter must be used.
    *     (optional)
    * @param pageToken Pagination token from a previous request (optional)
    * @param limit Maximum number of items to return (optional)
+   * @param includeDeclared When true (default), includes tables that have been declared in the
+   *     namespace but not yet created on storage, in addition to tables that have been created.
+   *     When false, only tables with storage components are returned. (optional, default to true)
    * @param additionalHeaders additionalHeaders for this call
    * @return ListTablesResponse
    * @throws ApiException if fails to make API call
    */
   public ListTablesResponse listAllTables(
-      String delimiter, String pageToken, Integer limit, Map<String, String> additionalHeaders)
+      String delimiter,
+      String pageToken,
+      Integer limit,
+      Boolean includeDeclared,
+      Map<String, String> additionalHeaders)
       throws ApiException {
     Object localVarPostBody = null;
 
@@ -2914,6 +2927,7 @@ public class TableApi extends BaseApi {
     localVarQueryParams.addAll(apiClient.parameterToPair("delimiter", delimiter));
     localVarQueryParams.addAll(apiClient.parameterToPair("page_token", pageToken));
     localVarQueryParams.addAll(apiClient.parameterToPair("limit", limit));
+    localVarQueryParams.addAll(apiClient.parameterToPair("include_declared", includeDeclared));
 
     localVarHeaderParams.putAll(additionalHeaders);
 
@@ -3279,7 +3293,7 @@ public class TableApi extends BaseApi {
    * It passes in the &#x60;ListTablesRequest&#x60; information in the following way: -
    * &#x60;id&#x60;: pass through path parameter of the same name - &#x60;page_token&#x60;: pass
    * through query parameter of the same name - &#x60;limit&#x60;: pass through query parameter of
-   * the same name
+   * the same name - &#x60;include_declared&#x60;: pass through query parameter of the same name
    *
    * @param id &#x60;string identifier&#x60; of an object in a namespace, following the Lance
    *     Namespace spec. When the value is equal to the delimiter, it represents the root namespace.
@@ -3290,12 +3304,17 @@ public class TableApi extends BaseApi {
    *     (optional)
    * @param pageToken Pagination token from a previous request (optional)
    * @param limit Maximum number of items to return (optional)
+   * @param includeDeclared When true (default), includes tables that have been declared in the
+   *     namespace but not yet created on storage, in addition to tables that have been created.
+   *     When false, only tables with storage components are returned. (optional, default to true)
    * @return ListTablesResponse
    * @throws ApiException if fails to make API call
    */
-  public ListTablesResponse listTables(String id, String delimiter, String pageToken, Integer limit)
+  public ListTablesResponse listTables(
+      String id, String delimiter, String pageToken, Integer limit, Boolean includeDeclared)
       throws ApiException {
-    return this.listTables(id, delimiter, pageToken, limit, Collections.emptyMap());
+    return this.listTables(
+        id, delimiter, pageToken, limit, includeDeclared, Collections.emptyMap());
   }
 
   /**
@@ -3304,7 +3323,7 @@ public class TableApi extends BaseApi {
    * It passes in the &#x60;ListTablesRequest&#x60; information in the following way: -
    * &#x60;id&#x60;: pass through path parameter of the same name - &#x60;page_token&#x60;: pass
    * through query parameter of the same name - &#x60;limit&#x60;: pass through query parameter of
-   * the same name
+   * the same name - &#x60;include_declared&#x60;: pass through query parameter of the same name
    *
    * @param id &#x60;string identifier&#x60; of an object in a namespace, following the Lance
    *     Namespace spec. When the value is equal to the delimiter, it represents the root namespace.
@@ -3315,6 +3334,9 @@ public class TableApi extends BaseApi {
    *     (optional)
    * @param pageToken Pagination token from a previous request (optional)
    * @param limit Maximum number of items to return (optional)
+   * @param includeDeclared When true (default), includes tables that have been declared in the
+   *     namespace but not yet created on storage, in addition to tables that have been created.
+   *     When false, only tables with storage components are returned. (optional, default to true)
    * @param additionalHeaders additionalHeaders for this call
    * @return ListTablesResponse
    * @throws ApiException if fails to make API call
@@ -3324,6 +3346,7 @@ public class TableApi extends BaseApi {
       String delimiter,
       String pageToken,
       Integer limit,
+      Boolean includeDeclared,
       Map<String, String> additionalHeaders)
       throws ApiException {
     Object localVarPostBody = null;
@@ -3350,6 +3373,7 @@ public class TableApi extends BaseApi {
     localVarQueryParams.addAll(apiClient.parameterToPair("delimiter", delimiter));
     localVarQueryParams.addAll(apiClient.parameterToPair("page_token", pageToken));
     localVarQueryParams.addAll(apiClient.parameterToPair("limit", limit));
+    localVarQueryParams.addAll(apiClient.parameterToPair("include_declared", includeDeclared));
 
     localVarHeaderParams.putAll(additionalHeaders);
 

--- a/java/lance-namespace-apache-client/src/main/java/org/lance/namespace/model/ListTablesRequest.java
+++ b/java/lance-namespace-apache-client/src/main/java/org/lance/namespace/model/ListTablesRequest.java
@@ -55,7 +55,7 @@ public class ListTablesRequest {
   @javax.annotation.Nullable private Integer limit;
 
   public static final String JSON_PROPERTY_INCLUDE_DECLARED = "include_declared";
-  @javax.annotation.Nullable private Boolean includeDeclared;
+  @javax.annotation.Nullable private Boolean includeDeclared = true;
 
   public ListTablesRequest() {}
 
@@ -213,8 +213,8 @@ public class ListTablesRequest {
   }
 
   /**
-   * When true, includes tables that have been declared in the namespace but not yet created on
-   * storage, in addition to tables that have been created. When false or not set, only tables with
+   * When true (default), includes tables that have been declared in the namespace but not yet
+   * created on storage, in addition to tables that have been created. When false, only tables with
    * storage components are returned.
    *
    * @return includeDeclared

--- a/java/lance-namespace-async-client/api/openapi.yaml
+++ b/java/lance-namespace-async-client/api/openapi.yaml
@@ -288,12 +288,14 @@ paths:
         - `id`: pass through path parameter of the same name
         - `page_token`: pass through query parameter of the same name
         - `limit`: pass through query parameter of the same name
+        - `include_declared`: pass through query parameter of the same name
       operationId: ListTables
       parameters:
       - $ref: '#/components/parameters/id'
       - $ref: '#/components/parameters/delimiter'
       - $ref: '#/components/parameters/page_token'
       - $ref: '#/components/parameters/limit'
+      - $ref: '#/components/parameters/include_declared'
       responses:
         "200":
           $ref: '#/components/responses/ListTablesResponse'
@@ -323,6 +325,7 @@ paths:
     - $ref: '#/components/parameters/delimiter'
     - $ref: '#/components/parameters/page_token'
     - $ref: '#/components/parameters/limit'
+    - $ref: '#/components/parameters/include_declared'
   /v1/table:
     get:
       description: |
@@ -334,11 +337,13 @@ paths:
         - `page_token`: pass through query parameter of the same name
         - `limit`: pass through query parameter of the same name
         - `delimiter`: pass through query parameter of the same name
+        - `include_declared`: pass through query parameter of the same name
       operationId: ListAllTables
       parameters:
       - $ref: '#/components/parameters/delimiter'
       - $ref: '#/components/parameters/page_token'
       - $ref: '#/components/parameters/limit'
+      - $ref: '#/components/parameters/include_declared'
       responses:
         "200":
           $ref: '#/components/responses/ListTablesResponse'
@@ -2440,6 +2445,20 @@ components:
         default: false
         type: boolean
       style: form
+    include_declared:
+      description: |
+        When true (default), includes tables that have been declared in the namespace
+        but not yet created on storage, in addition to tables that have
+        been created. When false, only tables with storage
+        components are returned.
+      explode: true
+      in: query
+      name: include_declared
+      required: false
+      schema:
+        default: true
+        type: boolean
+      style: form
     load_detailed_metadata:
       description: |
         Whether to load detailed metadata that requires opening the dataset.
@@ -3331,10 +3350,11 @@ components:
           type: integer
           nullable: true
         include_declared:
+          default: true
           description: |
-            When true, includes tables that have been declared in the namespace
+            When true (default), includes tables that have been declared in the namespace
             but not yet created on storage, in addition to tables that have
-            been created. When false or not set, only tables with storage
+            been created. When false, only tables with storage
             components are returned.
           type: boolean
     ListTablesResponse:

--- a/java/lance-namespace-async-client/docs/ListTablesRequest.md
+++ b/java/lance-namespace-async-client/docs/ListTablesRequest.md
@@ -12,7 +12,7 @@
 |**id** | **List&lt;String&gt;** |  |  [optional] |
 |**pageToken** | **String** | An opaque token that allows pagination for list operations (e.g. ListNamespaces).  For an initial request of a list operation, if the implementation cannot return all items in one response, or if there are more items than the page limit specified in the request, the implementation must return a page token in the response, indicating there are more results available.  After the initial request, the value of the page token from each response must be used as the page token value for the next request.  Caller must interpret either &#x60;null&#x60;, missing value or empty string value of the page token from the implementation&#39;s response as the end of the listing results.  |  [optional] |
 |**limit** | **Integer** | An inclusive upper bound of the number of results that a caller will receive.  |  [optional] |
-|**includeDeclared** | **Boolean** | When true, includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false or not set, only tables with storage components are returned.  |  [optional] |
+|**includeDeclared** | **Boolean** | When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned.  |  [optional] |
 
 
 

--- a/java/lance-namespace-async-client/docs/MetadataApi.md
+++ b/java/lance-namespace-async-client/docs/MetadataApi.md
@@ -5521,11 +5521,11 @@ CompletableFuture<ApiResponse<[**ListTableVersionsResponse**](ListTableVersionsR
 
 ## listTables
 
-> CompletableFuture<ListTablesResponse> listTables(id, delimiter, pageToken, limit)
+> CompletableFuture<ListTablesResponse> listTables(id, delimiter, pageToken, limit, includeDeclared)
 
 List tables in a namespace
 
-List all child table names of the parent namespace &#x60;id&#x60;.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the &#x60;ListTablesRequest&#x60; information in the following way: - &#x60;id&#x60;: pass through path parameter of the same name - &#x60;page_token&#x60;: pass through query parameter of the same name - &#x60;limit&#x60;: pass through query parameter of the same name 
+List all child table names of the parent namespace &#x60;id&#x60;.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the &#x60;ListTablesRequest&#x60; information in the following way: - &#x60;id&#x60;: pass through path parameter of the same name - &#x60;page_token&#x60;: pass through query parameter of the same name - &#x60;limit&#x60;: pass through query parameter of the same name - &#x60;include_declared&#x60;: pass through query parameter of the same name 
 
 ### Example
 
@@ -5563,8 +5563,9 @@ public class Example {
         String delimiter = "delimiter_example"; // String | An optional delimiter of the `string identifier`, following the Lance Namespace spec. When not specified, the `$` delimiter must be used. 
         String pageToken = "pageToken_example"; // String | Pagination token from a previous request
         Integer limit = 56; // Integer | Maximum number of items to return
+        Boolean includeDeclared = true; // Boolean | When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned. 
         try {
-            CompletableFuture<ListTablesResponse> result = apiInstance.listTables(id, delimiter, pageToken, limit);
+            CompletableFuture<ListTablesResponse> result = apiInstance.listTables(id, delimiter, pageToken, limit, includeDeclared);
             System.out.println(result.get());
         } catch (ApiException e) {
             System.err.println("Exception when calling MetadataApi#listTables");
@@ -5586,6 +5587,7 @@ public class Example {
 | **delimiter** | **String**| An optional delimiter of the &#x60;string identifier&#x60;, following the Lance Namespace spec. When not specified, the &#x60;$&#x60; delimiter must be used.  | [optional] |
 | **pageToken** | **String**| Pagination token from a previous request | [optional] |
 | **limit** | **Integer**| Maximum number of items to return | [optional] |
+| **includeDeclared** | **Boolean**| When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned.  | [optional] [default to true] |
 
 ### Return type
 
@@ -5615,11 +5617,11 @@ CompletableFuture<[**ListTablesResponse**](ListTablesResponse.md)>
 
 ## listTablesWithHttpInfo
 
-> CompletableFuture<ApiResponse<ListTablesResponse>> listTables listTablesWithHttpInfo(id, delimiter, pageToken, limit)
+> CompletableFuture<ApiResponse<ListTablesResponse>> listTables listTablesWithHttpInfo(id, delimiter, pageToken, limit, includeDeclared)
 
 List tables in a namespace
 
-List all child table names of the parent namespace &#x60;id&#x60;.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the &#x60;ListTablesRequest&#x60; information in the following way: - &#x60;id&#x60;: pass through path parameter of the same name - &#x60;page_token&#x60;: pass through query parameter of the same name - &#x60;limit&#x60;: pass through query parameter of the same name 
+List all child table names of the parent namespace &#x60;id&#x60;.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the &#x60;ListTablesRequest&#x60; information in the following way: - &#x60;id&#x60;: pass through path parameter of the same name - &#x60;page_token&#x60;: pass through query parameter of the same name - &#x60;limit&#x60;: pass through query parameter of the same name - &#x60;include_declared&#x60;: pass through query parameter of the same name 
 
 ### Example
 
@@ -5658,8 +5660,9 @@ public class Example {
         String delimiter = "delimiter_example"; // String | An optional delimiter of the `string identifier`, following the Lance Namespace spec. When not specified, the `$` delimiter must be used. 
         String pageToken = "pageToken_example"; // String | Pagination token from a previous request
         Integer limit = 56; // Integer | Maximum number of items to return
+        Boolean includeDeclared = true; // Boolean | When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned. 
         try {
-            CompletableFuture<ApiResponse<ListTablesResponse>> response = apiInstance.listTablesWithHttpInfo(id, delimiter, pageToken, limit);
+            CompletableFuture<ApiResponse<ListTablesResponse>> response = apiInstance.listTablesWithHttpInfo(id, delimiter, pageToken, limit, includeDeclared);
             System.out.println("Status code: " + response.get().getStatusCode());
             System.out.println("Response headers: " + response.get().getHeaders());
             System.out.println("Response body: " + response.get().getData());
@@ -5690,6 +5693,7 @@ public class Example {
 | **delimiter** | **String**| An optional delimiter of the &#x60;string identifier&#x60;, following the Lance Namespace spec. When not specified, the &#x60;$&#x60; delimiter must be used.  | [optional] |
 | **pageToken** | **String**| Pagination token from a previous request | [optional] |
 | **limit** | **Integer**| Maximum number of items to return | [optional] |
+| **includeDeclared** | **Boolean**| When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned.  | [optional] [default to true] |
 
 ### Return type
 

--- a/java/lance-namespace-async-client/docs/NamespaceApi.md
+++ b/java/lance-namespace-async-client/docs/NamespaceApi.md
@@ -805,11 +805,11 @@ CompletableFuture<ApiResponse<[**ListNamespacesResponse**](ListNamespacesRespons
 
 ## listTables
 
-> CompletableFuture<ListTablesResponse> listTables(id, delimiter, pageToken, limit)
+> CompletableFuture<ListTablesResponse> listTables(id, delimiter, pageToken, limit, includeDeclared)
 
 List tables in a namespace
 
-List all child table names of the parent namespace &#x60;id&#x60;.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the &#x60;ListTablesRequest&#x60; information in the following way: - &#x60;id&#x60;: pass through path parameter of the same name - &#x60;page_token&#x60;: pass through query parameter of the same name - &#x60;limit&#x60;: pass through query parameter of the same name 
+List all child table names of the parent namespace &#x60;id&#x60;.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the &#x60;ListTablesRequest&#x60; information in the following way: - &#x60;id&#x60;: pass through path parameter of the same name - &#x60;page_token&#x60;: pass through query parameter of the same name - &#x60;limit&#x60;: pass through query parameter of the same name - &#x60;include_declared&#x60;: pass through query parameter of the same name 
 
 ### Example
 
@@ -847,8 +847,9 @@ public class Example {
         String delimiter = "delimiter_example"; // String | An optional delimiter of the `string identifier`, following the Lance Namespace spec. When not specified, the `$` delimiter must be used. 
         String pageToken = "pageToken_example"; // String | Pagination token from a previous request
         Integer limit = 56; // Integer | Maximum number of items to return
+        Boolean includeDeclared = true; // Boolean | When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned. 
         try {
-            CompletableFuture<ListTablesResponse> result = apiInstance.listTables(id, delimiter, pageToken, limit);
+            CompletableFuture<ListTablesResponse> result = apiInstance.listTables(id, delimiter, pageToken, limit, includeDeclared);
             System.out.println(result.get());
         } catch (ApiException e) {
             System.err.println("Exception when calling NamespaceApi#listTables");
@@ -870,6 +871,7 @@ public class Example {
 | **delimiter** | **String**| An optional delimiter of the &#x60;string identifier&#x60;, following the Lance Namespace spec. When not specified, the &#x60;$&#x60; delimiter must be used.  | [optional] |
 | **pageToken** | **String**| Pagination token from a previous request | [optional] |
 | **limit** | **Integer**| Maximum number of items to return | [optional] |
+| **includeDeclared** | **Boolean**| When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned.  | [optional] [default to true] |
 
 ### Return type
 
@@ -899,11 +901,11 @@ CompletableFuture<[**ListTablesResponse**](ListTablesResponse.md)>
 
 ## listTablesWithHttpInfo
 
-> CompletableFuture<ApiResponse<ListTablesResponse>> listTables listTablesWithHttpInfo(id, delimiter, pageToken, limit)
+> CompletableFuture<ApiResponse<ListTablesResponse>> listTables listTablesWithHttpInfo(id, delimiter, pageToken, limit, includeDeclared)
 
 List tables in a namespace
 
-List all child table names of the parent namespace &#x60;id&#x60;.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the &#x60;ListTablesRequest&#x60; information in the following way: - &#x60;id&#x60;: pass through path parameter of the same name - &#x60;page_token&#x60;: pass through query parameter of the same name - &#x60;limit&#x60;: pass through query parameter of the same name 
+List all child table names of the parent namespace &#x60;id&#x60;.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the &#x60;ListTablesRequest&#x60; information in the following way: - &#x60;id&#x60;: pass through path parameter of the same name - &#x60;page_token&#x60;: pass through query parameter of the same name - &#x60;limit&#x60;: pass through query parameter of the same name - &#x60;include_declared&#x60;: pass through query parameter of the same name 
 
 ### Example
 
@@ -942,8 +944,9 @@ public class Example {
         String delimiter = "delimiter_example"; // String | An optional delimiter of the `string identifier`, following the Lance Namespace spec. When not specified, the `$` delimiter must be used. 
         String pageToken = "pageToken_example"; // String | Pagination token from a previous request
         Integer limit = 56; // Integer | Maximum number of items to return
+        Boolean includeDeclared = true; // Boolean | When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned. 
         try {
-            CompletableFuture<ApiResponse<ListTablesResponse>> response = apiInstance.listTablesWithHttpInfo(id, delimiter, pageToken, limit);
+            CompletableFuture<ApiResponse<ListTablesResponse>> response = apiInstance.listTablesWithHttpInfo(id, delimiter, pageToken, limit, includeDeclared);
             System.out.println("Status code: " + response.get().getStatusCode());
             System.out.println("Response headers: " + response.get().getHeaders());
             System.out.println("Response body: " + response.get().getData());
@@ -974,6 +977,7 @@ public class Example {
 | **delimiter** | **String**| An optional delimiter of the &#x60;string identifier&#x60;, following the Lance Namespace spec. When not specified, the &#x60;$&#x60; delimiter must be used.  | [optional] |
 | **pageToken** | **String**| Pagination token from a previous request | [optional] |
 | **limit** | **Integer**| Maximum number of items to return | [optional] |
+| **includeDeclared** | **Boolean**| When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned.  | [optional] [default to true] |
 
 ### Return type
 

--- a/java/lance-namespace-async-client/docs/TableApi.md
+++ b/java/lance-namespace-async-client/docs/TableApi.md
@@ -5135,11 +5135,11 @@ CompletableFuture<ApiResponse<[**InsertIntoTableResponse**](InsertIntoTableRespo
 
 ## listAllTables
 
-> CompletableFuture<ListTablesResponse> listAllTables(delimiter, pageToken, limit)
+> CompletableFuture<ListTablesResponse> listAllTables(delimiter, pageToken, limit, includeDeclared)
 
 List all tables
 
-List all tables across all namespaces.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the &#x60;ListAllTablesRequest&#x60; information in the following way: - &#x60;page_token&#x60;: pass through query parameter of the same name - &#x60;limit&#x60;: pass through query parameter of the same name - &#x60;delimiter&#x60;: pass through query parameter of the same name 
+List all tables across all namespaces.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the &#x60;ListAllTablesRequest&#x60; information in the following way: - &#x60;page_token&#x60;: pass through query parameter of the same name - &#x60;limit&#x60;: pass through query parameter of the same name - &#x60;delimiter&#x60;: pass through query parameter of the same name - &#x60;include_declared&#x60;: pass through query parameter of the same name 
 
 ### Example
 
@@ -5176,8 +5176,9 @@ public class Example {
         String delimiter = "delimiter_example"; // String | An optional delimiter of the `string identifier`, following the Lance Namespace spec. When not specified, the `$` delimiter must be used. 
         String pageToken = "pageToken_example"; // String | Pagination token from a previous request
         Integer limit = 56; // Integer | Maximum number of items to return
+        Boolean includeDeclared = true; // Boolean | When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned. 
         try {
-            CompletableFuture<ListTablesResponse> result = apiInstance.listAllTables(delimiter, pageToken, limit);
+            CompletableFuture<ListTablesResponse> result = apiInstance.listAllTables(delimiter, pageToken, limit, includeDeclared);
             System.out.println(result.get());
         } catch (ApiException e) {
             System.err.println("Exception when calling TableApi#listAllTables");
@@ -5198,6 +5199,7 @@ public class Example {
 | **delimiter** | **String**| An optional delimiter of the &#x60;string identifier&#x60;, following the Lance Namespace spec. When not specified, the &#x60;$&#x60; delimiter must be used.  | [optional] |
 | **pageToken** | **String**| Pagination token from a previous request | [optional] |
 | **limit** | **Integer**| Maximum number of items to return | [optional] |
+| **includeDeclared** | **Boolean**| When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned.  | [optional] [default to true] |
 
 ### Return type
 
@@ -5225,11 +5227,11 @@ CompletableFuture<[**ListTablesResponse**](ListTablesResponse.md)>
 
 ## listAllTablesWithHttpInfo
 
-> CompletableFuture<ApiResponse<ListTablesResponse>> listAllTables listAllTablesWithHttpInfo(delimiter, pageToken, limit)
+> CompletableFuture<ApiResponse<ListTablesResponse>> listAllTables listAllTablesWithHttpInfo(delimiter, pageToken, limit, includeDeclared)
 
 List all tables
 
-List all tables across all namespaces.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the &#x60;ListAllTablesRequest&#x60; information in the following way: - &#x60;page_token&#x60;: pass through query parameter of the same name - &#x60;limit&#x60;: pass through query parameter of the same name - &#x60;delimiter&#x60;: pass through query parameter of the same name 
+List all tables across all namespaces.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the &#x60;ListAllTablesRequest&#x60; information in the following way: - &#x60;page_token&#x60;: pass through query parameter of the same name - &#x60;limit&#x60;: pass through query parameter of the same name - &#x60;delimiter&#x60;: pass through query parameter of the same name - &#x60;include_declared&#x60;: pass through query parameter of the same name 
 
 ### Example
 
@@ -5267,8 +5269,9 @@ public class Example {
         String delimiter = "delimiter_example"; // String | An optional delimiter of the `string identifier`, following the Lance Namespace spec. When not specified, the `$` delimiter must be used. 
         String pageToken = "pageToken_example"; // String | Pagination token from a previous request
         Integer limit = 56; // Integer | Maximum number of items to return
+        Boolean includeDeclared = true; // Boolean | When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned. 
         try {
-            CompletableFuture<ApiResponse<ListTablesResponse>> response = apiInstance.listAllTablesWithHttpInfo(delimiter, pageToken, limit);
+            CompletableFuture<ApiResponse<ListTablesResponse>> response = apiInstance.listAllTablesWithHttpInfo(delimiter, pageToken, limit, includeDeclared);
             System.out.println("Status code: " + response.get().getStatusCode());
             System.out.println("Response headers: " + response.get().getHeaders());
             System.out.println("Response body: " + response.get().getData());
@@ -5298,6 +5301,7 @@ public class Example {
 | **delimiter** | **String**| An optional delimiter of the &#x60;string identifier&#x60;, following the Lance Namespace spec. When not specified, the &#x60;$&#x60; delimiter must be used.  | [optional] |
 | **pageToken** | **String**| Pagination token from a previous request | [optional] |
 | **limit** | **Integer**| Maximum number of items to return | [optional] |
+| **includeDeclared** | **Boolean**| When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned.  | [optional] [default to true] |
 
 ### Return type
 
@@ -5917,11 +5921,11 @@ CompletableFuture<ApiResponse<[**ListTableVersionsResponse**](ListTableVersionsR
 
 ## listTables
 
-> CompletableFuture<ListTablesResponse> listTables(id, delimiter, pageToken, limit)
+> CompletableFuture<ListTablesResponse> listTables(id, delimiter, pageToken, limit, includeDeclared)
 
 List tables in a namespace
 
-List all child table names of the parent namespace &#x60;id&#x60;.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the &#x60;ListTablesRequest&#x60; information in the following way: - &#x60;id&#x60;: pass through path parameter of the same name - &#x60;page_token&#x60;: pass through query parameter of the same name - &#x60;limit&#x60;: pass through query parameter of the same name 
+List all child table names of the parent namespace &#x60;id&#x60;.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the &#x60;ListTablesRequest&#x60; information in the following way: - &#x60;id&#x60;: pass through path parameter of the same name - &#x60;page_token&#x60;: pass through query parameter of the same name - &#x60;limit&#x60;: pass through query parameter of the same name - &#x60;include_declared&#x60;: pass through query parameter of the same name 
 
 ### Example
 
@@ -5959,8 +5963,9 @@ public class Example {
         String delimiter = "delimiter_example"; // String | An optional delimiter of the `string identifier`, following the Lance Namespace spec. When not specified, the `$` delimiter must be used. 
         String pageToken = "pageToken_example"; // String | Pagination token from a previous request
         Integer limit = 56; // Integer | Maximum number of items to return
+        Boolean includeDeclared = true; // Boolean | When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned. 
         try {
-            CompletableFuture<ListTablesResponse> result = apiInstance.listTables(id, delimiter, pageToken, limit);
+            CompletableFuture<ListTablesResponse> result = apiInstance.listTables(id, delimiter, pageToken, limit, includeDeclared);
             System.out.println(result.get());
         } catch (ApiException e) {
             System.err.println("Exception when calling TableApi#listTables");
@@ -5982,6 +5987,7 @@ public class Example {
 | **delimiter** | **String**| An optional delimiter of the &#x60;string identifier&#x60;, following the Lance Namespace spec. When not specified, the &#x60;$&#x60; delimiter must be used.  | [optional] |
 | **pageToken** | **String**| Pagination token from a previous request | [optional] |
 | **limit** | **Integer**| Maximum number of items to return | [optional] |
+| **includeDeclared** | **Boolean**| When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned.  | [optional] [default to true] |
 
 ### Return type
 
@@ -6011,11 +6017,11 @@ CompletableFuture<[**ListTablesResponse**](ListTablesResponse.md)>
 
 ## listTablesWithHttpInfo
 
-> CompletableFuture<ApiResponse<ListTablesResponse>> listTables listTablesWithHttpInfo(id, delimiter, pageToken, limit)
+> CompletableFuture<ApiResponse<ListTablesResponse>> listTables listTablesWithHttpInfo(id, delimiter, pageToken, limit, includeDeclared)
 
 List tables in a namespace
 
-List all child table names of the parent namespace &#x60;id&#x60;.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the &#x60;ListTablesRequest&#x60; information in the following way: - &#x60;id&#x60;: pass through path parameter of the same name - &#x60;page_token&#x60;: pass through query parameter of the same name - &#x60;limit&#x60;: pass through query parameter of the same name 
+List all child table names of the parent namespace &#x60;id&#x60;.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the &#x60;ListTablesRequest&#x60; information in the following way: - &#x60;id&#x60;: pass through path parameter of the same name - &#x60;page_token&#x60;: pass through query parameter of the same name - &#x60;limit&#x60;: pass through query parameter of the same name - &#x60;include_declared&#x60;: pass through query parameter of the same name 
 
 ### Example
 
@@ -6054,8 +6060,9 @@ public class Example {
         String delimiter = "delimiter_example"; // String | An optional delimiter of the `string identifier`, following the Lance Namespace spec. When not specified, the `$` delimiter must be used. 
         String pageToken = "pageToken_example"; // String | Pagination token from a previous request
         Integer limit = 56; // Integer | Maximum number of items to return
+        Boolean includeDeclared = true; // Boolean | When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned. 
         try {
-            CompletableFuture<ApiResponse<ListTablesResponse>> response = apiInstance.listTablesWithHttpInfo(id, delimiter, pageToken, limit);
+            CompletableFuture<ApiResponse<ListTablesResponse>> response = apiInstance.listTablesWithHttpInfo(id, delimiter, pageToken, limit, includeDeclared);
             System.out.println("Status code: " + response.get().getStatusCode());
             System.out.println("Response headers: " + response.get().getHeaders());
             System.out.println("Response body: " + response.get().getData());
@@ -6086,6 +6093,7 @@ public class Example {
 | **delimiter** | **String**| An optional delimiter of the &#x60;string identifier&#x60;, following the Lance Namespace spec. When not specified, the &#x60;$&#x60; delimiter must be used.  | [optional] |
 | **pageToken** | **String**| Pagination token from a previous request | [optional] |
 | **limit** | **Integer**| Maximum number of items to return | [optional] |
+| **includeDeclared** | **Boolean**| When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned.  | [optional] [default to true] |
 
 ### Return type
 

--- a/java/lance-namespace-async-client/src/main/java/org/lance/namespace/client/async/api/MetadataApi.java
+++ b/java/lance-namespace-async-client/src/main/java/org/lance/namespace/client/async/api/MetadataApi.java
@@ -4481,7 +4481,7 @@ public class MetadataApi {
    * It passes in the &#x60;ListTablesRequest&#x60; information in the following way: -
    * &#x60;id&#x60;: pass through path parameter of the same name - &#x60;page_token&#x60;: pass
    * through query parameter of the same name - &#x60;limit&#x60;: pass through query parameter of
-   * the same name
+   * the same name - &#x60;include_declared&#x60;: pass through query parameter of the same name
    *
    * @param id &#x60;string identifier&#x60; of an object in a namespace, following the Lance
    *     Namespace spec. When the value is equal to the delimiter, it represents the root namespace.
@@ -4492,14 +4492,18 @@ public class MetadataApi {
    *     (optional)
    * @param pageToken Pagination token from a previous request (optional)
    * @param limit Maximum number of items to return (optional)
+   * @param includeDeclared When true (default), includes tables that have been declared in the
+   *     namespace but not yet created on storage, in addition to tables that have been created.
+   *     When false, only tables with storage components are returned. (optional, default to true)
    * @return CompletableFuture&lt;ListTablesResponse&gt;
    * @throws ApiException if fails to make API call
    */
   public CompletableFuture<ListTablesResponse> listTables(
-      String id, String delimiter, String pageToken, Integer limit) throws ApiException {
+      String id, String delimiter, String pageToken, Integer limit, Boolean includeDeclared)
+      throws ApiException {
     try {
       HttpRequest.Builder localVarRequestBuilder =
-          listTablesRequestBuilder(id, delimiter, pageToken, limit);
+          listTablesRequestBuilder(id, delimiter, pageToken, limit, includeDeclared);
       return memberVarHttpClient
           .sendAsync(localVarRequestBuilder.build(), HttpResponse.BodyHandlers.ofString())
           .thenComposeAsync(
@@ -4530,7 +4534,7 @@ public class MetadataApi {
    * It passes in the &#x60;ListTablesRequest&#x60; information in the following way: -
    * &#x60;id&#x60;: pass through path parameter of the same name - &#x60;page_token&#x60;: pass
    * through query parameter of the same name - &#x60;limit&#x60;: pass through query parameter of
-   * the same name
+   * the same name - &#x60;include_declared&#x60;: pass through query parameter of the same name
    *
    * @param id &#x60;string identifier&#x60; of an object in a namespace, following the Lance
    *     Namespace spec. When the value is equal to the delimiter, it represents the root namespace.
@@ -4541,14 +4545,18 @@ public class MetadataApi {
    *     (optional)
    * @param pageToken Pagination token from a previous request (optional)
    * @param limit Maximum number of items to return (optional)
+   * @param includeDeclared When true (default), includes tables that have been declared in the
+   *     namespace but not yet created on storage, in addition to tables that have been created.
+   *     When false, only tables with storage components are returned. (optional, default to true)
    * @return CompletableFuture&lt;ApiResponse&lt;ListTablesResponse&gt;&gt;
    * @throws ApiException if fails to make API call
    */
   public CompletableFuture<ApiResponse<ListTablesResponse>> listTablesWithHttpInfo(
-      String id, String delimiter, String pageToken, Integer limit) throws ApiException {
+      String id, String delimiter, String pageToken, Integer limit, Boolean includeDeclared)
+      throws ApiException {
     try {
       HttpRequest.Builder localVarRequestBuilder =
-          listTablesRequestBuilder(id, delimiter, pageToken, limit);
+          listTablesRequestBuilder(id, delimiter, pageToken, limit, includeDeclared);
       return memberVarHttpClient
           .sendAsync(localVarRequestBuilder.build(), HttpResponse.BodyHandlers.ofString())
           .thenComposeAsync(
@@ -4580,7 +4588,8 @@ public class MetadataApi {
   }
 
   private HttpRequest.Builder listTablesRequestBuilder(
-      String id, String delimiter, String pageToken, Integer limit) throws ApiException {
+      String id, String delimiter, String pageToken, Integer limit, Boolean includeDeclared)
+      throws ApiException {
     // verify the required parameter 'id' is set
     if (id == null) {
       throw new ApiException(400, "Missing the required parameter 'id' when calling listTables");
@@ -4600,6 +4609,8 @@ public class MetadataApi {
     localVarQueryParams.addAll(ApiClient.parameterToPairs("page_token", pageToken));
     localVarQueryParameterBaseName = "limit";
     localVarQueryParams.addAll(ApiClient.parameterToPairs("limit", limit));
+    localVarQueryParameterBaseName = "include_declared";
+    localVarQueryParams.addAll(ApiClient.parameterToPairs("include_declared", includeDeclared));
 
     if (!localVarQueryParams.isEmpty() || localVarQueryStringJoiner.length() != 0) {
       StringJoiner queryJoiner = new StringJoiner("&");

--- a/java/lance-namespace-async-client/src/main/java/org/lance/namespace/client/async/api/NamespaceApi.java
+++ b/java/lance-namespace-async-client/src/main/java/org/lance/namespace/client/async/api/NamespaceApi.java
@@ -694,7 +694,7 @@ public class NamespaceApi {
    * It passes in the &#x60;ListTablesRequest&#x60; information in the following way: -
    * &#x60;id&#x60;: pass through path parameter of the same name - &#x60;page_token&#x60;: pass
    * through query parameter of the same name - &#x60;limit&#x60;: pass through query parameter of
-   * the same name
+   * the same name - &#x60;include_declared&#x60;: pass through query parameter of the same name
    *
    * @param id &#x60;string identifier&#x60; of an object in a namespace, following the Lance
    *     Namespace spec. When the value is equal to the delimiter, it represents the root namespace.
@@ -705,14 +705,18 @@ public class NamespaceApi {
    *     (optional)
    * @param pageToken Pagination token from a previous request (optional)
    * @param limit Maximum number of items to return (optional)
+   * @param includeDeclared When true (default), includes tables that have been declared in the
+   *     namespace but not yet created on storage, in addition to tables that have been created.
+   *     When false, only tables with storage components are returned. (optional, default to true)
    * @return CompletableFuture&lt;ListTablesResponse&gt;
    * @throws ApiException if fails to make API call
    */
   public CompletableFuture<ListTablesResponse> listTables(
-      String id, String delimiter, String pageToken, Integer limit) throws ApiException {
+      String id, String delimiter, String pageToken, Integer limit, Boolean includeDeclared)
+      throws ApiException {
     try {
       HttpRequest.Builder localVarRequestBuilder =
-          listTablesRequestBuilder(id, delimiter, pageToken, limit);
+          listTablesRequestBuilder(id, delimiter, pageToken, limit, includeDeclared);
       return memberVarHttpClient
           .sendAsync(localVarRequestBuilder.build(), HttpResponse.BodyHandlers.ofString())
           .thenComposeAsync(
@@ -743,7 +747,7 @@ public class NamespaceApi {
    * It passes in the &#x60;ListTablesRequest&#x60; information in the following way: -
    * &#x60;id&#x60;: pass through path parameter of the same name - &#x60;page_token&#x60;: pass
    * through query parameter of the same name - &#x60;limit&#x60;: pass through query parameter of
-   * the same name
+   * the same name - &#x60;include_declared&#x60;: pass through query parameter of the same name
    *
    * @param id &#x60;string identifier&#x60; of an object in a namespace, following the Lance
    *     Namespace spec. When the value is equal to the delimiter, it represents the root namespace.
@@ -754,14 +758,18 @@ public class NamespaceApi {
    *     (optional)
    * @param pageToken Pagination token from a previous request (optional)
    * @param limit Maximum number of items to return (optional)
+   * @param includeDeclared When true (default), includes tables that have been declared in the
+   *     namespace but not yet created on storage, in addition to tables that have been created.
+   *     When false, only tables with storage components are returned. (optional, default to true)
    * @return CompletableFuture&lt;ApiResponse&lt;ListTablesResponse&gt;&gt;
    * @throws ApiException if fails to make API call
    */
   public CompletableFuture<ApiResponse<ListTablesResponse>> listTablesWithHttpInfo(
-      String id, String delimiter, String pageToken, Integer limit) throws ApiException {
+      String id, String delimiter, String pageToken, Integer limit, Boolean includeDeclared)
+      throws ApiException {
     try {
       HttpRequest.Builder localVarRequestBuilder =
-          listTablesRequestBuilder(id, delimiter, pageToken, limit);
+          listTablesRequestBuilder(id, delimiter, pageToken, limit, includeDeclared);
       return memberVarHttpClient
           .sendAsync(localVarRequestBuilder.build(), HttpResponse.BodyHandlers.ofString())
           .thenComposeAsync(
@@ -793,7 +801,8 @@ public class NamespaceApi {
   }
 
   private HttpRequest.Builder listTablesRequestBuilder(
-      String id, String delimiter, String pageToken, Integer limit) throws ApiException {
+      String id, String delimiter, String pageToken, Integer limit, Boolean includeDeclared)
+      throws ApiException {
     // verify the required parameter 'id' is set
     if (id == null) {
       throw new ApiException(400, "Missing the required parameter 'id' when calling listTables");
@@ -813,6 +822,8 @@ public class NamespaceApi {
     localVarQueryParams.addAll(ApiClient.parameterToPairs("page_token", pageToken));
     localVarQueryParameterBaseName = "limit";
     localVarQueryParams.addAll(ApiClient.parameterToPairs("limit", limit));
+    localVarQueryParameterBaseName = "include_declared";
+    localVarQueryParams.addAll(ApiClient.parameterToPairs("include_declared", includeDeclared));
 
     if (!localVarQueryParams.isEmpty() || localVarQueryStringJoiner.length() != 0) {
       StringJoiner queryJoiner = new StringJoiner("&");

--- a/java/lance-namespace-async-client/src/main/java/org/lance/namespace/client/async/api/TableApi.java
+++ b/java/lance-namespace-async-client/src/main/java/org/lance/namespace/client/async/api/TableApi.java
@@ -4257,21 +4257,26 @@ public class TableApi {
    * GET to perform this operation without a request body. It passes in the
    * &#x60;ListAllTablesRequest&#x60; information in the following way: - &#x60;page_token&#x60;:
    * pass through query parameter of the same name - &#x60;limit&#x60;: pass through query parameter
-   * of the same name - &#x60;delimiter&#x60;: pass through query parameter of the same name
+   * of the same name - &#x60;delimiter&#x60;: pass through query parameter of the same name -
+   * &#x60;include_declared&#x60;: pass through query parameter of the same name
    *
    * @param delimiter An optional delimiter of the &#x60;string identifier&#x60;, following the
    *     Lance Namespace spec. When not specified, the &#x60;$&#x60; delimiter must be used.
    *     (optional)
    * @param pageToken Pagination token from a previous request (optional)
    * @param limit Maximum number of items to return (optional)
+   * @param includeDeclared When true (default), includes tables that have been declared in the
+   *     namespace but not yet created on storage, in addition to tables that have been created.
+   *     When false, only tables with storage components are returned. (optional, default to true)
    * @return CompletableFuture&lt;ListTablesResponse&gt;
    * @throws ApiException if fails to make API call
    */
   public CompletableFuture<ListTablesResponse> listAllTables(
-      String delimiter, String pageToken, Integer limit) throws ApiException {
+      String delimiter, String pageToken, Integer limit, Boolean includeDeclared)
+      throws ApiException {
     try {
       HttpRequest.Builder localVarRequestBuilder =
-          listAllTablesRequestBuilder(delimiter, pageToken, limit);
+          listAllTablesRequestBuilder(delimiter, pageToken, limit, includeDeclared);
       return memberVarHttpClient
           .sendAsync(localVarRequestBuilder.build(), HttpResponse.BodyHandlers.ofString())
           .thenComposeAsync(
@@ -4301,21 +4306,26 @@ public class TableApi {
    * GET to perform this operation without a request body. It passes in the
    * &#x60;ListAllTablesRequest&#x60; information in the following way: - &#x60;page_token&#x60;:
    * pass through query parameter of the same name - &#x60;limit&#x60;: pass through query parameter
-   * of the same name - &#x60;delimiter&#x60;: pass through query parameter of the same name
+   * of the same name - &#x60;delimiter&#x60;: pass through query parameter of the same name -
+   * &#x60;include_declared&#x60;: pass through query parameter of the same name
    *
    * @param delimiter An optional delimiter of the &#x60;string identifier&#x60;, following the
    *     Lance Namespace spec. When not specified, the &#x60;$&#x60; delimiter must be used.
    *     (optional)
    * @param pageToken Pagination token from a previous request (optional)
    * @param limit Maximum number of items to return (optional)
+   * @param includeDeclared When true (default), includes tables that have been declared in the
+   *     namespace but not yet created on storage, in addition to tables that have been created.
+   *     When false, only tables with storage components are returned. (optional, default to true)
    * @return CompletableFuture&lt;ApiResponse&lt;ListTablesResponse&gt;&gt;
    * @throws ApiException if fails to make API call
    */
   public CompletableFuture<ApiResponse<ListTablesResponse>> listAllTablesWithHttpInfo(
-      String delimiter, String pageToken, Integer limit) throws ApiException {
+      String delimiter, String pageToken, Integer limit, Boolean includeDeclared)
+      throws ApiException {
     try {
       HttpRequest.Builder localVarRequestBuilder =
-          listAllTablesRequestBuilder(delimiter, pageToken, limit);
+          listAllTablesRequestBuilder(delimiter, pageToken, limit, includeDeclared);
       return memberVarHttpClient
           .sendAsync(localVarRequestBuilder.build(), HttpResponse.BodyHandlers.ofString())
           .thenComposeAsync(
@@ -4347,7 +4357,8 @@ public class TableApi {
   }
 
   private HttpRequest.Builder listAllTablesRequestBuilder(
-      String delimiter, String pageToken, Integer limit) throws ApiException {
+      String delimiter, String pageToken, Integer limit, Boolean includeDeclared)
+      throws ApiException {
 
     HttpRequest.Builder localVarRequestBuilder = HttpRequest.newBuilder();
 
@@ -4362,6 +4373,8 @@ public class TableApi {
     localVarQueryParams.addAll(ApiClient.parameterToPairs("page_token", pageToken));
     localVarQueryParameterBaseName = "limit";
     localVarQueryParams.addAll(ApiClient.parameterToPairs("limit", limit));
+    localVarQueryParameterBaseName = "include_declared";
+    localVarQueryParams.addAll(ApiClient.parameterToPairs("include_declared", includeDeclared));
 
     if (!localVarQueryParams.isEmpty() || localVarQueryStringJoiner.length() != 0) {
       StringJoiner queryJoiner = new StringJoiner("&");
@@ -4861,7 +4874,7 @@ public class TableApi {
    * It passes in the &#x60;ListTablesRequest&#x60; information in the following way: -
    * &#x60;id&#x60;: pass through path parameter of the same name - &#x60;page_token&#x60;: pass
    * through query parameter of the same name - &#x60;limit&#x60;: pass through query parameter of
-   * the same name
+   * the same name - &#x60;include_declared&#x60;: pass through query parameter of the same name
    *
    * @param id &#x60;string identifier&#x60; of an object in a namespace, following the Lance
    *     Namespace spec. When the value is equal to the delimiter, it represents the root namespace.
@@ -4872,14 +4885,18 @@ public class TableApi {
    *     (optional)
    * @param pageToken Pagination token from a previous request (optional)
    * @param limit Maximum number of items to return (optional)
+   * @param includeDeclared When true (default), includes tables that have been declared in the
+   *     namespace but not yet created on storage, in addition to tables that have been created.
+   *     When false, only tables with storage components are returned. (optional, default to true)
    * @return CompletableFuture&lt;ListTablesResponse&gt;
    * @throws ApiException if fails to make API call
    */
   public CompletableFuture<ListTablesResponse> listTables(
-      String id, String delimiter, String pageToken, Integer limit) throws ApiException {
+      String id, String delimiter, String pageToken, Integer limit, Boolean includeDeclared)
+      throws ApiException {
     try {
       HttpRequest.Builder localVarRequestBuilder =
-          listTablesRequestBuilder(id, delimiter, pageToken, limit);
+          listTablesRequestBuilder(id, delimiter, pageToken, limit, includeDeclared);
       return memberVarHttpClient
           .sendAsync(localVarRequestBuilder.build(), HttpResponse.BodyHandlers.ofString())
           .thenComposeAsync(
@@ -4910,7 +4927,7 @@ public class TableApi {
    * It passes in the &#x60;ListTablesRequest&#x60; information in the following way: -
    * &#x60;id&#x60;: pass through path parameter of the same name - &#x60;page_token&#x60;: pass
    * through query parameter of the same name - &#x60;limit&#x60;: pass through query parameter of
-   * the same name
+   * the same name - &#x60;include_declared&#x60;: pass through query parameter of the same name
    *
    * @param id &#x60;string identifier&#x60; of an object in a namespace, following the Lance
    *     Namespace spec. When the value is equal to the delimiter, it represents the root namespace.
@@ -4921,14 +4938,18 @@ public class TableApi {
    *     (optional)
    * @param pageToken Pagination token from a previous request (optional)
    * @param limit Maximum number of items to return (optional)
+   * @param includeDeclared When true (default), includes tables that have been declared in the
+   *     namespace but not yet created on storage, in addition to tables that have been created.
+   *     When false, only tables with storage components are returned. (optional, default to true)
    * @return CompletableFuture&lt;ApiResponse&lt;ListTablesResponse&gt;&gt;
    * @throws ApiException if fails to make API call
    */
   public CompletableFuture<ApiResponse<ListTablesResponse>> listTablesWithHttpInfo(
-      String id, String delimiter, String pageToken, Integer limit) throws ApiException {
+      String id, String delimiter, String pageToken, Integer limit, Boolean includeDeclared)
+      throws ApiException {
     try {
       HttpRequest.Builder localVarRequestBuilder =
-          listTablesRequestBuilder(id, delimiter, pageToken, limit);
+          listTablesRequestBuilder(id, delimiter, pageToken, limit, includeDeclared);
       return memberVarHttpClient
           .sendAsync(localVarRequestBuilder.build(), HttpResponse.BodyHandlers.ofString())
           .thenComposeAsync(
@@ -4960,7 +4981,8 @@ public class TableApi {
   }
 
   private HttpRequest.Builder listTablesRequestBuilder(
-      String id, String delimiter, String pageToken, Integer limit) throws ApiException {
+      String id, String delimiter, String pageToken, Integer limit, Boolean includeDeclared)
+      throws ApiException {
     // verify the required parameter 'id' is set
     if (id == null) {
       throw new ApiException(400, "Missing the required parameter 'id' when calling listTables");
@@ -4980,6 +5002,8 @@ public class TableApi {
     localVarQueryParams.addAll(ApiClient.parameterToPairs("page_token", pageToken));
     localVarQueryParameterBaseName = "limit";
     localVarQueryParams.addAll(ApiClient.parameterToPairs("limit", limit));
+    localVarQueryParameterBaseName = "include_declared";
+    localVarQueryParams.addAll(ApiClient.parameterToPairs("include_declared", includeDeclared));
 
     if (!localVarQueryParams.isEmpty() || localVarQueryStringJoiner.length() != 0) {
       StringJoiner queryJoiner = new StringJoiner("&");

--- a/java/lance-namespace-async-client/src/main/java/org/lance/namespace/model/ListTablesRequest.java
+++ b/java/lance-namespace-async-client/src/main/java/org/lance/namespace/model/ListTablesRequest.java
@@ -55,7 +55,7 @@ public class ListTablesRequest {
   @javax.annotation.Nullable private Integer limit;
 
   public static final String JSON_PROPERTY_INCLUDE_DECLARED = "include_declared";
-  @javax.annotation.Nullable private Boolean includeDeclared;
+  @javax.annotation.Nullable private Boolean includeDeclared = true;
 
   public ListTablesRequest() {}
 
@@ -207,8 +207,8 @@ public class ListTablesRequest {
   }
 
   /**
-   * When true, includes tables that have been declared in the namespace but not yet created on
-   * storage, in addition to tables that have been created. When false or not set, only tables with
+   * When true (default), includes tables that have been declared in the namespace but not yet
+   * created on storage, in addition to tables that have been created. When false, only tables with
    * storage components are returned.
    *
    * @return includeDeclared

--- a/java/lance-namespace-springboot-server/src/main/java/org/lance/namespace/server/springboot/api/NamespaceApi.java
+++ b/java/lance-namespace-springboot-server/src/main/java/org/lance/namespace/server/springboot/api/NamespaceApi.java
@@ -840,7 +840,8 @@ public interface NamespaceApi {
    * this operation without a request body. It passes in the &#x60;ListTablesRequest&#x60;
    * information in the following way: - &#x60;id&#x60;: pass through path parameter of the same
    * name - &#x60;page_token&#x60;: pass through query parameter of the same name -
-   * &#x60;limit&#x60;: pass through query parameter of the same name
+   * &#x60;limit&#x60;: pass through query parameter of the same name -
+   * &#x60;include_declared&#x60;: pass through query parameter of the same name
    *
    * @param id &#x60;string identifier&#x60; of an object in a namespace, following the Lance
    *     Namespace spec. When the value is equal to the delimiter, it represents the root namespace.
@@ -851,6 +852,9 @@ public interface NamespaceApi {
    *     (optional)
    * @param pageToken Pagination token from a previous request (optional)
    * @param limit Maximum number of items to return (optional)
+   * @param includeDeclared When true (default), includes tables that have been declared in the
+   *     namespace but not yet created on storage, in addition to tables that have been created.
+   *     When false, only tables with storage components are returned. (optional, default to true)
    * @return A list of tables (status code 200) or Indicates a bad request error. It could be caused
    *     by an unexpected request body format or other forms of request validation failure, such as
    *     invalid json. Usually serves application/json content, although in some cases simple
@@ -869,7 +873,7 @@ public interface NamespaceApi {
       operationId = "listTables",
       summary = "List tables in a namespace",
       description =
-          "List all child table names of the parent namespace `id`.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the `ListTablesRequest` information in the following way: - `id`: pass through path parameter of the same name - `page_token`: pass through query parameter of the same name - `limit`: pass through query parameter of the same name ",
+          "List all child table names of the parent namespace `id`.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the `ListTablesRequest` information in the following way: - `id`: pass through path parameter of the same name - `page_token`: pass through query parameter of the same name - `limit`: pass through query parameter of the same name - `include_declared`: pass through query parameter of the same name ",
       tags = {"Namespace", "Table", "Metadata"},
       responses = {
         @ApiResponse(
@@ -981,7 +985,15 @@ public interface NamespaceApi {
               in = ParameterIn.QUERY)
           @Valid
           @RequestParam(value = "limit", required = false)
-          Optional<Integer> limit) {
+          Optional<Integer> limit,
+      @Parameter(
+              name = "include_declared",
+              description =
+                  "When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned. ",
+              in = ParameterIn.QUERY)
+          @Valid
+          @RequestParam(value = "include_declared", required = false, defaultValue = "true")
+          Optional<Boolean> includeDeclared) {
     getRequest()
         .ifPresent(
             request -> {

--- a/java/lance-namespace-springboot-server/src/main/java/org/lance/namespace/server/springboot/api/TableApi.java
+++ b/java/lance-namespace-springboot-server/src/main/java/org/lance/namespace/server/springboot/api/TableApi.java
@@ -4828,13 +4828,17 @@ public interface TableApi {
    * namespace uses GET to perform this operation without a request body. It passes in the
    * &#x60;ListAllTablesRequest&#x60; information in the following way: - &#x60;page_token&#x60;:
    * pass through query parameter of the same name - &#x60;limit&#x60;: pass through query parameter
-   * of the same name - &#x60;delimiter&#x60;: pass through query parameter of the same name
+   * of the same name - &#x60;delimiter&#x60;: pass through query parameter of the same name -
+   * &#x60;include_declared&#x60;: pass through query parameter of the same name
    *
    * @param delimiter An optional delimiter of the &#x60;string identifier&#x60;, following the
    *     Lance Namespace spec. When not specified, the &#x60;$&#x60; delimiter must be used.
    *     (optional)
    * @param pageToken Pagination token from a previous request (optional)
    * @param limit Maximum number of items to return (optional)
+   * @param includeDeclared When true (default), includes tables that have been declared in the
+   *     namespace but not yet created on storage, in addition to tables that have been created.
+   *     When false, only tables with storage components are returned. (optional, default to true)
    * @return A list of tables (status code 200) or Indicates a bad request error. It could be caused
    *     by an unexpected request body format or other forms of request validation failure, such as
    *     invalid json. Usually serves application/json content, although in some cases simple
@@ -4851,7 +4855,7 @@ public interface TableApi {
       operationId = "listAllTables",
       summary = "List all tables",
       description =
-          "List all tables across all namespaces.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the `ListAllTablesRequest` information in the following way: - `page_token`: pass through query parameter of the same name - `limit`: pass through query parameter of the same name - `delimiter`: pass through query parameter of the same name ",
+          "List all tables across all namespaces.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the `ListAllTablesRequest` information in the following way: - `page_token`: pass through query parameter of the same name - `limit`: pass through query parameter of the same name - `delimiter`: pass through query parameter of the same name - `include_declared`: pass through query parameter of the same name ",
       tags = {"Table"},
       responses = {
         @ApiResponse(
@@ -4938,7 +4942,15 @@ public interface TableApi {
               in = ParameterIn.QUERY)
           @Valid
           @RequestParam(value = "limit", required = false)
-          Optional<Integer> limit) {
+          Optional<Integer> limit,
+      @Parameter(
+              name = "include_declared",
+              description =
+                  "When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned. ",
+              in = ParameterIn.QUERY)
+          @Valid
+          @RequestParam(value = "include_declared", required = false, defaultValue = "true")
+          Optional<Boolean> includeDeclared) {
     getRequest()
         .ifPresent(
             request -> {

--- a/java/lance-namespace-springboot-server/src/main/java/org/lance/namespace/server/springboot/model/ListTablesRequest.java
+++ b/java/lance-namespace-springboot-server/src/main/java/org/lance/namespace/server/springboot/model/ListTablesRequest.java
@@ -42,7 +42,7 @@ public class ListTablesRequest {
 
   private Integer limit;
 
-  private Boolean includeDeclared;
+  private Boolean includeDeclared = true;
 
   public ListTablesRequest identity(Identity identity) {
     this.identity = identity;
@@ -189,8 +189,8 @@ public class ListTablesRequest {
   }
 
   /**
-   * When true, includes tables that have been declared in the namespace but not yet created on
-   * storage, in addition to tables that have been created. When false or not set, only tables with
+   * When true (default), includes tables that have been declared in the namespace but not yet
+   * created on storage, in addition to tables that have been created. When false, only tables with
    * storage components are returned.
    *
    * @return includeDeclared
@@ -198,7 +198,7 @@ public class ListTablesRequest {
   @Schema(
       name = "include_declared",
       description =
-          "When true, includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false or not set, only tables with storage components are returned. ",
+          "When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned. ",
       requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   @JsonProperty("include_declared")
   public Boolean getIncludeDeclared() {

--- a/python/lance_namespace_urllib3_client/docs/ListTablesRequest.md
+++ b/python/lance_namespace_urllib3_client/docs/ListTablesRequest.md
@@ -10,7 +10,7 @@ Name | Type | Description | Notes
 **id** | **List[str]** |  | [optional] 
 **page_token** | **str** | An opaque token that allows pagination for list operations (e.g. ListNamespaces).  For an initial request of a list operation, if the implementation cannot return all items in one response, or if there are more items than the page limit specified in the request, the implementation must return a page token in the response, indicating there are more results available.  After the initial request, the value of the page token from each response must be used as the page token value for the next request.  Caller must interpret either &#x60;null&#x60;, missing value or empty string value of the page token from the implementation&#39;s response as the end of the listing results.  | [optional] 
 **limit** | **int** | An inclusive upper bound of the number of results that a caller will receive.  | [optional] 
-**include_declared** | **bool** | When true, includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false or not set, only tables with storage components are returned.  | [optional] 
+**include_declared** | **bool** | When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned.  | [optional] [default to True]
 
 ## Example
 

--- a/python/lance_namespace_urllib3_client/docs/MetadataApi.md
+++ b/python/lance_namespace_urllib3_client/docs/MetadataApi.md
@@ -2942,7 +2942,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **list_tables**
-> ListTablesResponse list_tables(id, delimiter=delimiter, page_token=page_token, limit=limit)
+> ListTablesResponse list_tables(id, delimiter=delimiter, page_token=page_token, limit=limit, include_declared=include_declared)
 
 List tables in a namespace
 
@@ -2954,6 +2954,7 @@ It passes in the `ListTablesRequest` information in the following way:
 - `id`: pass through path parameter of the same name
 - `page_token`: pass through query parameter of the same name
 - `limit`: pass through query parameter of the same name
+- `include_declared`: pass through query parameter of the same name
 
 
 ### Example
@@ -3000,10 +3001,11 @@ with lance_namespace_urllib3_client.ApiClient(configuration) as api_client:
     delimiter = 'delimiter_example' # str | An optional delimiter of the `string identifier`, following the Lance Namespace spec. When not specified, the `$` delimiter must be used.  (optional)
     page_token = 'page_token_example' # str | Pagination token from a previous request (optional)
     limit = 56 # int | Maximum number of items to return (optional)
+    include_declared = True # bool | When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned.  (optional) (default to True)
 
     try:
         # List tables in a namespace
-        api_response = api_instance.list_tables(id, delimiter=delimiter, page_token=page_token, limit=limit)
+        api_response = api_instance.list_tables(id, delimiter=delimiter, page_token=page_token, limit=limit, include_declared=include_declared)
         print("The response of MetadataApi->list_tables:\n")
         pprint(api_response)
     except Exception as e:
@@ -3021,6 +3023,7 @@ Name | Type | Description  | Notes
  **delimiter** | **str**| An optional delimiter of the &#x60;string identifier&#x60;, following the Lance Namespace spec. When not specified, the &#x60;$&#x60; delimiter must be used.  | [optional] 
  **page_token** | **str**| Pagination token from a previous request | [optional] 
  **limit** | **int**| Maximum number of items to return | [optional] 
+ **include_declared** | **bool**| When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned.  | [optional] [default to True]
 
 ### Return type
 

--- a/python/lance_namespace_urllib3_client/docs/NamespaceApi.md
+++ b/python/lance_namespace_urllib3_client/docs/NamespaceApi.md
@@ -429,7 +429,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **list_tables**
-> ListTablesResponse list_tables(id, delimiter=delimiter, page_token=page_token, limit=limit)
+> ListTablesResponse list_tables(id, delimiter=delimiter, page_token=page_token, limit=limit, include_declared=include_declared)
 
 List tables in a namespace
 
@@ -441,6 +441,7 @@ It passes in the `ListTablesRequest` information in the following way:
 - `id`: pass through path parameter of the same name
 - `page_token`: pass through query parameter of the same name
 - `limit`: pass through query parameter of the same name
+- `include_declared`: pass through query parameter of the same name
 
 
 ### Example
@@ -487,10 +488,11 @@ with lance_namespace_urllib3_client.ApiClient(configuration) as api_client:
     delimiter = 'delimiter_example' # str | An optional delimiter of the `string identifier`, following the Lance Namespace spec. When not specified, the `$` delimiter must be used.  (optional)
     page_token = 'page_token_example' # str | Pagination token from a previous request (optional)
     limit = 56 # int | Maximum number of items to return (optional)
+    include_declared = True # bool | When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned.  (optional) (default to True)
 
     try:
         # List tables in a namespace
-        api_response = api_instance.list_tables(id, delimiter=delimiter, page_token=page_token, limit=limit)
+        api_response = api_instance.list_tables(id, delimiter=delimiter, page_token=page_token, limit=limit, include_declared=include_declared)
         print("The response of NamespaceApi->list_tables:\n")
         pprint(api_response)
     except Exception as e:
@@ -508,6 +510,7 @@ Name | Type | Description  | Notes
  **delimiter** | **str**| An optional delimiter of the &#x60;string identifier&#x60;, following the Lance Namespace spec. When not specified, the &#x60;$&#x60; delimiter must be used.  | [optional] 
  **page_token** | **str**| Pagination token from a previous request | [optional] 
  **limit** | **int**| Maximum number of items to return | [optional] 
+ **include_declared** | **bool**| When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned.  | [optional] [default to True]
 
 ### Return type
 

--- a/python/lance_namespace_urllib3_client/docs/TableApi.md
+++ b/python/lance_namespace_urllib3_client/docs/TableApi.md
@@ -2747,7 +2747,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **list_all_tables**
-> ListTablesResponse list_all_tables(delimiter=delimiter, page_token=page_token, limit=limit)
+> ListTablesResponse list_all_tables(delimiter=delimiter, page_token=page_token, limit=limit, include_declared=include_declared)
 
 List all tables
 
@@ -2759,6 +2759,7 @@ It passes in the `ListAllTablesRequest` information in the following way:
 - `page_token`: pass through query parameter of the same name
 - `limit`: pass through query parameter of the same name
 - `delimiter`: pass through query parameter of the same name
+- `include_declared`: pass through query parameter of the same name
 
 
 ### Example
@@ -2804,10 +2805,11 @@ with lance_namespace_urllib3_client.ApiClient(configuration) as api_client:
     delimiter = 'delimiter_example' # str | An optional delimiter of the `string identifier`, following the Lance Namespace spec. When not specified, the `$` delimiter must be used.  (optional)
     page_token = 'page_token_example' # str | Pagination token from a previous request (optional)
     limit = 56 # int | Maximum number of items to return (optional)
+    include_declared = True # bool | When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned.  (optional) (default to True)
 
     try:
         # List all tables
-        api_response = api_instance.list_all_tables(delimiter=delimiter, page_token=page_token, limit=limit)
+        api_response = api_instance.list_all_tables(delimiter=delimiter, page_token=page_token, limit=limit, include_declared=include_declared)
         print("The response of TableApi->list_all_tables:\n")
         pprint(api_response)
     except Exception as e:
@@ -2824,6 +2826,7 @@ Name | Type | Description  | Notes
  **delimiter** | **str**| An optional delimiter of the &#x60;string identifier&#x60;, following the Lance Namespace spec. When not specified, the &#x60;$&#x60; delimiter must be used.  | [optional] 
  **page_token** | **str**| Pagination token from a previous request | [optional] 
  **limit** | **int**| Maximum number of items to return | [optional] 
+ **include_declared** | **bool**| When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned.  | [optional] [default to True]
 
 ### Return type
 
@@ -3176,7 +3179,7 @@ Name | Type | Description  | Notes
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **list_tables**
-> ListTablesResponse list_tables(id, delimiter=delimiter, page_token=page_token, limit=limit)
+> ListTablesResponse list_tables(id, delimiter=delimiter, page_token=page_token, limit=limit, include_declared=include_declared)
 
 List tables in a namespace
 
@@ -3188,6 +3191,7 @@ It passes in the `ListTablesRequest` information in the following way:
 - `id`: pass through path parameter of the same name
 - `page_token`: pass through query parameter of the same name
 - `limit`: pass through query parameter of the same name
+- `include_declared`: pass through query parameter of the same name
 
 
 ### Example
@@ -3234,10 +3238,11 @@ with lance_namespace_urllib3_client.ApiClient(configuration) as api_client:
     delimiter = 'delimiter_example' # str | An optional delimiter of the `string identifier`, following the Lance Namespace spec. When not specified, the `$` delimiter must be used.  (optional)
     page_token = 'page_token_example' # str | Pagination token from a previous request (optional)
     limit = 56 # int | Maximum number of items to return (optional)
+    include_declared = True # bool | When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned.  (optional) (default to True)
 
     try:
         # List tables in a namespace
-        api_response = api_instance.list_tables(id, delimiter=delimiter, page_token=page_token, limit=limit)
+        api_response = api_instance.list_tables(id, delimiter=delimiter, page_token=page_token, limit=limit, include_declared=include_declared)
         print("The response of TableApi->list_tables:\n")
         pprint(api_response)
     except Exception as e:
@@ -3255,6 +3260,7 @@ Name | Type | Description  | Notes
  **delimiter** | **str**| An optional delimiter of the &#x60;string identifier&#x60;, following the Lance Namespace spec. When not specified, the &#x60;$&#x60; delimiter must be used.  | [optional] 
  **page_token** | **str**| Pagination token from a previous request | [optional] 
  **limit** | **int**| Maximum number of items to return | [optional] 
+ **include_declared** | **bool**| When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned.  | [optional] [default to True]
 
 ### Return type
 

--- a/python/lance_namespace_urllib3_client/lance_namespace_urllib3_client/api/metadata_api.py
+++ b/python/lance_namespace_urllib3_client/lance_namespace_urllib3_client/api/metadata_api.py
@@ -9277,6 +9277,7 @@ class MetadataApi:
         delimiter: Annotated[Optional[StrictStr], Field(description="An optional delimiter of the `string identifier`, following the Lance Namespace spec. When not specified, the `$` delimiter must be used. ")] = None,
         page_token: Annotated[Optional[StrictStr], Field(description="Pagination token from a previous request")] = None,
         limit: Annotated[Optional[StrictInt], Field(description="Maximum number of items to return")] = None,
+        include_declared: Annotated[Optional[StrictBool], Field(description="When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned. ")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -9292,7 +9293,7 @@ class MetadataApi:
     ) -> ListTablesResponse:
         """List tables in a namespace
 
-        List all child table names of the parent namespace `id`.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the `ListTablesRequest` information in the following way: - `id`: pass through path parameter of the same name - `page_token`: pass through query parameter of the same name - `limit`: pass through query parameter of the same name 
+        List all child table names of the parent namespace `id`.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the `ListTablesRequest` information in the following way: - `id`: pass through path parameter of the same name - `page_token`: pass through query parameter of the same name - `limit`: pass through query parameter of the same name - `include_declared`: pass through query parameter of the same name 
 
         :param id: `string identifier` of an object in a namespace, following the Lance Namespace spec. When the value is equal to the delimiter, it represents the root namespace. For example, `v1/namespace/$/list` performs a `ListNamespace` on the root namespace.  (required)
         :type id: str
@@ -9302,6 +9303,8 @@ class MetadataApi:
         :type page_token: str
         :param limit: Maximum number of items to return
         :type limit: int
+        :param include_declared: When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned. 
+        :type include_declared: bool
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -9329,6 +9332,7 @@ class MetadataApi:
             delimiter=delimiter,
             page_token=page_token,
             limit=limit,
+            include_declared=include_declared,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -9363,6 +9367,7 @@ class MetadataApi:
         delimiter: Annotated[Optional[StrictStr], Field(description="An optional delimiter of the `string identifier`, following the Lance Namespace spec. When not specified, the `$` delimiter must be used. ")] = None,
         page_token: Annotated[Optional[StrictStr], Field(description="Pagination token from a previous request")] = None,
         limit: Annotated[Optional[StrictInt], Field(description="Maximum number of items to return")] = None,
+        include_declared: Annotated[Optional[StrictBool], Field(description="When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned. ")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -9378,7 +9383,7 @@ class MetadataApi:
     ) -> ApiResponse[ListTablesResponse]:
         """List tables in a namespace
 
-        List all child table names of the parent namespace `id`.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the `ListTablesRequest` information in the following way: - `id`: pass through path parameter of the same name - `page_token`: pass through query parameter of the same name - `limit`: pass through query parameter of the same name 
+        List all child table names of the parent namespace `id`.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the `ListTablesRequest` information in the following way: - `id`: pass through path parameter of the same name - `page_token`: pass through query parameter of the same name - `limit`: pass through query parameter of the same name - `include_declared`: pass through query parameter of the same name 
 
         :param id: `string identifier` of an object in a namespace, following the Lance Namespace spec. When the value is equal to the delimiter, it represents the root namespace. For example, `v1/namespace/$/list` performs a `ListNamespace` on the root namespace.  (required)
         :type id: str
@@ -9388,6 +9393,8 @@ class MetadataApi:
         :type page_token: str
         :param limit: Maximum number of items to return
         :type limit: int
+        :param include_declared: When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned. 
+        :type include_declared: bool
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -9415,6 +9422,7 @@ class MetadataApi:
             delimiter=delimiter,
             page_token=page_token,
             limit=limit,
+            include_declared=include_declared,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -9449,6 +9457,7 @@ class MetadataApi:
         delimiter: Annotated[Optional[StrictStr], Field(description="An optional delimiter of the `string identifier`, following the Lance Namespace spec. When not specified, the `$` delimiter must be used. ")] = None,
         page_token: Annotated[Optional[StrictStr], Field(description="Pagination token from a previous request")] = None,
         limit: Annotated[Optional[StrictInt], Field(description="Maximum number of items to return")] = None,
+        include_declared: Annotated[Optional[StrictBool], Field(description="When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned. ")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -9464,7 +9473,7 @@ class MetadataApi:
     ) -> RESTResponseType:
         """List tables in a namespace
 
-        List all child table names of the parent namespace `id`.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the `ListTablesRequest` information in the following way: - `id`: pass through path parameter of the same name - `page_token`: pass through query parameter of the same name - `limit`: pass through query parameter of the same name 
+        List all child table names of the parent namespace `id`.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the `ListTablesRequest` information in the following way: - `id`: pass through path parameter of the same name - `page_token`: pass through query parameter of the same name - `limit`: pass through query parameter of the same name - `include_declared`: pass through query parameter of the same name 
 
         :param id: `string identifier` of an object in a namespace, following the Lance Namespace spec. When the value is equal to the delimiter, it represents the root namespace. For example, `v1/namespace/$/list` performs a `ListNamespace` on the root namespace.  (required)
         :type id: str
@@ -9474,6 +9483,8 @@ class MetadataApi:
         :type page_token: str
         :param limit: Maximum number of items to return
         :type limit: int
+        :param include_declared: When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned. 
+        :type include_declared: bool
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -9501,6 +9512,7 @@ class MetadataApi:
             delimiter=delimiter,
             page_token=page_token,
             limit=limit,
+            include_declared=include_declared,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -9530,6 +9542,7 @@ class MetadataApi:
         delimiter,
         page_token,
         limit,
+        include_declared,
         _request_auth,
         _content_type,
         _headers,
@@ -9565,6 +9578,10 @@ class MetadataApi:
         if limit is not None:
             
             _query_params.append(('limit', limit))
+            
+        if include_declared is not None:
+            
+            _query_params.append(('include_declared', include_declared))
             
         # process the header parameters
         # process the form parameters

--- a/python/lance_namespace_urllib3_client/lance_namespace_urllib3_client/api/namespace_api.py
+++ b/python/lance_namespace_urllib3_client/lance_namespace_urllib3_client/api/namespace_api.py
@@ -16,7 +16,7 @@ from pydantic import validate_call, Field, StrictFloat, StrictStr, StrictInt
 from typing import Any, Dict, List, Optional, Tuple, Union
 from typing_extensions import Annotated
 
-from pydantic import Field, StrictInt, StrictStr
+from pydantic import Field, StrictBool, StrictInt, StrictStr
 from typing import Optional
 from typing_extensions import Annotated
 from lance_namespace_urllib3_client.models.create_namespace_request import CreateNamespaceRequest
@@ -1376,6 +1376,7 @@ class NamespaceApi:
         delimiter: Annotated[Optional[StrictStr], Field(description="An optional delimiter of the `string identifier`, following the Lance Namespace spec. When not specified, the `$` delimiter must be used. ")] = None,
         page_token: Annotated[Optional[StrictStr], Field(description="Pagination token from a previous request")] = None,
         limit: Annotated[Optional[StrictInt], Field(description="Maximum number of items to return")] = None,
+        include_declared: Annotated[Optional[StrictBool], Field(description="When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned. ")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1391,7 +1392,7 @@ class NamespaceApi:
     ) -> ListTablesResponse:
         """List tables in a namespace
 
-        List all child table names of the parent namespace `id`.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the `ListTablesRequest` information in the following way: - `id`: pass through path parameter of the same name - `page_token`: pass through query parameter of the same name - `limit`: pass through query parameter of the same name 
+        List all child table names of the parent namespace `id`.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the `ListTablesRequest` information in the following way: - `id`: pass through path parameter of the same name - `page_token`: pass through query parameter of the same name - `limit`: pass through query parameter of the same name - `include_declared`: pass through query parameter of the same name 
 
         :param id: `string identifier` of an object in a namespace, following the Lance Namespace spec. When the value is equal to the delimiter, it represents the root namespace. For example, `v1/namespace/$/list` performs a `ListNamespace` on the root namespace.  (required)
         :type id: str
@@ -1401,6 +1402,8 @@ class NamespaceApi:
         :type page_token: str
         :param limit: Maximum number of items to return
         :type limit: int
+        :param include_declared: When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned. 
+        :type include_declared: bool
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1428,6 +1431,7 @@ class NamespaceApi:
             delimiter=delimiter,
             page_token=page_token,
             limit=limit,
+            include_declared=include_declared,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -1462,6 +1466,7 @@ class NamespaceApi:
         delimiter: Annotated[Optional[StrictStr], Field(description="An optional delimiter of the `string identifier`, following the Lance Namespace spec. When not specified, the `$` delimiter must be used. ")] = None,
         page_token: Annotated[Optional[StrictStr], Field(description="Pagination token from a previous request")] = None,
         limit: Annotated[Optional[StrictInt], Field(description="Maximum number of items to return")] = None,
+        include_declared: Annotated[Optional[StrictBool], Field(description="When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned. ")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1477,7 +1482,7 @@ class NamespaceApi:
     ) -> ApiResponse[ListTablesResponse]:
         """List tables in a namespace
 
-        List all child table names of the parent namespace `id`.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the `ListTablesRequest` information in the following way: - `id`: pass through path parameter of the same name - `page_token`: pass through query parameter of the same name - `limit`: pass through query parameter of the same name 
+        List all child table names of the parent namespace `id`.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the `ListTablesRequest` information in the following way: - `id`: pass through path parameter of the same name - `page_token`: pass through query parameter of the same name - `limit`: pass through query parameter of the same name - `include_declared`: pass through query parameter of the same name 
 
         :param id: `string identifier` of an object in a namespace, following the Lance Namespace spec. When the value is equal to the delimiter, it represents the root namespace. For example, `v1/namespace/$/list` performs a `ListNamespace` on the root namespace.  (required)
         :type id: str
@@ -1487,6 +1492,8 @@ class NamespaceApi:
         :type page_token: str
         :param limit: Maximum number of items to return
         :type limit: int
+        :param include_declared: When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned. 
+        :type include_declared: bool
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1514,6 +1521,7 @@ class NamespaceApi:
             delimiter=delimiter,
             page_token=page_token,
             limit=limit,
+            include_declared=include_declared,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -1548,6 +1556,7 @@ class NamespaceApi:
         delimiter: Annotated[Optional[StrictStr], Field(description="An optional delimiter of the `string identifier`, following the Lance Namespace spec. When not specified, the `$` delimiter must be used. ")] = None,
         page_token: Annotated[Optional[StrictStr], Field(description="Pagination token from a previous request")] = None,
         limit: Annotated[Optional[StrictInt], Field(description="Maximum number of items to return")] = None,
+        include_declared: Annotated[Optional[StrictBool], Field(description="When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned. ")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1563,7 +1572,7 @@ class NamespaceApi:
     ) -> RESTResponseType:
         """List tables in a namespace
 
-        List all child table names of the parent namespace `id`.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the `ListTablesRequest` information in the following way: - `id`: pass through path parameter of the same name - `page_token`: pass through query parameter of the same name - `limit`: pass through query parameter of the same name 
+        List all child table names of the parent namespace `id`.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the `ListTablesRequest` information in the following way: - `id`: pass through path parameter of the same name - `page_token`: pass through query parameter of the same name - `limit`: pass through query parameter of the same name - `include_declared`: pass through query parameter of the same name 
 
         :param id: `string identifier` of an object in a namespace, following the Lance Namespace spec. When the value is equal to the delimiter, it represents the root namespace. For example, `v1/namespace/$/list` performs a `ListNamespace` on the root namespace.  (required)
         :type id: str
@@ -1573,6 +1582,8 @@ class NamespaceApi:
         :type page_token: str
         :param limit: Maximum number of items to return
         :type limit: int
+        :param include_declared: When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned. 
+        :type include_declared: bool
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1600,6 +1611,7 @@ class NamespaceApi:
             delimiter=delimiter,
             page_token=page_token,
             limit=limit,
+            include_declared=include_declared,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -1629,6 +1641,7 @@ class NamespaceApi:
         delimiter,
         page_token,
         limit,
+        include_declared,
         _request_auth,
         _content_type,
         _headers,
@@ -1664,6 +1677,10 @@ class NamespaceApi:
         if limit is not None:
             
             _query_params.append(('limit', limit))
+            
+        if include_declared is not None:
+            
+            _query_params.append(('include_declared', include_declared))
             
         # process the header parameters
         # process the form parameters

--- a/python/lance_namespace_urllib3_client/lance_namespace_urllib3_client/api/table_api.py
+++ b/python/lance_namespace_urllib3_client/lance_namespace_urllib3_client/api/table_api.py
@@ -8662,6 +8662,7 @@ class TableApi:
         delimiter: Annotated[Optional[StrictStr], Field(description="An optional delimiter of the `string identifier`, following the Lance Namespace spec. When not specified, the `$` delimiter must be used. ")] = None,
         page_token: Annotated[Optional[StrictStr], Field(description="Pagination token from a previous request")] = None,
         limit: Annotated[Optional[StrictInt], Field(description="Maximum number of items to return")] = None,
+        include_declared: Annotated[Optional[StrictBool], Field(description="When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned. ")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -8677,7 +8678,7 @@ class TableApi:
     ) -> ListTablesResponse:
         """List all tables
 
-        List all tables across all namespaces.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the `ListAllTablesRequest` information in the following way: - `page_token`: pass through query parameter of the same name - `limit`: pass through query parameter of the same name - `delimiter`: pass through query parameter of the same name 
+        List all tables across all namespaces.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the `ListAllTablesRequest` information in the following way: - `page_token`: pass through query parameter of the same name - `limit`: pass through query parameter of the same name - `delimiter`: pass through query parameter of the same name - `include_declared`: pass through query parameter of the same name 
 
         :param delimiter: An optional delimiter of the `string identifier`, following the Lance Namespace spec. When not specified, the `$` delimiter must be used. 
         :type delimiter: str
@@ -8685,6 +8686,8 @@ class TableApi:
         :type page_token: str
         :param limit: Maximum number of items to return
         :type limit: int
+        :param include_declared: When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned. 
+        :type include_declared: bool
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -8711,6 +8714,7 @@ class TableApi:
             delimiter=delimiter,
             page_token=page_token,
             limit=limit,
+            include_declared=include_declared,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -8742,6 +8746,7 @@ class TableApi:
         delimiter: Annotated[Optional[StrictStr], Field(description="An optional delimiter of the `string identifier`, following the Lance Namespace spec. When not specified, the `$` delimiter must be used. ")] = None,
         page_token: Annotated[Optional[StrictStr], Field(description="Pagination token from a previous request")] = None,
         limit: Annotated[Optional[StrictInt], Field(description="Maximum number of items to return")] = None,
+        include_declared: Annotated[Optional[StrictBool], Field(description="When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned. ")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -8757,7 +8762,7 @@ class TableApi:
     ) -> ApiResponse[ListTablesResponse]:
         """List all tables
 
-        List all tables across all namespaces.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the `ListAllTablesRequest` information in the following way: - `page_token`: pass through query parameter of the same name - `limit`: pass through query parameter of the same name - `delimiter`: pass through query parameter of the same name 
+        List all tables across all namespaces.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the `ListAllTablesRequest` information in the following way: - `page_token`: pass through query parameter of the same name - `limit`: pass through query parameter of the same name - `delimiter`: pass through query parameter of the same name - `include_declared`: pass through query parameter of the same name 
 
         :param delimiter: An optional delimiter of the `string identifier`, following the Lance Namespace spec. When not specified, the `$` delimiter must be used. 
         :type delimiter: str
@@ -8765,6 +8770,8 @@ class TableApi:
         :type page_token: str
         :param limit: Maximum number of items to return
         :type limit: int
+        :param include_declared: When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned. 
+        :type include_declared: bool
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -8791,6 +8798,7 @@ class TableApi:
             delimiter=delimiter,
             page_token=page_token,
             limit=limit,
+            include_declared=include_declared,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -8822,6 +8830,7 @@ class TableApi:
         delimiter: Annotated[Optional[StrictStr], Field(description="An optional delimiter of the `string identifier`, following the Lance Namespace spec. When not specified, the `$` delimiter must be used. ")] = None,
         page_token: Annotated[Optional[StrictStr], Field(description="Pagination token from a previous request")] = None,
         limit: Annotated[Optional[StrictInt], Field(description="Maximum number of items to return")] = None,
+        include_declared: Annotated[Optional[StrictBool], Field(description="When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned. ")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -8837,7 +8846,7 @@ class TableApi:
     ) -> RESTResponseType:
         """List all tables
 
-        List all tables across all namespaces.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the `ListAllTablesRequest` information in the following way: - `page_token`: pass through query parameter of the same name - `limit`: pass through query parameter of the same name - `delimiter`: pass through query parameter of the same name 
+        List all tables across all namespaces.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the `ListAllTablesRequest` information in the following way: - `page_token`: pass through query parameter of the same name - `limit`: pass through query parameter of the same name - `delimiter`: pass through query parameter of the same name - `include_declared`: pass through query parameter of the same name 
 
         :param delimiter: An optional delimiter of the `string identifier`, following the Lance Namespace spec. When not specified, the `$` delimiter must be used. 
         :type delimiter: str
@@ -8845,6 +8854,8 @@ class TableApi:
         :type page_token: str
         :param limit: Maximum number of items to return
         :type limit: int
+        :param include_declared: When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned. 
+        :type include_declared: bool
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -8871,6 +8882,7 @@ class TableApi:
             delimiter=delimiter,
             page_token=page_token,
             limit=limit,
+            include_declared=include_declared,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -8897,6 +8909,7 @@ class TableApi:
         delimiter,
         page_token,
         limit,
+        include_declared,
         _request_auth,
         _content_type,
         _headers,
@@ -8930,6 +8943,10 @@ class TableApi:
         if limit is not None:
             
             _query_params.append(('limit', limit))
+            
+        if include_declared is not None:
+            
+            _query_params.append(('include_declared', include_declared))
             
         # process the header parameters
         # process the form parameters
@@ -9984,6 +10001,7 @@ class TableApi:
         delimiter: Annotated[Optional[StrictStr], Field(description="An optional delimiter of the `string identifier`, following the Lance Namespace spec. When not specified, the `$` delimiter must be used. ")] = None,
         page_token: Annotated[Optional[StrictStr], Field(description="Pagination token from a previous request")] = None,
         limit: Annotated[Optional[StrictInt], Field(description="Maximum number of items to return")] = None,
+        include_declared: Annotated[Optional[StrictBool], Field(description="When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned. ")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -9999,7 +10017,7 @@ class TableApi:
     ) -> ListTablesResponse:
         """List tables in a namespace
 
-        List all child table names of the parent namespace `id`.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the `ListTablesRequest` information in the following way: - `id`: pass through path parameter of the same name - `page_token`: pass through query parameter of the same name - `limit`: pass through query parameter of the same name 
+        List all child table names of the parent namespace `id`.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the `ListTablesRequest` information in the following way: - `id`: pass through path parameter of the same name - `page_token`: pass through query parameter of the same name - `limit`: pass through query parameter of the same name - `include_declared`: pass through query parameter of the same name 
 
         :param id: `string identifier` of an object in a namespace, following the Lance Namespace spec. When the value is equal to the delimiter, it represents the root namespace. For example, `v1/namespace/$/list` performs a `ListNamespace` on the root namespace.  (required)
         :type id: str
@@ -10009,6 +10027,8 @@ class TableApi:
         :type page_token: str
         :param limit: Maximum number of items to return
         :type limit: int
+        :param include_declared: When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned. 
+        :type include_declared: bool
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -10036,6 +10056,7 @@ class TableApi:
             delimiter=delimiter,
             page_token=page_token,
             limit=limit,
+            include_declared=include_declared,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -10070,6 +10091,7 @@ class TableApi:
         delimiter: Annotated[Optional[StrictStr], Field(description="An optional delimiter of the `string identifier`, following the Lance Namespace spec. When not specified, the `$` delimiter must be used. ")] = None,
         page_token: Annotated[Optional[StrictStr], Field(description="Pagination token from a previous request")] = None,
         limit: Annotated[Optional[StrictInt], Field(description="Maximum number of items to return")] = None,
+        include_declared: Annotated[Optional[StrictBool], Field(description="When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned. ")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -10085,7 +10107,7 @@ class TableApi:
     ) -> ApiResponse[ListTablesResponse]:
         """List tables in a namespace
 
-        List all child table names of the parent namespace `id`.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the `ListTablesRequest` information in the following way: - `id`: pass through path parameter of the same name - `page_token`: pass through query parameter of the same name - `limit`: pass through query parameter of the same name 
+        List all child table names of the parent namespace `id`.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the `ListTablesRequest` information in the following way: - `id`: pass through path parameter of the same name - `page_token`: pass through query parameter of the same name - `limit`: pass through query parameter of the same name - `include_declared`: pass through query parameter of the same name 
 
         :param id: `string identifier` of an object in a namespace, following the Lance Namespace spec. When the value is equal to the delimiter, it represents the root namespace. For example, `v1/namespace/$/list` performs a `ListNamespace` on the root namespace.  (required)
         :type id: str
@@ -10095,6 +10117,8 @@ class TableApi:
         :type page_token: str
         :param limit: Maximum number of items to return
         :type limit: int
+        :param include_declared: When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned. 
+        :type include_declared: bool
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -10122,6 +10146,7 @@ class TableApi:
             delimiter=delimiter,
             page_token=page_token,
             limit=limit,
+            include_declared=include_declared,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -10156,6 +10181,7 @@ class TableApi:
         delimiter: Annotated[Optional[StrictStr], Field(description="An optional delimiter of the `string identifier`, following the Lance Namespace spec. When not specified, the `$` delimiter must be used. ")] = None,
         page_token: Annotated[Optional[StrictStr], Field(description="Pagination token from a previous request")] = None,
         limit: Annotated[Optional[StrictInt], Field(description="Maximum number of items to return")] = None,
+        include_declared: Annotated[Optional[StrictBool], Field(description="When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned. ")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -10171,7 +10197,7 @@ class TableApi:
     ) -> RESTResponseType:
         """List tables in a namespace
 
-        List all child table names of the parent namespace `id`.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the `ListTablesRequest` information in the following way: - `id`: pass through path parameter of the same name - `page_token`: pass through query parameter of the same name - `limit`: pass through query parameter of the same name 
+        List all child table names of the parent namespace `id`.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the `ListTablesRequest` information in the following way: - `id`: pass through path parameter of the same name - `page_token`: pass through query parameter of the same name - `limit`: pass through query parameter of the same name - `include_declared`: pass through query parameter of the same name 
 
         :param id: `string identifier` of an object in a namespace, following the Lance Namespace spec. When the value is equal to the delimiter, it represents the root namespace. For example, `v1/namespace/$/list` performs a `ListNamespace` on the root namespace.  (required)
         :type id: str
@@ -10181,6 +10207,8 @@ class TableApi:
         :type page_token: str
         :param limit: Maximum number of items to return
         :type limit: int
+        :param include_declared: When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned. 
+        :type include_declared: bool
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -10208,6 +10236,7 @@ class TableApi:
             delimiter=delimiter,
             page_token=page_token,
             limit=limit,
+            include_declared=include_declared,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -10237,6 +10266,7 @@ class TableApi:
         delimiter,
         page_token,
         limit,
+        include_declared,
         _request_auth,
         _content_type,
         _headers,
@@ -10272,6 +10302,10 @@ class TableApi:
         if limit is not None:
             
             _query_params.append(('limit', limit))
+            
+        if include_declared is not None:
+            
+            _query_params.append(('include_declared', include_declared))
             
         # process the header parameters
         # process the form parameters

--- a/python/lance_namespace_urllib3_client/lance_namespace_urllib3_client/models/list_tables_request.py
+++ b/python/lance_namespace_urllib3_client/lance_namespace_urllib3_client/models/list_tables_request.py
@@ -32,7 +32,7 @@ class ListTablesRequest(BaseModel):
     id: Optional[List[StrictStr]] = None
     page_token: Optional[StrictStr] = Field(default=None, description="An opaque token that allows pagination for list operations (e.g. ListNamespaces).  For an initial request of a list operation, if the implementation cannot return all items in one response, or if there are more items than the page limit specified in the request, the implementation must return a page token in the response, indicating there are more results available.  After the initial request, the value of the page token from each response must be used as the page token value for the next request.  Caller must interpret either `null`, missing value or empty string value of the page token from the implementation's response as the end of the listing results. ")
     limit: Optional[StrictInt] = Field(default=None, description="An inclusive upper bound of the number of results that a caller will receive. ")
-    include_declared: Optional[StrictBool] = Field(default=None, description="When true, includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false or not set, only tables with storage components are returned. ")
+    include_declared: Optional[StrictBool] = Field(default=True, description="When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned. ")
     __properties: ClassVar[List[str]] = ["identity", "context", "id", "page_token", "limit", "include_declared"]
 
     model_config = ConfigDict(
@@ -94,7 +94,7 @@ class ListTablesRequest(BaseModel):
             "id": obj.get("id"),
             "page_token": obj.get("page_token"),
             "limit": obj.get("limit"),
-            "include_declared": obj.get("include_declared")
+            "include_declared": obj.get("include_declared") if obj.get("include_declared") is not None else True
         })
         return _obj
 

--- a/rust/lance-namespace-reqwest-client/docs/ListTablesRequest.md
+++ b/rust/lance-namespace-reqwest-client/docs/ListTablesRequest.md
@@ -9,7 +9,7 @@ Name | Type | Description | Notes
 **id** | Option<**Vec<String>**> |  | [optional]
 **page_token** | Option<**String**> | An opaque token that allows pagination for list operations (e.g. ListNamespaces).  For an initial request of a list operation, if the implementation cannot return all items in one response, or if there are more items than the page limit specified in the request, the implementation must return a page token in the response, indicating there are more results available.  After the initial request, the value of the page token from each response must be used as the page token value for the next request.  Caller must interpret either `null`, missing value or empty string value of the page token from the implementation's response as the end of the listing results.  | [optional]
 **limit** | Option<**i32**> | An inclusive upper bound of the number of results that a caller will receive.  | [optional]
-**include_declared** | Option<**bool**> | When true, includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false or not set, only tables with storage components are returned.  | [optional]
+**include_declared** | Option<**bool**> | When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned.  | [optional][default to true]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/rust/lance-namespace-reqwest-client/docs/MetadataApi.md
+++ b/rust/lance-namespace-reqwest-client/docs/MetadataApi.md
@@ -945,10 +945,10 @@ Name | Type | Description  | Required | Notes
 
 ## list_tables
 
-> models::ListTablesResponse list_tables(id, delimiter, page_token, limit)
+> models::ListTablesResponse list_tables(id, delimiter, page_token, limit, include_declared)
 List tables in a namespace
 
-List all child table names of the parent namespace `id`.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the `ListTablesRequest` information in the following way: - `id`: pass through path parameter of the same name - `page_token`: pass through query parameter of the same name - `limit`: pass through query parameter of the same name 
+List all child table names of the parent namespace `id`.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the `ListTablesRequest` information in the following way: - `id`: pass through path parameter of the same name - `page_token`: pass through query parameter of the same name - `limit`: pass through query parameter of the same name - `include_declared`: pass through query parameter of the same name 
 
 ### Parameters
 
@@ -959,6 +959,7 @@ Name | Type | Description  | Required | Notes
 **delimiter** | Option<**String**> | An optional delimiter of the `string identifier`, following the Lance Namespace spec. When not specified, the `$` delimiter must be used.  |  |
 **page_token** | Option<**String**> | Pagination token from a previous request |  |
 **limit** | Option<**i32**> | Maximum number of items to return |  |
+**include_declared** | Option<**bool**> | When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned.  |  |[default to true]
 
 ### Return type
 

--- a/rust/lance-namespace-reqwest-client/docs/NamespaceApi.md
+++ b/rust/lance-namespace-reqwest-client/docs/NamespaceApi.md
@@ -144,10 +144,10 @@ Name | Type | Description  | Required | Notes
 
 ## list_tables
 
-> models::ListTablesResponse list_tables(id, delimiter, page_token, limit)
+> models::ListTablesResponse list_tables(id, delimiter, page_token, limit, include_declared)
 List tables in a namespace
 
-List all child table names of the parent namespace `id`.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the `ListTablesRequest` information in the following way: - `id`: pass through path parameter of the same name - `page_token`: pass through query parameter of the same name - `limit`: pass through query parameter of the same name 
+List all child table names of the parent namespace `id`.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the `ListTablesRequest` information in the following way: - `id`: pass through path parameter of the same name - `page_token`: pass through query parameter of the same name - `limit`: pass through query parameter of the same name - `include_declared`: pass through query parameter of the same name 
 
 ### Parameters
 
@@ -158,6 +158,7 @@ Name | Type | Description  | Required | Notes
 **delimiter** | Option<**String**> | An optional delimiter of the `string identifier`, following the Lance Namespace spec. When not specified, the `$` delimiter must be used.  |  |
 **page_token** | Option<**String**> | Pagination token from a previous request |  |
 **limit** | Option<**i32**> | Maximum number of items to return |  |
+**include_declared** | Option<**bool**> | When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned.  |  |[default to true]
 
 ### Return type
 

--- a/rust/lance-namespace-reqwest-client/docs/TableApi.md
+++ b/rust/lance-namespace-reqwest-client/docs/TableApi.md
@@ -885,10 +885,10 @@ Name | Type | Description  | Required | Notes
 
 ## list_all_tables
 
-> models::ListTablesResponse list_all_tables(delimiter, page_token, limit)
+> models::ListTablesResponse list_all_tables(delimiter, page_token, limit, include_declared)
 List all tables
 
-List all tables across all namespaces.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the `ListAllTablesRequest` information in the following way: - `page_token`: pass through query parameter of the same name - `limit`: pass through query parameter of the same name - `delimiter`: pass through query parameter of the same name 
+List all tables across all namespaces.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the `ListAllTablesRequest` information in the following way: - `page_token`: pass through query parameter of the same name - `limit`: pass through query parameter of the same name - `delimiter`: pass through query parameter of the same name - `include_declared`: pass through query parameter of the same name 
 
 ### Parameters
 
@@ -898,6 +898,7 @@ Name | Type | Description  | Required | Notes
 **delimiter** | Option<**String**> | An optional delimiter of the `string identifier`, following the Lance Namespace spec. When not specified, the `$` delimiter must be used.  |  |
 **page_token** | Option<**String**> | Pagination token from a previous request |  |
 **limit** | Option<**i32**> | Maximum number of items to return |  |
+**include_declared** | Option<**bool**> | When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned.  |  |[default to true]
 
 ### Return type
 
@@ -1016,10 +1017,10 @@ Name | Type | Description  | Required | Notes
 
 ## list_tables
 
-> models::ListTablesResponse list_tables(id, delimiter, page_token, limit)
+> models::ListTablesResponse list_tables(id, delimiter, page_token, limit, include_declared)
 List tables in a namespace
 
-List all child table names of the parent namespace `id`.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the `ListTablesRequest` information in the following way: - `id`: pass through path parameter of the same name - `page_token`: pass through query parameter of the same name - `limit`: pass through query parameter of the same name 
+List all child table names of the parent namespace `id`.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the `ListTablesRequest` information in the following way: - `id`: pass through path parameter of the same name - `page_token`: pass through query parameter of the same name - `limit`: pass through query parameter of the same name - `include_declared`: pass through query parameter of the same name 
 
 ### Parameters
 
@@ -1030,6 +1031,7 @@ Name | Type | Description  | Required | Notes
 **delimiter** | Option<**String**> | An optional delimiter of the `string identifier`, following the Lance Namespace spec. When not specified, the `$` delimiter must be used.  |  |
 **page_token** | Option<**String**> | Pagination token from a previous request |  |
 **limit** | Option<**i32**> | Maximum number of items to return |  |
+**include_declared** | Option<**bool**> | When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned.  |  |[default to true]
 
 ### Return type
 

--- a/rust/lance-namespace-reqwest-client/src/apis/metadata_api.rs
+++ b/rust/lance-namespace-reqwest-client/src/apis/metadata_api.rs
@@ -2120,13 +2120,14 @@ pub async fn list_table_versions(configuration: &configuration::Configuration, i
     }
 }
 
-/// List all child table names of the parent namespace `id`.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the `ListTablesRequest` information in the following way: - `id`: pass through path parameter of the same name - `page_token`: pass through query parameter of the same name - `limit`: pass through query parameter of the same name 
-pub async fn list_tables(configuration: &configuration::Configuration, id: &str, delimiter: Option<&str>, page_token: Option<&str>, limit: Option<i32>) -> Result<models::ListTablesResponse, Error<ListTablesError>> {
+/// List all child table names of the parent namespace `id`.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the `ListTablesRequest` information in the following way: - `id`: pass through path parameter of the same name - `page_token`: pass through query parameter of the same name - `limit`: pass through query parameter of the same name - `include_declared`: pass through query parameter of the same name 
+pub async fn list_tables(configuration: &configuration::Configuration, id: &str, delimiter: Option<&str>, page_token: Option<&str>, limit: Option<i32>, include_declared: Option<bool>) -> Result<models::ListTablesResponse, Error<ListTablesError>> {
     // add a prefix to parameters to efficiently prevent name collisions
     let p_id = id;
     let p_delimiter = delimiter;
     let p_page_token = page_token;
     let p_limit = limit;
+    let p_include_declared = include_declared;
 
     let uri_str = format!("{}/v1/namespace/{id}/table/list", configuration.base_path, id=crate::apis::urlencode(p_id));
     let mut req_builder = configuration.client.request(reqwest::Method::GET, &uri_str);
@@ -2139,6 +2140,9 @@ pub async fn list_tables(configuration: &configuration::Configuration, id: &str,
     }
     if let Some(ref param_value) = p_limit {
         req_builder = req_builder.query(&[("limit", &param_value.to_string())]);
+    }
+    if let Some(ref param_value) = p_include_declared {
+        req_builder = req_builder.query(&[("include_declared", &param_value.to_string())]);
     }
     if let Some(ref user_agent) = configuration.user_agent {
         req_builder = req_builder.header(reqwest::header::USER_AGENT, user_agent.clone());

--- a/rust/lance-namespace-reqwest-client/src/apis/namespace_api.rs
+++ b/rust/lance-namespace-reqwest-client/src/apis/namespace_api.rs
@@ -333,13 +333,14 @@ pub async fn list_namespaces(configuration: &configuration::Configuration, id: &
     }
 }
 
-/// List all child table names of the parent namespace `id`.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the `ListTablesRequest` information in the following way: - `id`: pass through path parameter of the same name - `page_token`: pass through query parameter of the same name - `limit`: pass through query parameter of the same name 
-pub async fn list_tables(configuration: &configuration::Configuration, id: &str, delimiter: Option<&str>, page_token: Option<&str>, limit: Option<i32>) -> Result<models::ListTablesResponse, Error<ListTablesError>> {
+/// List all child table names of the parent namespace `id`.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the `ListTablesRequest` information in the following way: - `id`: pass through path parameter of the same name - `page_token`: pass through query parameter of the same name - `limit`: pass through query parameter of the same name - `include_declared`: pass through query parameter of the same name 
+pub async fn list_tables(configuration: &configuration::Configuration, id: &str, delimiter: Option<&str>, page_token: Option<&str>, limit: Option<i32>, include_declared: Option<bool>) -> Result<models::ListTablesResponse, Error<ListTablesError>> {
     // add a prefix to parameters to efficiently prevent name collisions
     let p_id = id;
     let p_delimiter = delimiter;
     let p_page_token = page_token;
     let p_limit = limit;
+    let p_include_declared = include_declared;
 
     let uri_str = format!("{}/v1/namespace/{id}/table/list", configuration.base_path, id=crate::apis::urlencode(p_id));
     let mut req_builder = configuration.client.request(reqwest::Method::GET, &uri_str);
@@ -352,6 +353,9 @@ pub async fn list_tables(configuration: &configuration::Configuration, id: &str,
     }
     if let Some(ref param_value) = p_limit {
         req_builder = req_builder.query(&[("limit", &param_value.to_string())]);
+    }
+    if let Some(ref param_value) = p_include_declared {
+        req_builder = req_builder.query(&[("include_declared", &param_value.to_string())]);
     }
     if let Some(ref user_agent) = configuration.user_agent {
         req_builder = req_builder.header(reqwest::header::USER_AGENT, user_agent.clone());

--- a/rust/lance-namespace-reqwest-client/src/apis/table_api.rs
+++ b/rust/lance-namespace-reqwest-client/src/apis/table_api.rs
@@ -2047,12 +2047,13 @@ pub async fn insert_into_table(configuration: &configuration::Configuration, id:
     }
 }
 
-/// List all tables across all namespaces.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the `ListAllTablesRequest` information in the following way: - `page_token`: pass through query parameter of the same name - `limit`: pass through query parameter of the same name - `delimiter`: pass through query parameter of the same name 
-pub async fn list_all_tables(configuration: &configuration::Configuration, delimiter: Option<&str>, page_token: Option<&str>, limit: Option<i32>) -> Result<models::ListTablesResponse, Error<ListAllTablesError>> {
+/// List all tables across all namespaces.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the `ListAllTablesRequest` information in the following way: - `page_token`: pass through query parameter of the same name - `limit`: pass through query parameter of the same name - `delimiter`: pass through query parameter of the same name - `include_declared`: pass through query parameter of the same name 
+pub async fn list_all_tables(configuration: &configuration::Configuration, delimiter: Option<&str>, page_token: Option<&str>, limit: Option<i32>, include_declared: Option<bool>) -> Result<models::ListTablesResponse, Error<ListAllTablesError>> {
     // add a prefix to parameters to efficiently prevent name collisions
     let p_delimiter = delimiter;
     let p_page_token = page_token;
     let p_limit = limit;
+    let p_include_declared = include_declared;
 
     let uri_str = format!("{}/v1/table", configuration.base_path);
     let mut req_builder = configuration.client.request(reqwest::Method::GET, &uri_str);
@@ -2065,6 +2066,9 @@ pub async fn list_all_tables(configuration: &configuration::Configuration, delim
     }
     if let Some(ref param_value) = p_limit {
         req_builder = req_builder.query(&[("limit", &param_value.to_string())]);
+    }
+    if let Some(ref param_value) = p_include_declared {
+        req_builder = req_builder.query(&[("include_declared", &param_value.to_string())]);
     }
     if let Some(ref user_agent) = configuration.user_agent {
         req_builder = req_builder.header(reqwest::header::USER_AGENT, user_agent.clone());
@@ -2296,13 +2300,14 @@ pub async fn list_table_versions(configuration: &configuration::Configuration, i
     }
 }
 
-/// List all child table names of the parent namespace `id`.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the `ListTablesRequest` information in the following way: - `id`: pass through path parameter of the same name - `page_token`: pass through query parameter of the same name - `limit`: pass through query parameter of the same name 
-pub async fn list_tables(configuration: &configuration::Configuration, id: &str, delimiter: Option<&str>, page_token: Option<&str>, limit: Option<i32>) -> Result<models::ListTablesResponse, Error<ListTablesError>> {
+/// List all child table names of the parent namespace `id`.  REST NAMESPACE ONLY REST namespace uses GET to perform this operation without a request body. It passes in the `ListTablesRequest` information in the following way: - `id`: pass through path parameter of the same name - `page_token`: pass through query parameter of the same name - `limit`: pass through query parameter of the same name - `include_declared`: pass through query parameter of the same name 
+pub async fn list_tables(configuration: &configuration::Configuration, id: &str, delimiter: Option<&str>, page_token: Option<&str>, limit: Option<i32>, include_declared: Option<bool>) -> Result<models::ListTablesResponse, Error<ListTablesError>> {
     // add a prefix to parameters to efficiently prevent name collisions
     let p_id = id;
     let p_delimiter = delimiter;
     let p_page_token = page_token;
     let p_limit = limit;
+    let p_include_declared = include_declared;
 
     let uri_str = format!("{}/v1/namespace/{id}/table/list", configuration.base_path, id=crate::apis::urlencode(p_id));
     let mut req_builder = configuration.client.request(reqwest::Method::GET, &uri_str);
@@ -2315,6 +2320,9 @@ pub async fn list_tables(configuration: &configuration::Configuration, id: &str,
     }
     if let Some(ref param_value) = p_limit {
         req_builder = req_builder.query(&[("limit", &param_value.to_string())]);
+    }
+    if let Some(ref param_value) = p_include_declared {
+        req_builder = req_builder.query(&[("include_declared", &param_value.to_string())]);
     }
     if let Some(ref user_agent) = configuration.user_agent {
         req_builder = req_builder.header(reqwest::header::USER_AGENT, user_agent.clone());

--- a/rust/lance-namespace-reqwest-client/src/models/list_tables_request.rs
+++ b/rust/lance-namespace-reqwest-client/src/models/list_tables_request.rs
@@ -26,7 +26,7 @@ pub struct ListTablesRequest {
     /// An inclusive upper bound of the number of results that a caller will receive. 
     #[serde(rename = "limit", skip_serializing_if = "Option::is_none")]
     pub limit: Option<i32>,
-    /// When true, includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false or not set, only tables with storage components are returned. 
+    /// When true (default), includes tables that have been declared in the namespace but not yet created on storage, in addition to tables that have been created. When false, only tables with storage components are returned. 
     #[serde(rename = "include_declared", skip_serializing_if = "Option::is_none")]
     pub include_declared: Option<bool>,
 }


### PR DESCRIPTION
## Summary

- Default `include_declared` to `true` in `ListTablesRequest` schema and REST query parameter for backwards compatibility
- Add `include_declared` query parameter to both `ListTables` and `ListAllTables` REST endpoints