### PR TITLE
fix(rest): add id field to request schemas for client-side access

### DIFF
--- a/docs/src/client/operations/models/AlterTableAddColumnsRequest.md
+++ b/docs/src/client/operations/models/AlterTableAddColumnsRequest.md
@@ -7,6 +7,7 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
+|**id** | **List&lt;String&gt;** | Table identifier path (namespace + table name) |  [optional] |
 |**newColumns** | [**List&lt;AddColumnsEntry&gt;**](AddColumnsEntry.md) | List of new columns to add to the table |  |
 
 

--- a/docs/src/client/operations/models/AlterTableAlterColumnsRequest.md
+++ b/docs/src/client/operations/models/AlterTableAlterColumnsRequest.md
@@ -7,6 +7,7 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
+|**id** | **List&lt;String&gt;** | Table identifier path (namespace + table name) |  [optional] |
 |**alterations** | [**List&lt;AlterColumnsEntry&gt;**](AlterColumnsEntry.md) | List of column alterations to apply to the table |  |
 
 

--- a/docs/src/client/operations/models/AlterTableBackfillColumnsRequest.md
+++ b/docs/src/client/operations/models/AlterTableBackfillColumnsRequest.md
@@ -7,6 +7,7 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
+|**id** | **List&lt;String&gt;** | Table identifier path (namespace + table name) |  [optional] |
 |**column** | **String** | Column name to backfill |  |
 |**where** | **String** | Optional WHERE clause filter |  [optional] |
 |**concurrency** | **Integer** | Optional concurrency override |  [optional] |

--- a/docs/src/client/operations/models/RefreshMaterializedViewRequest.md
+++ b/docs/src/client/operations/models/RefreshMaterializedViewRequest.md
@@ -7,6 +7,7 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
+|**id** | **List&lt;String&gt;** | Table identifier path (namespace + table name) |  [optional] |
 |**srcVersion** | **Integer** | Optional source version to refresh from |  [optional] |
 |**maxRowsPerFragment** | **Integer** | Optional maximum rows per fragment |  [optional] |
 |**concurrency** | **Integer** | Optional concurrency override |  [optional] |

--- a/docs/src/rest.yaml
+++ b/docs/src/rest.yaml
@@ -4557,6 +4557,11 @@ components:
       required:
         - new_columns
       properties:
+        id:
+          type: array
+          items:
+            type: string
+          description: Table identifier path (namespace + table name)
         new_columns:
           type: array
           items:
@@ -4629,6 +4634,11 @@ components:
       required:
         - alterations
       properties:
+        id:
+          type: array
+          items:
+            type: string
+          description: Table identifier path (namespace + table name)
         alterations:
           type: array
           items:
@@ -4710,6 +4720,11 @@ components:
       required:
         - column
       properties:
+        id:
+          type: array
+          items:
+            type: string
+          description: Table identifier path (namespace + table name)
         column:
           type: string
           description: Column name to backfill
@@ -4791,6 +4806,11 @@ components:
     RefreshMaterializedViewRequest:
       type: object
       properties:
+        id:
+          type: array
+          items:
+            type: string
+          description: Table identifier path (namespace + table name)
         src_version:
           type:
             - integer

--- a/java/lance-namespace-apache-client/api/openapi.yaml
+++ b/java/lance-namespace-apache-client/api/openapi.yaml
@@ -7027,7 +7027,15 @@ components:
             - input_columns
             data_type: "{}"
             udf_version: udf_version
+        id:
+        - id
+        - id
       properties:
+        id:
+          description: Table identifier path (namespace + table name)
+          items:
+            type: string
+          type: array
         new_columns:
           description: List of new columns to add to the table
           items:
@@ -7137,7 +7145,15 @@ components:
             - input_columns
             - input_columns
             udf_version: udf_version
+        id:
+        - id
+        - id
       properties:
+        id:
+          description: Table identifier path (namespace + table name)
+          items:
+            type: string
+          type: array
         alterations:
           description: List of column alterations to apply to the table
           items:
@@ -7237,8 +7253,16 @@ components:
         task_size: 7
         batch_checkpoint_flush_interval_seconds: 5.637376656633329
         where: where
+        id:
+        - id
+        - id
         intra_applier_concurrency: 6
       properties:
+        id:
+          description: Table identifier path (namespace + table name)
+          items:
+            type: string
+          type: array
         column:
           description: Column name to backfill
           type: string
@@ -7310,10 +7334,18 @@ components:
         src_version: 0
         cluster: cluster
         manifest: manifest
+        id:
+        - id
+        - id
         max_rows_per_fragment: 6
         intra_applier_concurrency: 5
         concurrency: 1
       properties:
+        id:
+          description: Table identifier path (namespace + table name)
+          items:
+            type: string
+          type: array
         src_version:
           description: Optional source version to refresh from
           nullable: true

--- a/java/lance-namespace-apache-client/docs/AlterTableAddColumnsRequest.md
+++ b/java/lance-namespace-apache-client/docs/AlterTableAddColumnsRequest.md
@@ -7,6 +7,7 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
+|**id** | **List&lt;String&gt;** | Table identifier path (namespace + table name) |  [optional] |
 |**newColumns** | [**List&lt;AddColumnsEntry&gt;**](AddColumnsEntry.md) | List of new columns to add to the table |  |
 
 

--- a/java/lance-namespace-apache-client/docs/AlterTableAlterColumnsRequest.md
+++ b/java/lance-namespace-apache-client/docs/AlterTableAlterColumnsRequest.md
@@ -7,6 +7,7 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
+|**id** | **List&lt;String&gt;** | Table identifier path (namespace + table name) |  [optional] |
 |**alterations** | [**List&lt;AlterColumnsEntry&gt;**](AlterColumnsEntry.md) | List of column alterations to apply to the table |  |
 
 

--- a/java/lance-namespace-apache-client/docs/AlterTableBackfillColumnsRequest.md
+++ b/java/lance-namespace-apache-client/docs/AlterTableBackfillColumnsRequest.md
@@ -7,6 +7,7 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
+|**id** | **List&lt;String&gt;** | Table identifier path (namespace + table name) |  [optional] |
 |**column** | **String** | Column name to backfill |  |
 |**where** | **String** | Optional WHERE clause filter |  [optional] |
 |**concurrency** | **Integer** | Optional concurrency override |  [optional] |

--- a/java/lance-namespace-apache-client/docs/RefreshMaterializedViewRequest.md
+++ b/java/lance-namespace-apache-client/docs/RefreshMaterializedViewRequest.md
@@ -7,6 +7,7 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
+|**id** | **List&lt;String&gt;** | Table identifier path (namespace + table name) |  [optional] |
 |**srcVersion** | **Integer** | Optional source version to refresh from |  [optional] |
 |**maxRowsPerFragment** | **Integer** | Optional maximum rows per fragment |  [optional] |
 |**concurrency** | **Integer** | Optional concurrency override |  [optional] |

--- a/java/lance-namespace-apache-client/src/main/java/org/lance/namespace/model/AlterTableAddColumnsRequest.java
+++ b/java/lance-namespace-apache-client/src/main/java/org/lance/namespace/model/AlterTableAddColumnsRequest.java
@@ -17,21 +17,61 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.StringJoiner;
 
 /** AlterTableAddColumnsRequest */
