### PR TITLE
fix: restore CreateEmptyTable deprecated shims for backwards compatibility

### DIFF
--- a/python/lance_namespace/lance_namespace/__init__.py
+++ b/python/lance_namespace/lance_namespace/__init__.py
@@ -25,6 +25,7 @@ and plugin registration mechanism.
 """
 
 import importlib
+import warnings
 from abc import ABC, abstractmethod
 from typing import Dict
 
@@ -148,6 +149,14 @@ from lance_namespace_urllib3_client.models import (
     UpdateTableTagResponse,
 )
 
+# Backwards-compat shims for symbols removed in 0.7.0.
+# Released pylance wheels (e.g. 2.0.1, 4.0.0b1) do:
+#   from lance_namespace import CreateEmptyTableRequest, CreateEmptyTableResponse
+# Provide deprecated aliases so those imports don't break.
+# These will be removed in a future release.
+CreateEmptyTableRequest = CreateTableRequest
+CreateEmptyTableResponse = CreateTableResponse
+
 __all__ = [
     # Interface and factory
     "LanceNamespace",
@@ -201,6 +210,9 @@ __all__ = [
     "CommitTableResult",
     "CountTableRowsRequest",
     "CreateTableVersionEntry",
+    # Deprecated aliases (removed in 0.7.0, kept for backwards compatibility)
+    "CreateEmptyTableRequest",
+    "CreateEmptyTableResponse",
     "CreateNamespaceRequest",
     "CreateNamespaceResponse",
     "CreateTableIndexRequest",
@@ -500,6 +512,30 @@ class LanceNamespace(ABC):
             If a concurrent modification conflict occurs.
         """
         raise UnsupportedOperationError("Not supported: declare_table")
+
+    def create_empty_table(
+        self, request: "CreateEmptyTableRequest"
+    ) -> "CreateEmptyTableResponse":
+        """Create an empty table (metadata only operation).
+
+        .. deprecated::
+            Use :meth:`declare_table` instead.
+
+        Raises
+        ------
+        NamespaceNotFoundError
+            If the namespace does not exist.
+        TableAlreadyExistsError
+            If a table with the same name already exists.
+        ConcurrentModificationError
+            If a concurrent modification conflict occurs.
+        """
+        warnings.warn(
+            "create_empty_table is deprecated, use declare_table instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        raise UnsupportedOperationError("Not supported: create_empty_table")
 
     def insert_into_table(
         self, request: InsertIntoTableRequest, request_data: bytes


### PR DESCRIPTION
## Summary

Restore `CreateEmptyTableRequest` / `CreateEmptyTableResponse` as deprecated aliases and restore the `create_empty_table()` method with a `DeprecationWarning`, to unbreak previously-released pylance wheels.

## Problem

v0.7.0 (#330) removed these symbols entirely. Released pylance wheels (`2.0.1`, `4.0.0b1`, etc.) do:

```python
from lance_namespace import CreateEmptyTableRequest, CreateEmptyTableResponse, ...
```

With `lance-namespace>=0.7.0` installed, `import lance` fails with `ImportError`.

Downstream workarounds:
- https://github.com/lance-format/lance/pull/6597 — CI compat test pin
- https://github.com/lance-format/lance/pull/6604 — `pyproject.toml` upper bound pin

## Fix

Three minimal changes to `python/lance_namespace/lance_namespace/__init__.py`:

1. **Deprecated aliases** — `CreateEmptyTableRequest = CreateTableRequest` / `CreateEmptyTableResponse = CreateTableResponse` with a comment explaining they will be removed in a future release
2. **`__all__` updated** — re-export both symbols
3. **`create_empty_table()` method restored** — with `DeprecationWarning` directing users to `declare_table()` instead

This matches the deprecation approach already used in v0.6.1 and gives downstreams a migration window before final removal.

## Test plan

- [ ] `from lance_namespace import CreateEmptyTableRequest, CreateEmptyTableResponse` succeeds
- [ ] Old pylance wheels (`pip install pylance==2.0.1`) can `import lance` without error
- [ ] Existing tests remain green

Closes #331