-@JsonPropertyOrder({AlterTableAddColumnsRequest.JSON_PROPERTY_NEW_COLUMNS})
+@JsonPropertyOrder({
+  AlterTableAddColumnsRequest.JSON_PROPERTY_ID,
+  AlterTableAddColumnsRequest.JSON_PROPERTY_NEW_COLUMNS
+})
 @javax.annotation.Generated(
     value = "org.openapitools.codegen.languages.JavaClientCodegen",
     comments = "Generator version: 7.12.0")
 public class AlterTableAddColumnsRequest {
+  public static final String JSON_PROPERTY_ID = "id";
+  @javax.annotation.Nullable private List<String> id = new ArrayList<>();
+
   public static final String JSON_PROPERTY_NEW_COLUMNS = "new_columns";
   @javax.annotation.Nonnull private List<AddColumnsEntry> newColumns = new ArrayList<>();
 
   public AlterTableAddColumnsRequest() {}
+
+  public AlterTableAddColumnsRequest id(@javax.annotation.Nullable List<String> id) {
+
+    this.id = id;
+    return this;
+  }
+
+  public AlterTableAddColumnsRequest addIdItem(String idItem) {
+    if (this.id == null) {
+      this.id = new ArrayList<>();
+    }
+    this.id.add(idItem);
+    return this;
+  }
+
+  /**
+   * Table identifier path (namespace + table name)
+   *
+   * @return id
+   */
+  @javax.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public List<String> getId() {
+    return id;
+  }
+
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setId(@javax.annotation.Nullable List<String> id) {
+    this.id = id;
+  }
 
   public AlterTableAddColumnsRequest newColumns(
       @javax.annotation.Nonnull List<AddColumnsEntry> newColumns) {
@@ -75,18 +115,20 @@ public class AlterTableAddColumnsRequest {
       return false;
     }
     AlterTableAddColumnsRequest alterTableAddColumnsRequest = (AlterTableAddColumnsRequest) o;
-    return Objects.equals(this.newColumns, alterTableAddColumnsRequest.newColumns);
+    return Objects.equals(this.id, alterTableAddColumnsRequest.id)
+        && Objects.equals(this.newColumns, alterTableAddColumnsRequest.newColumns);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(newColumns);
+    return Objects.hash(id, newColumns);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class AlterTableAddColumnsRequest {\n");
+    sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    newColumns: ").append(toIndentedString(newColumns)).append("\n");
     sb.append("}");
     return sb.toString();
@@ -133,6 +175,27 @@ public class AlterTableAddColumnsRequest {
     }
 
     StringJoiner joiner = new StringJoiner("&");
+
+    // add `id` to the URL query string
+    if (getId() != null) {
+      for (int i = 0; i < getId().size(); i++) {
+        try {
+          joiner.add(
+              String.format(
+                  "%sid%s%s=%s",
+                  prefix,
+                  suffix,
+                  "".equals(suffix)
+                      ? ""
+                      : String.format("%s%d%s", containerPrefix, i, containerSuffix),
+                  URLEncoder.encode(String.valueOf(getId().get(i)), "UTF-8")
+                      .replaceAll("\\+", "%20")));
+        } catch (UnsupportedEncodingException e) {
+          // Should never happen, UTF-8 is always supported
+          throw new RuntimeException(e);
+        }
+      }
+    }
 
     // add `new_columns` to the URL query string
     if (getNewColumns() != null) {

--- a/java/lance-namespace-apache-client/src/main/java/org/lance/namespace/model/AlterTableAlterColumnsRequest.java
+++ b/java/lance-namespace-apache-client/src/main/java/org/lance/namespace/model/AlterTableAlterColumnsRequest.java
@@ -17,21 +17,61 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.StringJoiner;
 
 /** AlterTableAlterColumnsRequest */
-@JsonPropertyOrder({AlterTableAlterColumnsRequest.JSON_PROPERTY_ALTERATIONS})
+@JsonPropertyOrder({
+  AlterTableAlterColumnsRequest.JSON_PROPERTY_ID,
+  AlterTableAlterColumnsRequest.JSON_PROPERTY_ALTERATIONS
+})
 @javax.annotation.Generated(
     value = "org.openapitools.codegen.languages.JavaClientCodegen",
     comments = "Generator version: 7.12.0")
 public class AlterTableAlterColumnsRequest {
+  public static final String JSON_PROPERTY_ID = "id";
+  @javax.annotation.Nullable private List<String> id = new ArrayList<>();
+
   public static final String JSON_PROPERTY_ALTERATIONS = "alterations";
   @javax.annotation.Nonnull private List<AlterColumnsEntry> alterations = new ArrayList<>();
 
   public AlterTableAlterColumnsRequest() {}
+
+  public AlterTableAlterColumnsRequest id(@javax.annotation.Nullable List<String> id) {
+
+    this.id = id;
+    return this;
+  }
+
+  public AlterTableAlterColumnsRequest addIdItem(String idItem) {
+    if (this.id == null) {
+      this.id = new ArrayList<>();
+    }
+    this.id.add(idItem);
+    return this;
+  }
+
+  /**
+   * Table identifier path (namespace + table name)
+   *
+   * @return id
+   */
+  @javax.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public List<String> getId() {
+    return id;
+  }
+
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setId(@javax.annotation.Nullable List<String> id) {
+    this.id = id;
+  }
 
   public AlterTableAlterColumnsRequest alterations(
       @javax.annotation.Nonnull List<AlterColumnsEntry> alterations) {
@@ -75,18 +115,20 @@ public class AlterTableAlterColumnsRequest {
       return false;
     }
     AlterTableAlterColumnsRequest alterTableAlterColumnsRequest = (AlterTableAlterColumnsRequest) o;
-    return Objects.equals(this.alterations, alterTableAlterColumnsRequest.alterations);
+    return Objects.equals(this.id, alterTableAlterColumnsRequest.id)
+        && Objects.equals(this.alterations, alterTableAlterColumnsRequest.alterations);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(alterations);
+    return Objects.hash(id, alterations);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class AlterTableAlterColumnsRequest {\n");
+    sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    alterations: ").append(toIndentedString(alterations)).append("\n");
     sb.append("}");
     return sb.toString();
@@ -133,6 +175,27 @@ public class AlterTableAlterColumnsRequest {
     }
 
     StringJoiner joiner = new StringJoiner("&");
+
+    // add `id` to the URL query string
+    if (getId() != null) {
+      for (int i = 0; i < getId().size(); i++) {
+        try {
+          joiner.add(
+              String.format(
+                  "%sid%s%s=%s",
+                  prefix,
+                  suffix,
+                  "".equals(suffix)
+                      ? ""
+                      : String.format("%s%d%s", containerPrefix, i, containerSuffix),
+                  URLEncoder.encode(String.valueOf(getId().get(i)), "UTF-8")
+                      .replaceAll("\\+", "%20")));
+        } catch (UnsupportedEncodingException e) {
+          // Should never happen, UTF-8 is always supported
+          throw new RuntimeException(e);
+        }
+      }
+    }
 
     // add `alterations` to the URL query string
     if (getAlterations() != null) {

--- a/java/lance-namespace-apache-client/src/main/java/org/lance/namespace/model/AlterTableBackfillColumnsRequest.java
+++ b/java/lance-namespace-apache-client/src/main/java/org/lance/namespace/model/AlterTableBackfillColumnsRequest.java
@@ -22,12 +22,15 @@ import org.openapitools.jackson.nullable.JsonNullable;
 import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
 import java.net.URLEncoder;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 import java.util.StringJoiner;
 
 /** AlterTableBackfillColumnsRequest */
 @JsonPropertyOrder({
+  AlterTableBackfillColumnsRequest.JSON_PROPERTY_ID,
   AlterTableBackfillColumnsRequest.JSON_PROPERTY_COLUMN,
   AlterTableBackfillColumnsRequest.JSON_PROPERTY_WHERE,
   AlterTableBackfillColumnsRequest.JSON_PROPERTY_CONCURRENCY,
@@ -47,6 +50,9 @@ import java.util.StringJoiner;
     value = "org.openapitools.codegen.languages.JavaClientCodegen",
     comments = "Generator version: 7.12.0")
 public class AlterTableBackfillColumnsRequest {
+  public static final String JSON_PROPERTY_ID = "id";
+  @javax.annotation.Nullable private List<String> id = new ArrayList<>();
+
   public static final String JSON_PROPERTY_COLUMN = "column";
   @javax.annotation.Nonnull private String column;
 
@@ -116,6 +122,38 @@ public class AlterTableBackfillColumnsRequest {
   private JsonNullable<String> manifest = JsonNullable.<String>undefined();
 
   public AlterTableBackfillColumnsRequest() {}
+
+  public AlterTableBackfillColumnsRequest id(@javax.annotation.Nullable List<String> id) {
+
+    this.id = id;
+    return this;
+  }
+
+  public AlterTableBackfillColumnsRequest addIdItem(String idItem) {
+    if (this.id == null) {
+      this.id = new ArrayList<>();
+    }
+    this.id.add(idItem);
+    return this;
+  }
+
+  /**
+   * Table identifier path (namespace + table name)
+   *
+   * @return id
+   */
+  @javax.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public List<String> getId() {
+    return id;
+  }
+
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setId(@javax.annotation.Nullable List<String> id) {
+    this.id = id;
+  }
 
   public AlterTableBackfillColumnsRequest column(@javax.annotation.Nonnull String column) {
 
@@ -581,7 +619,8 @@ public class AlterTableBackfillColumnsRequest {
     }
     AlterTableBackfillColumnsRequest alterTableBackfillColumnsRequest =
         (AlterTableBackfillColumnsRequest) o;
-    return Objects.equals(this.column, alterTableBackfillColumnsRequest.column)
+    return Objects.equals(this.id, alterTableBackfillColumnsRequest.id)
+        && Objects.equals(this.column, alterTableBackfillColumnsRequest.column)
         && equalsNullable(this.where, alterTableBackfillColumnsRequest.where)
         && equalsNullable(this.concurrency, alterTableBackfillColumnsRequest.concurrency)
         && equalsNullable(
@@ -615,6 +654,7 @@ public class AlterTableBackfillColumnsRequest {
   @Override
   public int hashCode() {
     return Objects.hash(
+        id,
         column,
         hashCodeNullable(where),
         hashCodeNullable(concurrency),
@@ -642,6 +682,7 @@ public class AlterTableBackfillColumnsRequest {
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class AlterTableBackfillColumnsRequest {\n");
+    sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    column: ").append(toIndentedString(column)).append("\n");
     sb.append("    where: ").append(toIndentedString(where)).append("\n");
     sb.append("    concurrency: ").append(toIndentedString(concurrency)).append("\n");
@@ -705,6 +746,27 @@ public class AlterTableBackfillColumnsRequest {
     }
 
     StringJoiner joiner = new StringJoiner("&");
+
+    // add `id` to the URL query string
+    if (getId() != null) {
+      for (int i = 0; i < getId().size(); i++) {
+        try {
+          joiner.add(
+              String.format(
+                  "%sid%s%s=%s",
+                  prefix,
+                  suffix,
+                  "".equals(suffix)
+                      ? ""
+                      : String.format("%s%d%s", containerPrefix, i, containerSuffix),
+                  URLEncoder.encode(String.valueOf(getId().get(i)), "UTF-8")
+                      .replaceAll("\\+", "%20")));
+        } catch (UnsupportedEncodingException e) {
+          // Should never happen, UTF-8 is always supported
+          throw new RuntimeException(e);
+        }
+      }
+    }
 
     // add `column` to the URL query string
     if (getColumn() != null) {

--- a/java/lance-namespace-apache-client/src/main/java/org/lance/namespace/model/RefreshMaterializedViewRequest.java
+++ b/java/lance-namespace-apache-client/src/main/java/org/lance/namespace/model/RefreshMaterializedViewRequest.java
@@ -21,12 +21,15 @@ import org.openapitools.jackson.nullable.JsonNullable;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 import java.util.StringJoiner;
 
 /** RefreshMaterializedViewRequest */
 @JsonPropertyOrder({
+  RefreshMaterializedViewRequest.JSON_PROPERTY_ID,
   RefreshMaterializedViewRequest.JSON_PROPERTY_SRC_VERSION,
   RefreshMaterializedViewRequest.JSON_PROPERTY_MAX_ROWS_PER_FRAGMENT,
   RefreshMaterializedViewRequest.JSON_PROPERTY_CONCURRENCY,
@@ -38,6 +41,9 @@ import java.util.StringJoiner;
     value = "org.openapitools.codegen.languages.JavaClientCodegen",
     comments = "Generator version: 7.12.0")
 public class RefreshMaterializedViewRequest {
+  public static final String JSON_PROPERTY_ID = "id";
+  @javax.annotation.Nullable private List<String> id = new ArrayList<>();
+
   public static final String JSON_PROPERTY_SRC_VERSION = "src_version";
 
   @javax.annotation.Nullable
@@ -69,6 +75,38 @@ public class RefreshMaterializedViewRequest {
   private JsonNullable<String> manifest = JsonNullable.<String>undefined();
 
   public RefreshMaterializedViewRequest() {}
+
+  public RefreshMaterializedViewRequest id(@javax.annotation.Nullable List<String> id) {
+
+    this.id = id;
+    return this;
+  }
+
+  public RefreshMaterializedViewRequest addIdItem(String idItem) {
+    if (this.id == null) {
+      this.id = new ArrayList<>();
+    }
+    this.id.add(idItem);
+    return this;
+  }
+
+  /**
+   * Table identifier path (namespace + table name)
+   *
+   * @return id
+   */
+  @javax.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public List<String> getId() {
+    return id;
+  }
+
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setId(@javax.annotation.Nullable List<String> id) {
+    this.id = id;
+  }
 
   public RefreshMaterializedViewRequest srcVersion(@javax.annotation.Nullable Integer srcVersion) {
     this.srcVersion = JsonNullable.<Integer>of(srcVersion);
@@ -277,7 +315,8 @@ public class RefreshMaterializedViewRequest {
     }
     RefreshMaterializedViewRequest refreshMaterializedViewRequest =
         (RefreshMaterializedViewRequest) o;
-    return equalsNullable(this.srcVersion, refreshMaterializedViewRequest.srcVersion)
+    return Objects.equals(this.id, refreshMaterializedViewRequest.id)
+        && equalsNullable(this.srcVersion, refreshMaterializedViewRequest.srcVersion)
         && equalsNullable(
             this.maxRowsPerFragment, refreshMaterializedViewRequest.maxRowsPerFragment)
         && equalsNullable(this.concurrency, refreshMaterializedViewRequest.concurrency)
@@ -299,6 +338,7 @@ public class RefreshMaterializedViewRequest {
   @Override
   public int hashCode() {
     return Objects.hash(
+        id,
         hashCodeNullable(srcVersion),
         hashCodeNullable(maxRowsPerFragment),
         hashCodeNullable(concurrency),
@@ -318,6 +358,7 @@ public class RefreshMaterializedViewRequest {
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class RefreshMaterializedViewRequest {\n");
+    sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    srcVersion: ").append(toIndentedString(srcVersion)).append("\n");
     sb.append("    maxRowsPerFragment: ").append(toIndentedString(maxRowsPerFragment)).append("\n");
     sb.append("    concurrency: ").append(toIndentedString(concurrency)).append("\n");
@@ -371,6 +412,27 @@ public class RefreshMaterializedViewRequest {
     }
 
     StringJoiner joiner = new StringJoiner("&");
+
+    // add `id` to the URL query string
+    if (getId() != null) {
+      for (int i = 0; i < getId().size(); i++) {
+        try {
+          joiner.add(
+              String.format(
+                  "%sid%s%s=%s",
+                  prefix,
+                  suffix,
+                  "".equals(suffix)
+                      ? ""
+                      : String.format("%s%d%s", containerPrefix, i, containerSuffix),
+                  URLEncoder.encode(String.valueOf(getId().get(i)), "UTF-8")
+                      .replaceAll("\\+", "%20")));
+        } catch (UnsupportedEncodingException e) {
+          // Should never happen, UTF-8 is always supported
+          throw new RuntimeException(e);
+        }
+      }
+    }
 
     // add `src_version` to the URL query string
     if (getSrcVersion() != null) {

--- a/java/lance-namespace-async-client/api/openapi.yaml
+++ b/java/lance-namespace-async-client/api/openapi.yaml
@@ -7027,7 +7027,15 @@ components:
             - input_columns
             data_type: "{}"
             udf_version: udf_version
+        id:
+        - id
+        - id
       properties:
+        id:
+          description: Table identifier path (namespace + table name)
+          items:
+            type: string
+          type: array
         new_columns:
           description: List of new columns to add to the table
           items:
@@ -7137,7 +7145,15 @@ components:
             - input_columns
             - input_columns
             udf_version: udf_version
+        id:
+        - id
+        - id
       properties:
+        id:
+          description: Table identifier path (namespace + table name)
+          items:
+            type: string
+          type: array
         alterations:
           description: List of column alterations to apply to the table
           items:
@@ -7237,8 +7253,16 @@ components:
         task_size: 7
         batch_checkpoint_flush_interval_seconds: 5.637376656633329
         where: where
+        id:
+        - id
+        - id
         intra_applier_concurrency: 6
       properties:
+        id:
+          description: Table identifier path (namespace + table name)
+          items:
+            type: string
+          type: array
         column:
           description: Column name to backfill
           type: string
@@ -7310,10 +7334,18 @@ components:
         src_version: 0
         cluster: cluster
         manifest: manifest
+        id:
+        - id
+        - id
         max_rows_per_fragment: 6
         intra_applier_concurrency: 5
         concurrency: 1
       properties:
+        id:
+          description: Table identifier path (namespace + table name)
+          items:
+            type: string
+          type: array
         src_version:
           description: Optional source version to refresh from
           nullable: true

--- a/java/lance-namespace-async-client/docs/AlterTableAddColumnsRequest.md
+++ b/java/lance-namespace-async-client/docs/AlterTableAddColumnsRequest.md
@@ -7,6 +7,7 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
+|**id** | **List&lt;String&gt;** | Table identifier path (namespace + table name) |  [optional] |
 |**newColumns** | [**List&lt;AddColumnsEntry&gt;**](AddColumnsEntry.md) | List of new columns to add to the table |  |
 
 

--- a/java/lance-namespace-async-client/docs/AlterTableAlterColumnsRequest.md
+++ b/java/lance-namespace-async-client/docs/AlterTableAlterColumnsRequest.md
@@ -7,6 +7,7 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
+|**id** | **List&lt;String&gt;** | Table identifier path (namespace + table name) |  [optional] |
 |**alterations** | [**List&lt;AlterColumnsEntry&gt;**](AlterColumnsEntry.md) | List of column alterations to apply to the table |  |
 
 

--- a/java/lance-namespace-async-client/docs/AlterTableBackfillColumnsRequest.md
+++ b/java/lance-namespace-async-client/docs/AlterTableBackfillColumnsRequest.md
@@ -7,6 +7,7 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
+|**id** | **List&lt;String&gt;** | Table identifier path (namespace + table name) |  [optional] |
 |**column** | **String** | Column name to backfill |  |
 |**where** | **String** | Optional WHERE clause filter |  [optional] |
 |**concurrency** | **Integer** | Optional concurrency override |  [optional] |

--- a/java/lance-namespace-async-client/docs/RefreshMaterializedViewRequest.md
+++ b/java/lance-namespace-async-client/docs/RefreshMaterializedViewRequest.md
@@ -7,6 +7,7 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
+|**id** | **List&lt;String&gt;** | Table identifier path (namespace + table name) |  [optional] |
 |**srcVersion** | **Integer** | Optional source version to refresh from |  [optional] |
 |**maxRowsPerFragment** | **Integer** | Optional maximum rows per fragment |  [optional] |
 |**concurrency** | **Integer** | Optional concurrency override |  [optional] |

--- a/java/lance-namespace-async-client/src/main/java/org/lance/namespace/model/AlterTableAddColumnsRequest.java
+++ b/java/lance-namespace-async-client/src/main/java/org/lance/namespace/model/AlterTableAddColumnsRequest.java
@@ -13,6 +13,8 @@
  */
 package org.lance.namespace.model;
 
+import org.lance.namespace.client.async.ApiClient;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
@@ -23,15 +25,52 @@ import java.util.Objects;
 import java.util.StringJoiner;
 
 /** AlterTableAddColumnsRequest */
-@JsonPropertyOrder({AlterTableAddColumnsRequest.JSON_PROPERTY_NEW_COLUMNS})
+@JsonPropertyOrder({
+  AlterTableAddColumnsRequest.JSON_PROPERTY_ID,
+  AlterTableAddColumnsRequest.JSON_PROPERTY_NEW_COLUMNS
+})
 @javax.annotation.Generated(
     value = "org.openapitools.codegen.languages.JavaClientCodegen",
     comments = "Generator version: 7.12.0")
 public class AlterTableAddColumnsRequest {
+  public static final String JSON_PROPERTY_ID = "id";
+  @javax.annotation.Nullable private List<String> id = new ArrayList<>();
+
   public static final String JSON_PROPERTY_NEW_COLUMNS = "new_columns";
   @javax.annotation.Nonnull private List<AddColumnsEntry> newColumns = new ArrayList<>();
 
   public AlterTableAddColumnsRequest() {}
+
+  public AlterTableAddColumnsRequest id(@javax.annotation.Nullable List<String> id) {
+    this.id = id;
+    return this;
+  }
+
+  public AlterTableAddColumnsRequest addIdItem(String idItem) {
+    if (this.id == null) {
+      this.id = new ArrayList<>();
+    }
+    this.id.add(idItem);
+    return this;
+  }
+
+  /**
+   * Table identifier path (namespace + table name)
+   *
+   * @return id
+   */
+  @javax.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public List<String> getId() {
+    return id;
+  }
+
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setId(@javax.annotation.Nullable List<String> id) {
+    this.id = id;
+  }
 
   public AlterTableAddColumnsRequest newColumns(
       @javax.annotation.Nonnull List<AddColumnsEntry> newColumns) {
@@ -75,18 +114,20 @@ public class AlterTableAddColumnsRequest {
       return false;
     }
     AlterTableAddColumnsRequest alterTableAddColumnsRequest = (AlterTableAddColumnsRequest) o;
-    return Objects.equals(this.newColumns, alterTableAddColumnsRequest.newColumns);
+    return Objects.equals(this.id, alterTableAddColumnsRequest.id)
+        && Objects.equals(this.newColumns, alterTableAddColumnsRequest.newColumns);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(newColumns);
+    return Objects.hash(id, newColumns);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class AlterTableAddColumnsRequest {\n");
+    sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    newColumns: ").append(toIndentedString(newColumns)).append("\n");
     sb.append("}");
     return sb.toString();
@@ -133,6 +174,21 @@ public class AlterTableAddColumnsRequest {
     }
 
     StringJoiner joiner = new StringJoiner("&");
+
+    // add `id` to the URL query string
+    if (getId() != null) {
+      for (int i = 0; i < getId().size(); i++) {
+        joiner.add(
+            String.format(
+                "%sid%s%s=%s",
+                prefix,
+                suffix,
+                "".equals(suffix)
+                    ? ""
+                    : String.format("%s%d%s", containerPrefix, i, containerSuffix),
+                ApiClient.urlEncode(ApiClient.valueToString(getId().get(i)))));
+      }
+    }
 
     // add `new_columns` to the URL query string
     if (getNewColumns() != null) {

--- a/java/lance-namespace-async-client/src/main/java/org/lance/namespace/model/AlterTableAlterColumnsRequest.java
+++ b/java/lance-namespace-async-client/src/main/java/org/lance/namespace/model/AlterTableAlterColumnsRequest.java
@@ -13,6 +13,8 @@
  */
 package org.lance.namespace.model;
 
+import org.lance.namespace.client.async.ApiClient;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
@@ -23,15 +25,52 @@ import java.util.Objects;
 import java.util.StringJoiner;
 
 /** AlterTableAlterColumnsRequest */
-@JsonPropertyOrder({AlterTableAlterColumnsRequest.JSON_PROPERTY_ALTERATIONS})
+@JsonPropertyOrder({
+  AlterTableAlterColumnsRequest.JSON_PROPERTY_ID,
+  AlterTableAlterColumnsRequest.JSON_PROPERTY_ALTERATIONS
+})
 @javax.annotation.Generated(
     value = "org.openapitools.codegen.languages.JavaClientCodegen",
     comments = "Generator version: 7.12.0")
 public class AlterTableAlterColumnsRequest {
+  public static final String JSON_PROPERTY_ID = "id";
+  @javax.annotation.Nullable private List<String> id = new ArrayList<>();
+
   public static final String JSON_PROPERTY_ALTERATIONS = "alterations";
   @javax.annotation.Nonnull private List<AlterColumnsEntry> alterations = new ArrayList<>();
 
   public AlterTableAlterColumnsRequest() {}
+
+  public AlterTableAlterColumnsRequest id(@javax.annotation.Nullable List<String> id) {
+    this.id = id;
+    return this;
+  }
+
+  public AlterTableAlterColumnsRequest addIdItem(String idItem) {
+    if (this.id == null) {
+      this.id = new ArrayList<>();
+    }
+    this.id.add(idItem);
+    return this;
+  }
+
+  /**
+   * Table identifier path (namespace + table name)
+   *
+   * @return id
+   */
+  @javax.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public List<String> getId() {
+    return id;
+  }
+
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setId(@javax.annotation.Nullable List<String> id) {
+    this.id = id;
+  }
 
   public AlterTableAlterColumnsRequest alterations(
       @javax.annotation.Nonnull List<AlterColumnsEntry> alterations) {
@@ -75,18 +114,20 @@ public class AlterTableAlterColumnsRequest {
       return false;
     }
     AlterTableAlterColumnsRequest alterTableAlterColumnsRequest = (AlterTableAlterColumnsRequest) o;
-    return Objects.equals(this.alterations, alterTableAlterColumnsRequest.alterations);
+    return Objects.equals(this.id, alterTableAlterColumnsRequest.id)
+        && Objects.equals(this.alterations, alterTableAlterColumnsRequest.alterations);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(alterations);
+    return Objects.hash(id, alterations);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class AlterTableAlterColumnsRequest {\n");
+    sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    alterations: ").append(toIndentedString(alterations)).append("\n");
     sb.append("}");
     return sb.toString();
@@ -133,6 +174,21 @@ public class AlterTableAlterColumnsRequest {
     }
 
     StringJoiner joiner = new StringJoiner("&");
+
+    // add `id` to the URL query string
+    if (getId() != null) {
+      for (int i = 0; i < getId().size(); i++) {
+        joiner.add(
+            String.format(
+                "%sid%s%s=%s",
+                prefix,
+                suffix,
+                "".equals(suffix)
+                    ? ""
+                    : String.format("%s%d%s", containerPrefix, i, containerSuffix),
+                ApiClient.urlEncode(ApiClient.valueToString(getId().get(i)))));
+      }
+    }
 
     // add `alterations` to the URL query string
     if (getAlterations() != null) {

--- a/java/lance-namespace-async-client/src/main/java/org/lance/namespace/model/AlterTableBackfillColumnsRequest.java
+++ b/java/lance-namespace-async-client/src/main/java/org/lance/namespace/model/AlterTableBackfillColumnsRequest.java
@@ -22,12 +22,15 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.openapitools.jackson.nullable.JsonNullable;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 import java.util.StringJoiner;
 
 /** AlterTableBackfillColumnsRequest */
 @JsonPropertyOrder({
+  AlterTableBackfillColumnsRequest.JSON_PROPERTY_ID,
   AlterTableBackfillColumnsRequest.JSON_PROPERTY_COLUMN,
   AlterTableBackfillColumnsRequest.JSON_PROPERTY_WHERE,
   AlterTableBackfillColumnsRequest.JSON_PROPERTY_CONCURRENCY,
@@ -47,6 +50,9 @@ import java.util.StringJoiner;
     value = "org.openapitools.codegen.languages.JavaClientCodegen",
     comments = "Generator version: 7.12.0")
 public class AlterTableBackfillColumnsRequest {
+  public static final String JSON_PROPERTY_ID = "id";
+  @javax.annotation.Nullable private List<String> id = new ArrayList<>();
+
   public static final String JSON_PROPERTY_COLUMN = "column";
   @javax.annotation.Nonnull private String column;
 
@@ -92,6 +98,37 @@ public class AlterTableBackfillColumnsRequest {
   private JsonNullable<String> manifest = JsonNullable.<String>undefined();
 
   public AlterTableBackfillColumnsRequest() {}
+
+  public AlterTableBackfillColumnsRequest id(@javax.annotation.Nullable List<String> id) {
+    this.id = id;
+    return this;
+  }
+
+  public AlterTableBackfillColumnsRequest addIdItem(String idItem) {
+    if (this.id == null) {
+      this.id = new ArrayList<>();
+    }
+    this.id.add(idItem);
+    return this;
+  }
+
+  /**
+   * Table identifier path (namespace + table name)
+   *
+   * @return id
+   */
+  @javax.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public List<String> getId() {
+    return id;
+  }
+
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setId(@javax.annotation.Nullable List<String> id) {
+    this.id = id;
+  }
 
   public AlterTableBackfillColumnsRequest column(@javax.annotation.Nonnull String column) {
     this.column = column;
@@ -544,7 +581,8 @@ public class AlterTableBackfillColumnsRequest {
     }
     AlterTableBackfillColumnsRequest alterTableBackfillColumnsRequest =
         (AlterTableBackfillColumnsRequest) o;
-    return Objects.equals(this.column, alterTableBackfillColumnsRequest.column)
+    return Objects.equals(this.id, alterTableBackfillColumnsRequest.id)
+        && Objects.equals(this.column, alterTableBackfillColumnsRequest.column)
         && equalsNullable(this.where, alterTableBackfillColumnsRequest.where)
         && equalsNullable(this.concurrency, alterTableBackfillColumnsRequest.concurrency)
         && equalsNullable(
@@ -578,6 +616,7 @@ public class AlterTableBackfillColumnsRequest {
   @Override
   public int hashCode() {
     return Objects.hash(
+        id,
         column,
         hashCodeNullable(where),
         hashCodeNullable(concurrency),
@@ -605,6 +644,7 @@ public class AlterTableBackfillColumnsRequest {
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class AlterTableBackfillColumnsRequest {\n");
+    sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    column: ").append(toIndentedString(column)).append("\n");
     sb.append("    where: ").append(toIndentedString(where)).append("\n");
     sb.append("    concurrency: ").append(toIndentedString(concurrency)).append("\n");
@@ -668,6 +708,21 @@ public class AlterTableBackfillColumnsRequest {
     }
 
     StringJoiner joiner = new StringJoiner("&");
+
+    // add `id` to the URL query string
+    if (getId() != null) {
+      for (int i = 0; i < getId().size(); i++) {
+        joiner.add(
+            String.format(
+                "%sid%s%s=%s",
+                prefix,
+                suffix,
+                "".equals(suffix)
+                    ? ""
+                    : String.format("%s%d%s", containerPrefix, i, containerSuffix),
+                ApiClient.urlEncode(ApiClient.valueToString(getId().get(i)))));
+      }
+    }
 
     // add `column` to the URL query string
     if (getColumn() != null) {

--- a/java/lance-namespace-async-client/src/main/java/org/lance/namespace/model/RefreshMaterializedViewRequest.java
+++ b/java/lance-namespace-async-client/src/main/java/org/lance/namespace/model/RefreshMaterializedViewRequest.java
@@ -21,12 +21,15 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import org.openapitools.jackson.nullable.JsonNullable;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 import java.util.StringJoiner;
 
 /** RefreshMaterializedViewRequest */
 @JsonPropertyOrder({
+  RefreshMaterializedViewRequest.JSON_PROPERTY_ID,
   RefreshMaterializedViewRequest.JSON_PROPERTY_SRC_VERSION,
   RefreshMaterializedViewRequest.JSON_PROPERTY_MAX_ROWS_PER_FRAGMENT,
   RefreshMaterializedViewRequest.JSON_PROPERTY_CONCURRENCY,
@@ -38,6 +41,9 @@ import java.util.StringJoiner;
     value = "org.openapitools.codegen.languages.JavaClientCodegen",
     comments = "Generator version: 7.12.0")
 public class RefreshMaterializedViewRequest {
+  public static final String JSON_PROPERTY_ID = "id";
+  @javax.annotation.Nullable private List<String> id = new ArrayList<>();
+
   public static final String JSON_PROPERTY_SRC_VERSION = "src_version";
   private JsonNullable<Integer> srcVersion = JsonNullable.<Integer>undefined();
 
@@ -57,6 +63,37 @@ public class RefreshMaterializedViewRequest {
   private JsonNullable<String> manifest = JsonNullable.<String>undefined();
 
   public RefreshMaterializedViewRequest() {}
+
+  public RefreshMaterializedViewRequest id(@javax.annotation.Nullable List<String> id) {
+    this.id = id;
+    return this;
+  }
+
+  public RefreshMaterializedViewRequest addIdItem(String idItem) {
+    if (this.id == null) {
+      this.id = new ArrayList<>();
+    }
+    this.id.add(idItem);
+    return this;
+  }
+
+  /**
+   * Table identifier path (namespace + table name)
+   *
+   * @return id
+   */
+  @javax.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public List<String> getId() {
+    return id;
+  }
+
+  @JsonProperty(JSON_PROPERTY_ID)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setId(@javax.annotation.Nullable List<String> id) {
+    this.id = id;
+  }
 
   public RefreshMaterializedViewRequest srcVersion(@javax.annotation.Nullable Integer srcVersion) {
     this.srcVersion = JsonNullable.<Integer>of(srcVersion);
@@ -260,7 +297,8 @@ public class RefreshMaterializedViewRequest {
     }
     RefreshMaterializedViewRequest refreshMaterializedViewRequest =
         (RefreshMaterializedViewRequest) o;
-    return equalsNullable(this.srcVersion, refreshMaterializedViewRequest.srcVersion)
+    return Objects.equals(this.id, refreshMaterializedViewRequest.id)
+        && equalsNullable(this.srcVersion, refreshMaterializedViewRequest.srcVersion)
         && equalsNullable(
             this.maxRowsPerFragment, refreshMaterializedViewRequest.maxRowsPerFragment)
         && equalsNullable(this.concurrency, refreshMaterializedViewRequest.concurrency)
@@ -282,6 +320,7 @@ public class RefreshMaterializedViewRequest {
   @Override
   public int hashCode() {
     return Objects.hash(
+        id,
         hashCodeNullable(srcVersion),
         hashCodeNullable(maxRowsPerFragment),
         hashCodeNullable(concurrency),
@@ -301,6 +340,7 @@ public class RefreshMaterializedViewRequest {
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class RefreshMaterializedViewRequest {\n");
+    sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    srcVersion: ").append(toIndentedString(srcVersion)).append("\n");
     sb.append("    maxRowsPerFragment: ").append(toIndentedString(maxRowsPerFragment)).append("\n");
     sb.append("    concurrency: ").append(toIndentedString(concurrency)).append("\n");
@@ -354,6 +394,21 @@ public class RefreshMaterializedViewRequest {
     }
 
     StringJoiner joiner = new StringJoiner("&");
+
+    // add `id` to the URL query string
+    if (getId() != null) {
+      for (int i = 0; i < getId().size(); i++) {
+        joiner.add(
+            String.format(
+                "%sid%s%s=%s",
+                prefix,
+                suffix,
+                "".equals(suffix)
+                    ? ""
+                    : String.format("%s%d%s", containerPrefix, i, containerSuffix),
+                ApiClient.urlEncode(ApiClient.valueToString(getId().get(i)))));
+      }
+    }
 
     // add `src_version` to the URL query string
     if (getSrcVersion() != null) {

--- a/java/lance-namespace-springboot-server/src/main/java/org/lance/namespace/server/springboot/model/AlterTableAddColumnsRequest.java
+++ b/java/lance-namespace-springboot-server/src/main/java/org/lance/namespace/server/springboot/model/AlterTableAddColumnsRequest.java
@@ -30,6 +30,8 @@ import java.util.Objects;
     comments = "Generator version: 7.12.0")
 public class AlterTableAddColumnsRequest {
 
+  @Valid private List<String> id = new ArrayList<>();
+
   @Valid private List<@Valid AddColumnsEntry> newColumns = new ArrayList<>();
 
   public AlterTableAddColumnsRequest() {
@@ -39,6 +41,37 @@ public class AlterTableAddColumnsRequest {
   /** Constructor with only required parameters */
   public AlterTableAddColumnsRequest(List<@Valid AddColumnsEntry> newColumns) {
     this.newColumns = newColumns;
+  }
+
+  public AlterTableAddColumnsRequest id(List<String> id) {
+    this.id = id;
+    return this;
+  }
+
+  public AlterTableAddColumnsRequest addIdItem(String idItem) {
+    if (this.id == null) {
+      this.id = new ArrayList<>();
+    }
+    this.id.add(idItem);
+    return this;
+  }
+
+  /**
+   * Table identifier path (namespace + table name)
+   *
+   * @return id
+   */
+  @Schema(
+      name = "id",
+      description = "Table identifier path (namespace + table name)",
+      requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @JsonProperty("id")
+  public List<String> getId() {
+    return id;
+  }
+
+  public void setId(List<String> id) {
+    this.id = id;
   }
 
   public AlterTableAddColumnsRequest newColumns(List<@Valid AddColumnsEntry> newColumns) {
@@ -83,18 +116,20 @@ public class AlterTableAddColumnsRequest {
       return false;
     }
     AlterTableAddColumnsRequest alterTableAddColumnsRequest = (AlterTableAddColumnsRequest) o;
-    return Objects.equals(this.newColumns, alterTableAddColumnsRequest.newColumns);
+    return Objects.equals(this.id, alterTableAddColumnsRequest.id)
+        && Objects.equals(this.newColumns, alterTableAddColumnsRequest.newColumns);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(newColumns);
+    return Objects.hash(id, newColumns);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class AlterTableAddColumnsRequest {\n");
+    sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    newColumns: ").append(toIndentedString(newColumns)).append("\n");
     sb.append("}");
     return sb.toString();

--- a/java/lance-namespace-springboot-server/src/main/java/org/lance/namespace/server/springboot/model/AlterTableAlterColumnsRequest.java
+++ b/java/lance-namespace-springboot-server/src/main/java/org/lance/namespace/server/springboot/model/AlterTableAlterColumnsRequest.java
@@ -30,6 +30,8 @@ import java.util.Objects;
     comments = "Generator version: 7.12.0")
 public class AlterTableAlterColumnsRequest {
 
+  @Valid private List<String> id = new ArrayList<>();
+
   @Valid private List<@Valid AlterColumnsEntry> alterations = new ArrayList<>();
 
   public AlterTableAlterColumnsRequest() {
@@ -39,6 +41,37 @@ public class AlterTableAlterColumnsRequest {
   /** Constructor with only required parameters */
   public AlterTableAlterColumnsRequest(List<@Valid AlterColumnsEntry> alterations) {
     this.alterations = alterations;
+  }
+
+  public AlterTableAlterColumnsRequest id(List<String> id) {
+    this.id = id;
+    return this;
+  }
+
+  public AlterTableAlterColumnsRequest addIdItem(String idItem) {
+    if (this.id == null) {
+      this.id = new ArrayList<>();
+    }
+    this.id.add(idItem);
+    return this;
+  }
+
+  /**
+   * Table identifier path (namespace + table name)
+   *
+   * @return id
+   */
+  @Schema(
+      name = "id",
+      description = "Table identifier path (namespace + table name)",
+      requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @JsonProperty("id")
+  public List<String> getId() {
+    return id;
+  }
+
+  public void setId(List<String> id) {
+    this.id = id;
   }
 
   public AlterTableAlterColumnsRequest alterations(List<@Valid AlterColumnsEntry> alterations) {
@@ -83,18 +116,20 @@ public class AlterTableAlterColumnsRequest {
       return false;
     }
     AlterTableAlterColumnsRequest alterTableAlterColumnsRequest = (AlterTableAlterColumnsRequest) o;
-    return Objects.equals(this.alterations, alterTableAlterColumnsRequest.alterations);
+    return Objects.equals(this.id, alterTableAlterColumnsRequest.id)
+        && Objects.equals(this.alterations, alterTableAlterColumnsRequest.alterations);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(alterations);
+    return Objects.hash(id, alterations);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class AlterTableAlterColumnsRequest {\n");
+    sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    alterations: ").append(toIndentedString(alterations)).append("\n");
     sb.append("}");
     return sb.toString();

--- a/java/lance-namespace-springboot-server/src/main/java/org/lance/namespace/server/springboot/model/AlterTableBackfillColumnsRequest.java
+++ b/java/lance-namespace-springboot-server/src/main/java/org/lance/namespace/server/springboot/model/AlterTableBackfillColumnsRequest.java
@@ -21,6 +21,8 @@ import jakarta.validation.constraints.*;
 
 import java.math.BigDecimal;
 import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 /** AlterTableBackfillColumnsRequest */
@@ -28,6 +30,8 @@ import java.util.Objects;
     value = "org.openapitools.codegen.languages.SpringCodegen",
     comments = "Generator version: 7.12.0")
 public class AlterTableBackfillColumnsRequest {
+
+  @Valid private List<String> id = new ArrayList<>();
 
   private String column;
 
@@ -64,6 +68,37 @@ public class AlterTableBackfillColumnsRequest {
   /** Constructor with only required parameters */
   public AlterTableBackfillColumnsRequest(String column) {
     this.column = column;
+  }
+
+  public AlterTableBackfillColumnsRequest id(List<String> id) {
+    this.id = id;
+    return this;
+  }
+
+  public AlterTableBackfillColumnsRequest addIdItem(String idItem) {
+    if (this.id == null) {
+      this.id = new ArrayList<>();
+    }
+    this.id.add(idItem);
+    return this;
+  }
+
+  /**
+   * Table identifier path (namespace + table name)
+   *
+   * @return id
+   */
+  @Schema(
+      name = "id",
+      description = "Table identifier path (namespace + table name)",
+      requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @JsonProperty("id")
+  public List<String> getId() {
+    return id;
+  }
+
+  public void setId(List<String> id) {
+    this.id = id;
   }
 
   public AlterTableBackfillColumnsRequest column(String column) {
@@ -402,7 +437,8 @@ public class AlterTableBackfillColumnsRequest {
     }
     AlterTableBackfillColumnsRequest alterTableBackfillColumnsRequest =
         (AlterTableBackfillColumnsRequest) o;
-    return Objects.equals(this.column, alterTableBackfillColumnsRequest.column)
+    return Objects.equals(this.id, alterTableBackfillColumnsRequest.id)
+        && Objects.equals(this.column, alterTableBackfillColumnsRequest.column)
         && Objects.equals(this.where, alterTableBackfillColumnsRequest.where)
         && Objects.equals(this.concurrency, alterTableBackfillColumnsRequest.concurrency)
         && Objects.equals(
@@ -427,6 +463,7 @@ public class AlterTableBackfillColumnsRequest {
   @Override
   public int hashCode() {
     return Objects.hash(
+        id,
         column,
         where,
         concurrency,
@@ -447,6 +484,7 @@ public class AlterTableBackfillColumnsRequest {
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class AlterTableBackfillColumnsRequest {\n");
+    sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    column: ").append(toIndentedString(column)).append("\n");
     sb.append("    where: ").append(toIndentedString(where)).append("\n");
     sb.append("    concurrency: ").append(toIndentedString(concurrency)).append("\n");

--- a/java/lance-namespace-springboot-server/src/main/java/org/lance/namespace/server/springboot/model/RefreshMaterializedViewRequest.java
+++ b/java/lance-namespace-springboot-server/src/main/java/org/lance/namespace/server/springboot/model/RefreshMaterializedViewRequest.java
@@ -16,9 +16,12 @@ package org.lance.namespace.server.springboot.model;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Generated;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.*;
 
 import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 /** RefreshMaterializedViewRequest */
@@ -26,6 +29,8 @@ import java.util.Objects;
     value = "org.openapitools.codegen.languages.SpringCodegen",
     comments = "Generator version: 7.12.0")
 public class RefreshMaterializedViewRequest {
+
+  @Valid private List<String> id = new ArrayList<>();
 
   private Integer srcVersion = null;
 
@@ -38,6 +43,37 @@ public class RefreshMaterializedViewRequest {
   private String cluster = null;
 
   private String manifest = null;
+
+  public RefreshMaterializedViewRequest id(List<String> id) {
+    this.id = id;
+    return this;
+  }
+
+  public RefreshMaterializedViewRequest addIdItem(String idItem) {
+    if (this.id == null) {
+      this.id = new ArrayList<>();
+    }
+    this.id.add(idItem);
+    return this;
+  }
+
+  /**
+   * Table identifier path (namespace + table name)
+   *
+   * @return id
+   */
+  @Schema(
+      name = "id",
+      description = "Table identifier path (namespace + table name)",
+      requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @JsonProperty("id")
+  public List<String> getId() {
+    return id;
+  }
+
+  public void setId(List<String> id) {
+    this.id = id;
+  }
 
   public RefreshMaterializedViewRequest srcVersion(Integer srcVersion) {
     this.srcVersion = srcVersion;
@@ -187,7 +223,8 @@ public class RefreshMaterializedViewRequest {
     }
     RefreshMaterializedViewRequest refreshMaterializedViewRequest =
         (RefreshMaterializedViewRequest) o;
-    return Objects.equals(this.srcVersion, refreshMaterializedViewRequest.srcVersion)
+    return Objects.equals(this.id, refreshMaterializedViewRequest.id)
+        && Objects.equals(this.srcVersion, refreshMaterializedViewRequest.srcVersion)
         && Objects.equals(
             this.maxRowsPerFragment, refreshMaterializedViewRequest.maxRowsPerFragment)
         && Objects.equals(this.concurrency, refreshMaterializedViewRequest.concurrency)
@@ -200,13 +237,20 @@ public class RefreshMaterializedViewRequest {
   @Override
   public int hashCode() {
     return Objects.hash(
-        srcVersion, maxRowsPerFragment, concurrency, intraApplierConcurrency, cluster, manifest);
+        id,
+        srcVersion,
+        maxRowsPerFragment,
+        concurrency,
+        intraApplierConcurrency,
+        cluster,
+        manifest);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class RefreshMaterializedViewRequest {\n");
+    sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    srcVersion: ").append(toIndentedString(srcVersion)).append("\n");
     sb.append("    maxRowsPerFragment: ").append(toIndentedString(maxRowsPerFragment)).append("\n");
     sb.append("    concurrency: ").append(toIndentedString(concurrency)).append("\n");

--- a/python/lance_namespace_urllib3_client/docs/AlterTableAddColumnsRequest.md
+++ b/python/lance_namespace_urllib3_client/docs/AlterTableAddColumnsRequest.md
@@ -5,6 +5,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**id** | **List[str]** | Table identifier path (namespace + table name) | [optional] 
 **new_columns** | [**List[AddColumnsEntry]**](AddColumnsEntry.md) | List of new columns to add to the table | 
 
 ## Example

--- a/python/lance_namespace_urllib3_client/docs/AlterTableAlterColumnsRequest.md
+++ b/python/lance_namespace_urllib3_client/docs/AlterTableAlterColumnsRequest.md
@@ -5,6 +5,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**id** | **List[str]** | Table identifier path (namespace + table name) | [optional] 
 **alterations** | [**List[AlterColumnsEntry]**](AlterColumnsEntry.md) | List of column alterations to apply to the table | 
 
 ## Example

--- a/python/lance_namespace_urllib3_client/docs/AlterTableBackfillColumnsRequest.md
+++ b/python/lance_namespace_urllib3_client/docs/AlterTableBackfillColumnsRequest.md
@@ -5,6 +5,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**id** | **List[str]** | Table identifier path (namespace + table name) | [optional] 
 **column** | **str** | Column name to backfill | 
 **where** | **str** | Optional WHERE clause filter | [optional] 
 **concurrency** | **int** | Optional concurrency override | [optional] 

--- a/python/lance_namespace_urllib3_client/docs/RefreshMaterializedViewRequest.md
+++ b/python/lance_namespace_urllib3_client/docs/RefreshMaterializedViewRequest.md
@@ -5,6 +5,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**id** | **List[str]** | Table identifier path (namespace + table name) | [optional] 
 **src_version** | **int** | Optional source version to refresh from | [optional] 
 **max_rows_per_fragment** | **int** | Optional maximum rows per fragment | [optional] 
 **concurrency** | **int** | Optional concurrency override | [optional] 

--- a/python/lance_namespace_urllib3_client/lance_namespace_urllib3_client/models/alter_table_add_columns_request.py
+++ b/python/lance_namespace_urllib3_client/lance_namespace_urllib3_client/models/alter_table_add_columns_request.py
@@ -17,8 +17,8 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, Field
-from typing import Any, ClassVar, Dict, List
+from pydantic import BaseModel, ConfigDict, Field, StrictStr
+from typing import Any, ClassVar, Dict, List, Optional
 from lance_namespace_urllib3_client.models.add_columns_entry import AddColumnsEntry
 from typing import Optional, Set
 from typing_extensions import Self
@@ -27,8 +27,9 @@ class AlterTableAddColumnsRequest(BaseModel):
     """
     AlterTableAddColumnsRequest
     """ # noqa: E501
+    id: Optional[List[StrictStr]] = Field(default=None, description="Table identifier path (namespace + table name)")
     new_columns: List[AddColumnsEntry] = Field(description="List of new columns to add to the table")
-    __properties: ClassVar[List[str]] = ["new_columns"]
+    __properties: ClassVar[List[str]] = ["id", "new_columns"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -88,6 +89,7 @@ class AlterTableAddColumnsRequest(BaseModel):
             return cls.model_validate(obj)
 
         _obj = cls.model_validate({
+            "id": obj.get("id"),
             "new_columns": [AddColumnsEntry.from_dict(_item) for _item in obj["new_columns"]] if obj.get("new_columns") is not None else None
         })
         return _obj

--- a/python/lance_namespace_urllib3_client/lance_namespace_urllib3_client/models/alter_table_alter_columns_request.py
+++ b/python/lance_namespace_urllib3_client/lance_namespace_urllib3_client/models/alter_table_alter_columns_request.py
@@ -17,8 +17,8 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, Field
-from typing import Any, ClassVar, Dict, List
+from pydantic import BaseModel, ConfigDict, Field, StrictStr
+from typing import Any, ClassVar, Dict, List, Optional
 from lance_namespace_urllib3_client.models.alter_columns_entry import AlterColumnsEntry
 from typing import Optional, Set
 from typing_extensions import Self
@@ -27,8 +27,9 @@ class AlterTableAlterColumnsRequest(BaseModel):
     """
     AlterTableAlterColumnsRequest
     """ # noqa: E501
+    id: Optional[List[StrictStr]] = Field(default=None, description="Table identifier path (namespace + table name)")
     alterations: List[AlterColumnsEntry] = Field(description="List of column alterations to apply to the table")
-    __properties: ClassVar[List[str]] = ["alterations"]
+    __properties: ClassVar[List[str]] = ["id", "alterations"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -88,6 +89,7 @@ class AlterTableAlterColumnsRequest(BaseModel):
             return cls.model_validate(obj)
 
         _obj = cls.model_validate({
+            "id": obj.get("id"),
             "alterations": [AlterColumnsEntry.from_dict(_item) for _item in obj["alterations"]] if obj.get("alterations") is not None else None
         })
         return _obj

--- a/python/lance_namespace_urllib3_client/lance_namespace_urllib3_client/models/alter_table_backfill_columns_request.py
+++ b/python/lance_namespace_urllib3_client/lance_namespace_urllib3_client/models/alter_table_backfill_columns_request.py
@@ -26,6 +26,7 @@ class AlterTableBackfillColumnsRequest(BaseModel):
     """
     AlterTableBackfillColumnsRequest
     """ # noqa: E501
+    id: Optional[List[StrictStr]] = Field(default=None, description="Table identifier path (namespace + table name)")
     column: StrictStr = Field(description="Column name to backfill")
     where: Optional[StrictStr] = Field(default=None, description="Optional WHERE clause filter")
     concurrency: Optional[StrictInt] = Field(default=None, description="Optional concurrency override")
@@ -40,7 +41,7 @@ class AlterTableBackfillColumnsRequest(BaseModel):
     commit_granularity: Optional[StrictInt] = Field(default=None, description="Optional commit granularity")
     cluster: Optional[StrictStr] = Field(default=None, description="Optional cluster name")
     manifest: Optional[StrictStr] = Field(default=None, description="Optional manifest name")
-    __properties: ClassVar[List[str]] = ["column", "where", "concurrency", "intra_applier_concurrency", "min_checkpoint_size", "max_checkpoint_size", "batch_checkpoint_flush_interval_seconds", "read_version", "task_size", "num_frags", "checkpoint_size", "commit_granularity", "cluster", "manifest"]
+    __properties: ClassVar[List[str]] = ["id", "column", "where", "concurrency", "intra_applier_concurrency", "min_checkpoint_size", "max_checkpoint_size", "batch_checkpoint_flush_interval_seconds", "read_version", "task_size", "num_frags", "checkpoint_size", "commit_granularity", "cluster", "manifest"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -158,6 +159,7 @@ class AlterTableBackfillColumnsRequest(BaseModel):
             return cls.model_validate(obj)
 
         _obj = cls.model_validate({
+            "id": obj.get("id"),
             "column": obj.get("column"),
             "where": obj.get("where"),
             "concurrency": obj.get("concurrency"),

--- a/python/lance_namespace_urllib3_client/lance_namespace_urllib3_client/models/refresh_materialized_view_request.py
+++ b/python/lance_namespace_urllib3_client/lance_namespace_urllib3_client/models/refresh_materialized_view_request.py
@@ -26,13 +26,14 @@ class RefreshMaterializedViewRequest(BaseModel):
     """
     RefreshMaterializedViewRequest
     """ # noqa: E501
+    id: Optional[List[StrictStr]] = Field(default=None, description="Table identifier path (namespace + table name)")
     src_version: Optional[StrictInt] = Field(default=None, description="Optional source version to refresh from")
     max_rows_per_fragment: Optional[StrictInt] = Field(default=None, description="Optional maximum rows per fragment")
     concurrency: Optional[StrictInt] = Field(default=None, description="Optional concurrency override")
     intra_applier_concurrency: Optional[StrictInt] = Field(default=None, description="Optional intra-applier concurrency override")
     cluster: Optional[StrictStr] = Field(default=None, description="Optional cluster name")
     manifest: Optional[StrictStr] = Field(default=None, description="Optional manifest name")
-    __properties: ClassVar[List[str]] = ["src_version", "max_rows_per_fragment", "concurrency", "intra_applier_concurrency", "cluster", "manifest"]
+    __properties: ClassVar[List[str]] = ["id", "src_version", "max_rows_per_fragment", "concurrency", "intra_applier_concurrency", "cluster", "manifest"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -115,6 +116,7 @@ class RefreshMaterializedViewRequest(BaseModel):
             return cls.model_validate(obj)
 
         _obj = cls.model_validate({
+            "id": obj.get("id"),
             "src_version": obj.get("src_version"),
             "max_rows_per_fragment": obj.get("max_rows_per_fragment"),
             "concurrency": obj.get("concurrency"),

--- a/python/lance_namespace_urllib3_client/test/test_alter_table_add_columns_request.py
+++ b/python/lance_namespace_urllib3_client/test/test_alter_table_add_columns_request.py
@@ -35,6 +35,9 @@ class TestAlterTableAddColumnsRequest(unittest.TestCase):
         model = AlterTableAddColumnsRequest()
         if include_optional:
             return AlterTableAddColumnsRequest(
+                id = [
+                    ''
+                    ],
                 new_columns = [
                     lance_namespace_urllib3_client.models.add_columns_entry.AddColumnsEntry(
                         name = '', 

--- a/python/lance_namespace_urllib3_client/test/test_alter_table_alter_columns_request.py
+++ b/python/lance_namespace_urllib3_client/test/test_alter_table_alter_columns_request.py
@@ -35,6 +35,9 @@ class TestAlterTableAlterColumnsRequest(unittest.TestCase):
         model = AlterTableAlterColumnsRequest()
         if include_optional:
             return AlterTableAlterColumnsRequest(
+                id = [
+                    ''
+                    ],
                 alterations = [
                     lance_namespace_urllib3_client.models.alter_columns_entry.AlterColumnsEntry(
                         path = '', 

--- a/python/lance_namespace_urllib3_client/test/test_alter_table_backfill_columns_request.py
+++ b/python/lance_namespace_urllib3_client/test/test_alter_table_backfill_columns_request.py
@@ -35,6 +35,9 @@ class TestAlterTableBackfillColumnsRequest(unittest.TestCase):
         model = AlterTableBackfillColumnsRequest()
         if include_optional:
             return AlterTableBackfillColumnsRequest(
+                id = [
+                    ''
+                    ],
                 column = '',
                 where = '',
                 concurrency = 56,

--- a/python/lance_namespace_urllib3_client/test/test_refresh_materialized_view_request.py
+++ b/python/lance_namespace_urllib3_client/test/test_refresh_materialized_view_request.py
@@ -35,6 +35,9 @@ class TestRefreshMaterializedViewRequest(unittest.TestCase):
         model = RefreshMaterializedViewRequest()
         if include_optional:
             return RefreshMaterializedViewRequest(
+                id = [
+                    ''
+                    ],
                 src_version = 56,
                 max_rows_per_fragment = 56,
                 concurrency = 56,

--- a/rust/lance-namespace-reqwest-client/docs/AlterTableAddColumnsRequest.md
+++ b/rust/lance-namespace-reqwest-client/docs/AlterTableAddColumnsRequest.md
@@ -4,6 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**id** | Option<**Vec<String>**> | Table identifier path (namespace + table name) | [optional]
 **new_columns** | [**Vec<models::AddColumnsEntry>**](AddColumnsEntry.md) | List of new columns to add to the table | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/rust/lance-namespace-reqwest-client/docs/AlterTableAlterColumnsRequest.md
+++ b/rust/lance-namespace-reqwest-client/docs/AlterTableAlterColumnsRequest.md
@@ -4,6 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**id** | Option<**Vec<String>**> | Table identifier path (namespace + table name) | [optional]
 **alterations** | [**Vec<models::AlterColumnsEntry>**](AlterColumnsEntry.md) | List of column alterations to apply to the table | 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/rust/lance-namespace-reqwest-client/docs/AlterTableBackfillColumnsRequest.md
+++ b/rust/lance-namespace-reqwest-client/docs/AlterTableBackfillColumnsRequest.md
@@ -4,6 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**id** | Option<**Vec<String>**> | Table identifier path (namespace + table name) | [optional]
 **column** | **String** | Column name to backfill | 
 **r#where** | Option<**String**> | Optional WHERE clause filter | [optional]
 **concurrency** | Option<**i32**> | Optional concurrency override | [optional]

--- a/rust/lance-namespace-reqwest-client/docs/RefreshMaterializedViewRequest.md
+++ b/rust/lance-namespace-reqwest-client/docs/RefreshMaterializedViewRequest.md
@@ -4,6 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**id** | Option<**Vec<String>**> | Table identifier path (namespace + table name) | [optional]
 **src_version** | Option<**i32**> | Optional source version to refresh from | [optional]
 **max_rows_per_fragment** | Option<**i32**> | Optional maximum rows per fragment | [optional]
 **concurrency** | Option<**i32**> | Optional concurrency override | [optional]

--- a/rust/lance-namespace-reqwest-client/src/models/alter_table_add_columns_request.rs
+++ b/rust/lance-namespace-reqwest-client/src/models/alter_table_add_columns_request.rs
@@ -13,6 +13,9 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct AlterTableAddColumnsRequest {
+    /// Table identifier path (namespace + table name)
+    #[serde(rename = "id", skip_serializing_if = "Option::is_none")]
+    pub id: Option<Vec<String>>,
     /// List of new columns to add to the table
     #[serde(rename = "new_columns")]
     pub new_columns: Vec<models::AddColumnsEntry>,
@@ -21,6 +24,7 @@ pub struct AlterTableAddColumnsRequest {
 impl AlterTableAddColumnsRequest {
     pub fn new(new_columns: Vec<models::AddColumnsEntry>) -> AlterTableAddColumnsRequest {
         AlterTableAddColumnsRequest {
+            id: None,
             new_columns,
         }
     }

--- a/rust/lance-namespace-reqwest-client/src/models/alter_table_alter_columns_request.rs
+++ b/rust/lance-namespace-reqwest-client/src/models/alter_table_alter_columns_request.rs
@@ -13,6 +13,9 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct AlterTableAlterColumnsRequest {
+    /// Table identifier path (namespace + table name)
+    #[serde(rename = "id", skip_serializing_if = "Option::is_none")]
+    pub id: Option<Vec<String>>,
     /// List of column alterations to apply to the table
     #[serde(rename = "alterations")]
     pub alterations: Vec<models::AlterColumnsEntry>,
@@ -21,6 +24,7 @@ pub struct AlterTableAlterColumnsRequest {
 impl AlterTableAlterColumnsRequest {
     pub fn new(alterations: Vec<models::AlterColumnsEntry>) -> AlterTableAlterColumnsRequest {
         AlterTableAlterColumnsRequest {
+            id: None,
             alterations,
         }
     }

--- a/rust/lance-namespace-reqwest-client/src/models/alter_table_backfill_columns_request.rs
+++ b/rust/lance-namespace-reqwest-client/src/models/alter_table_backfill_columns_request.rs
@@ -13,6 +13,9 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct AlterTableBackfillColumnsRequest {
+    /// Table identifier path (namespace + table name)
+    #[serde(rename = "id", skip_serializing_if = "Option::is_none")]
+    pub id: Option<Vec<String>>,
     /// Column name to backfill
     #[serde(rename = "column")]
     pub column: String,
@@ -60,6 +63,7 @@ pub struct AlterTableBackfillColumnsRequest {
 impl AlterTableBackfillColumnsRequest {
     pub fn new(column: String) -> AlterTableBackfillColumnsRequest {
         AlterTableBackfillColumnsRequest {
+            id: None,
             column,
             r#where: None,
             concurrency: None,

--- a/rust/lance-namespace-reqwest-client/src/models/refresh_materialized_view_request.rs
+++ b/rust/lance-namespace-reqwest-client/src/models/refresh_materialized_view_request.rs
@@ -13,6 +13,9 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct RefreshMaterializedViewRequest {
+    /// Table identifier path (namespace + table name)
+    #[serde(rename = "id", skip_serializing_if = "Option::is_none")]
+    pub id: Option<Vec<String>>,
     /// Optional source version to refresh from
     #[serde(rename = "src_version", default, with = "::serde_with::rust::double_option", skip_serializing_if = "Option::is_none")]
     pub src_version: Option<Option<i32>>,
@@ -36,6 +39,7 @@ pub struct RefreshMaterializedViewRequest {
 impl RefreshMaterializedViewRequest {
     pub fn new() -> RefreshMaterializedViewRequest {
         RefreshMaterializedViewRequest {
+            id: None,
             src_version: None,
             max_rows_per_fragment: None,
             concurrency: None,


### PR DESCRIPTION
## Summary

- Add `id` (array of strings) field to `AlterTableAddColumnsRequest`, `AlterTableAlterColumnsRequest`, `AlterTableBackfillColumnsRequest`, and `RefreshMaterializedViewRequest`
- The namespace interface requires `id` in request objects for client-side table identification (see [operations spec](https://lancedb.github.io/lance-namespace/spec/operations))
- Regenerate all clients (Rust, Python, Java)

## Test plan

- [x] YAML validates
- [x] All clients build successfully