### PR TITLE
feat(rest): extend virtual column entries with UDF metadata and add identity to requests

### DIFF
--- a/docs/src/client/operations/models/AddVirtualColumnEntry.md
+++ b/docs/src/client/operations/models/AddVirtualColumnEntry.md
@@ -13,6 +13,11 @@
 |**udf** | **String** | Base64 encoded pickled UDF |  |
 |**udfName** | **String** | Name of the UDF |  |
 |**udfVersion** | **String** | Version of the UDF |  |
+|**udfBackend** | **String** | UDF backend type (e.g. DockerUDFSpecV1) |  [optional] |
+|**autoBackfill** | **Boolean** | Whether to automatically backfill the column after creation |  [optional] |
+|**manifest** | **String** | JSON-serialized manifest for the UDF environment |  [optional] |
+|**manifestChecksum** | **String** | SHA-256 checksum of the manifest content |  [optional] |
+|**fieldMetadata** | **Map&lt;String, String&gt;** | User-supplied field metadata (string key-value pairs) |  [optional] |
 
 
 

--- a/docs/src/client/operations/models/AlterTableAddColumnsRequest.md
+++ b/docs/src/client/operations/models/AlterTableAddColumnsRequest.md
@@ -7,6 +7,7 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
+|**identity** | [**Identity**](Identity.md) |  |  [optional] |
 |**id** | **List&lt;String&gt;** | Table identifier path (namespace + table name) |  [optional] |
 |**newColumns** | [**List&lt;AddColumnsEntry&gt;**](AddColumnsEntry.md) | List of new columns to add to the table |  |
 

--- a/docs/src/client/operations/models/AlterTableAlterColumnsRequest.md
+++ b/docs/src/client/operations/models/AlterTableAlterColumnsRequest.md
@@ -7,6 +7,7 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
+|**identity** | [**Identity**](Identity.md) |  |  [optional] |
 |**id** | **List&lt;String&gt;** | Table identifier path (namespace + table name) |  [optional] |
 |**alterations** | [**List&lt;AlterColumnsEntry&gt;**](AlterColumnsEntry.md) | List of column alterations to apply to the table |  |
 

--- a/docs/src/client/operations/models/AlterTableBackfillColumnsRequest.md
+++ b/docs/src/client/operations/models/AlterTableBackfillColumnsRequest.md
@@ -7,6 +7,7 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
+|**identity** | [**Identity**](Identity.md) |  |  [optional] |
 |**id** | **List&lt;String&gt;** | Table identifier path (namespace + table name) |  [optional] |
 |**column** | **String** | Column name to backfill |  |
 |**where** | **String** | Optional WHERE clause filter |  [optional] |

--- a/docs/src/client/operations/models/AlterVirtualColumnEntry.md
+++ b/docs/src/client/operations/models/AlterVirtualColumnEntry.md
@@ -12,6 +12,11 @@
 |**udf** | **String** | Base64 encoded pickled UDF (optional) |  [optional] |
 |**udfName** | **String** | Name of the UDF (optional) |  [optional] |
 |**udfVersion** | **String** | Version of the UDF (optional) |  [optional] |
+|**udfBackend** | **String** | UDF backend type (e.g. DockerUDFSpecV1) (optional) |  [optional] |
+|**autoBackfill** | **Boolean** | Whether to automatically backfill the column (optional) |  [optional] |
+|**manifest** | **String** | JSON-serialized manifest for the UDF environment (optional) |  [optional] |
+|**manifestChecksum** | **String** | SHA-256 checksum of the manifest content (optional) |  [optional] |
+|**fieldMetadata** | **Map&lt;String, String&gt;** | User-supplied field metadata (optional) |  [optional] |
 
 
 

--- a/docs/src/client/operations/models/RefreshMaterializedViewRequest.md
+++ b/docs/src/client/operations/models/RefreshMaterializedViewRequest.md
@@ -7,6 +7,7 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
+|**identity** | [**Identity**](Identity.md) |  |  [optional] |
 |**id** | **List&lt;String&gt;** | Table identifier path (namespace + table name) |  [optional] |
 |**srcVersion** | **Integer** | Optional source version to refresh from |  [optional] |
 |**maxRowsPerFragment** | **Integer** | Optional maximum rows per fragment |  [optional] |

--- a/docs/src/rest.yaml
+++ b/docs/src/rest.yaml
@@ -4557,6 +4557,8 @@ components:
       required:
         - new_columns
       properties:
+        identity:
+          $ref: "#/components/schemas/Identity"
         id:
           type: array
           items:
@@ -4617,6 +4619,33 @@ components:
         udf_version:
           type: string
           description: Version of the UDF
+        udf_backend:
+          type:
+            - string
+            - "null"
+          description: UDF backend type (e.g. DockerUDFSpecV1)
+        auto_backfill:
+          type:
+            - boolean
+            - "null"
+          description: Whether to automatically backfill the column after creation
+        manifest:
+          type:
+            - string
+            - "null"
+          description: JSON-serialized manifest for the UDF environment
+        manifest_checksum:
+          type:
+            - string
+            - "null"
+          description: SHA-256 checksum of the manifest content
+        field_metadata:
+          type:
+            - object
+            - "null"
+          additionalProperties:
+            type: string
+          description: User-supplied field metadata (string key-value pairs)
 
     AlterTableAddColumnsResponse:
       type: object
@@ -4634,6 +4663,8 @@ components:
       required:
         - alterations
       properties:
+        identity:
+          $ref: "#/components/schemas/Identity"
         id:
           type: array
           items:
@@ -4703,6 +4734,33 @@ components:
             - string
             - "null"
           description: Version of the UDF (optional)
+        udf_backend:
+          type:
+            - string
+            - "null"
+          description: UDF backend type (e.g. DockerUDFSpecV1) (optional)
+        auto_backfill:
+          type:
+            - boolean
+            - "null"
+          description: Whether to automatically backfill the column (optional)
+        manifest:
+          type:
+            - string
+            - "null"
+          description: JSON-serialized manifest for the UDF environment (optional)
+        manifest_checksum:
+          type:
+            - string
+            - "null"
+          description: SHA-256 checksum of the manifest content (optional)
+        field_metadata:
+          type:
+            - object
+            - "null"
+          additionalProperties:
+            type: string
+          description: User-supplied field metadata (optional)
 
     AlterTableAlterColumnsResponse:
       type: object
@@ -4720,6 +4778,8 @@ components:
       required:
         - column
       properties:
+        identity:
+          $ref: "#/components/schemas/Identity"
         id:
           type: array
           items:
@@ -4806,6 +4866,8 @@ components:
     RefreshMaterializedViewRequest:
       type: object
       properties:
+        identity:
+          $ref: "#/components/schemas/Identity"
         id:
           type: array
           items:

--- a/java/lance-namespace-apache-client/api/openapi.yaml
+++ b/java/lance-namespace-apache-client/api/openapi.yaml
@@ -7004,33 +7004,50 @@ components:
       - analysis
     AlterTableAddColumnsRequest:
       example:
+        identity:
+          api_key: api_key
+          auth_token: auth_token
         new_columns:
         - expression: expression
           name: name
           virtual_column:
             image: image
+            field_metadata:
+              key: field_metadata
+            manifest_checksum: manifest_checksum
             udf: udf
             udf_name: udf_name
+            manifest: manifest
             input_columns:
             - input_columns
             - input_columns
             data_type: "{}"
+            udf_backend: udf_backend
+            auto_backfill: true
             udf_version: udf_version
         - expression: expression
           name: name
           virtual_column:
             image: image
+            field_metadata:
+              key: field_metadata
+            manifest_checksum: manifest_checksum
             udf: udf
             udf_name: udf_name
+            manifest: manifest
             input_columns:
             - input_columns
             - input_columns
             data_type: "{}"
+            udf_backend: udf_backend
+            auto_backfill: true
             udf_version: udf_version
         id:
         - id
         - id
       properties:
+        identity:
+          $ref: '#/components/schemas/Identity'
         id:
           description: Table identifier path (namespace + table name)
           items:
@@ -7049,12 +7066,18 @@ components:
         name: name
         virtual_column:
           image: image
+          field_metadata:
+            key: field_metadata
+          manifest_checksum: manifest_checksum
           udf: udf
           udf_name: udf_name
+          manifest: manifest
           input_columns:
           - input_columns
           - input_columns
           data_type: "{}"
+          udf_backend: udf_backend
+          auto_backfill: true
           udf_version: udf_version
       properties:
         name:
@@ -7072,12 +7095,18 @@ components:
     AddVirtualColumnEntry:
       example:
         image: image
+        field_metadata:
+          key: field_metadata
+        manifest_checksum: manifest_checksum
         udf: udf
         udf_name: udf_name
+        manifest: manifest
         input_columns:
         - input_columns
         - input_columns
         data_type: "{}"
+        udf_backend: udf_backend
+        auto_backfill: true
         udf_version: udf_version
       properties:
         input_columns:
@@ -7100,6 +7129,26 @@ components:
         udf_version:
           description: Version of the UDF
           type: string
+        udf_backend:
+          description: UDF backend type (e.g. DockerUDFSpecV1)
+          nullable: true
+          type: string
+        auto_backfill:
+          description: Whether to automatically backfill the column after creation
+          nullable: true
+          type: boolean
+        manifest:
+          description: JSON-serialized manifest for the UDF environment
+          nullable: true
+          type: string
+        manifest_checksum:
+          description: SHA-256 checksum of the manifest content
+          nullable: true
+          type: string
+        field_metadata:
+          additionalProperties:
+            type: string
+          description: User-supplied field metadata (string key-value pairs)
       required:
       - data_type
       - image
@@ -7120,6 +7169,9 @@ components:
       - version
     AlterTableAlterColumnsRequest:
       example:
+        identity:
+          api_key: api_key
+          auth_token: auth_token
         alterations:
         - path: path
           nullable: true
@@ -7127,11 +7179,17 @@ components:
           data_type: "{}"
           virtual_column:
             image: image
+            field_metadata:
+              key: field_metadata
+            manifest_checksum: manifest_checksum
             udf: udf
             udf_name: udf_name
+            manifest: manifest
             input_columns:
             - input_columns
             - input_columns
+            udf_backend: udf_backend
+            auto_backfill: true
             udf_version: udf_version
         - path: path
           nullable: true
@@ -7139,16 +7197,24 @@ components:
           data_type: "{}"
           virtual_column:
             image: image
+            field_metadata:
+              key: field_metadata
+            manifest_checksum: manifest_checksum
             udf: udf
             udf_name: udf_name
+            manifest: manifest
             input_columns:
             - input_columns
             - input_columns
+            udf_backend: udf_backend
+            auto_backfill: true
             udf_version: udf_version
         id:
         - id
         - id
       properties:
+        identity:
+          $ref: '#/components/schemas/Identity'
         id:
           description: Table identifier path (namespace + table name)
           items:
@@ -7169,11 +7235,17 @@ components:
         data_type: "{}"
         virtual_column:
           image: image
+          field_metadata:
+            key: field_metadata
+          manifest_checksum: manifest_checksum
           udf: udf
           udf_name: udf_name
+          manifest: manifest
           input_columns:
           - input_columns
           - input_columns
+          udf_backend: udf_backend
+          auto_backfill: true
           udf_version: udf_version
       properties:
         path:
@@ -7198,11 +7270,17 @@ components:
     AlterVirtualColumnEntry:
       example:
         image: image
+        field_metadata:
+          key: field_metadata
+        manifest_checksum: manifest_checksum
         udf: udf
         udf_name: udf_name
+        manifest: manifest
         input_columns:
         - input_columns
         - input_columns
+        udf_backend: udf_backend
+        auto_backfill: true
         udf_version: udf_version
       properties:
         input_columns:
@@ -7227,6 +7305,26 @@ components:
           description: Version of the UDF (optional)
           nullable: true
           type: string
+        udf_backend:
+          description: UDF backend type (e.g. DockerUDFSpecV1) (optional)
+          nullable: true
+          type: string
+        auto_backfill:
+          description: Whether to automatically backfill the column (optional)
+          nullable: true
+          type: boolean
+        manifest:
+          description: JSON-serialized manifest for the UDF environment (optional)
+          nullable: true
+          type: string
+        manifest_checksum:
+          description: SHA-256 checksum of the manifest content (optional)
+          nullable: true
+          type: string
+        field_metadata:
+          additionalProperties:
+            type: string
+          description: User-supplied field metadata (optional)
     AlterTableAlterColumnsResponse:
       example:
         version: 0
@@ -7252,12 +7350,17 @@ components:
         commit_granularity: 2
         task_size: 7
         batch_checkpoint_flush_interval_seconds: 5.637376656633329
+        identity:
+          api_key: api_key
+          auth_token: auth_token
         where: where
         id:
         - id
         - id
         intra_applier_concurrency: 6
       properties:
+        identity:
+          $ref: '#/components/schemas/Identity'
         id:
           description: Table identifier path (namespace + table name)
           items:
@@ -7333,6 +7436,9 @@ components:
       example:
         src_version: 0
         cluster: cluster
+        identity:
+          api_key: api_key
+          auth_token: auth_token
         manifest: manifest
         id:
         - id
@@ -7341,6 +7447,8 @@ components:
         intra_applier_concurrency: 5
         concurrency: 1
       properties:
+        identity:
+          $ref: '#/components/schemas/Identity'
         id:
           description: Table identifier path (namespace + table name)
           items:

--- a/java/lance-namespace-apache-client/docs/AddVirtualColumnEntry.md
+++ b/java/lance-namespace-apache-client/docs/AddVirtualColumnEntry.md
@@ -13,6 +13,11 @@
 |**udf** | **String** | Base64 encoded pickled UDF |  |
 |**udfName** | **String** | Name of the UDF |  |
 |**udfVersion** | **String** | Version of the UDF |  |
+|**udfBackend** | **String** | UDF backend type (e.g. DockerUDFSpecV1) |  [optional] |
+|**autoBackfill** | **Boolean** | Whether to automatically backfill the column after creation |  [optional] |
+|**manifest** | **String** | JSON-serialized manifest for the UDF environment |  [optional] |
+|**manifestChecksum** | **String** | SHA-256 checksum of the manifest content |  [optional] |
+|**fieldMetadata** | **Map&lt;String, String&gt;** | User-supplied field metadata (string key-value pairs) |  [optional] |
 
 
 

--- a/java/lance-namespace-apache-client/docs/AlterTableAddColumnsRequest.md
+++ b/java/lance-namespace-apache-client/docs/AlterTableAddColumnsRequest.md
@@ -7,6 +7,7 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
+|**identity** | [**Identity**](Identity.md) |  |  [optional] |
 |**id** | **List&lt;String&gt;** | Table identifier path (namespace + table name) |  [optional] |
 |**newColumns** | [**List&lt;AddColumnsEntry&gt;**](AddColumnsEntry.md) | List of new columns to add to the table |  |
 

--- a/java/lance-namespace-apache-client/docs/AlterTableAlterColumnsRequest.md
+++ b/java/lance-namespace-apache-client/docs/AlterTableAlterColumnsRequest.md
@@ -7,6 +7,7 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
+|**identity** | [**Identity**](Identity.md) |  |  [optional] |
 |**id** | **List&lt;String&gt;** | Table identifier path (namespace + table name) |  [optional] |
 |**alterations** | [**List&lt;AlterColumnsEntry&gt;**](AlterColumnsEntry.md) | List of column alterations to apply to the table |  |
 

--- a/java/lance-namespace-apache-client/docs/AlterTableBackfillColumnsRequest.md
+++ b/java/lance-namespace-apache-client/docs/AlterTableBackfillColumnsRequest.md
@@ -7,6 +7,7 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
+|**identity** | [**Identity**](Identity.md) |  |  [optional] |
 |**id** | **List&lt;String&gt;** | Table identifier path (namespace + table name) |  [optional] |
 |**column** | **String** | Column name to backfill |  |
 |**where** | **String** | Optional WHERE clause filter |  [optional] |

--- a/java/lance-namespace-apache-client/docs/AlterVirtualColumnEntry.md
+++ b/java/lance-namespace-apache-client/docs/AlterVirtualColumnEntry.md
@@ -12,6 +12,11 @@
 |**udf** | **String** | Base64 encoded pickled UDF (optional) |  [optional] |
 |**udfName** | **String** | Name of the UDF (optional) |  [optional] |
 |**udfVersion** | **String** | Version of the UDF (optional) |  [optional] |
+|**udfBackend** | **String** | UDF backend type (e.g. DockerUDFSpecV1) (optional) |  [optional] |
+|**autoBackfill** | **Boolean** | Whether to automatically backfill the column (optional) |  [optional] |
+|**manifest** | **String** | JSON-serialized manifest for the UDF environment (optional) |  [optional] |
+|**manifestChecksum** | **String** | SHA-256 checksum of the manifest content (optional) |  [optional] |
+|**fieldMetadata** | **Map&lt;String, String&gt;** | User-supplied field metadata (optional) |  [optional] |
 
 
 

--- a/java/lance-namespace-apache-client/docs/RefreshMaterializedViewRequest.md
+++ b/java/lance-namespace-apache-client/docs/RefreshMaterializedViewRequest.md
@@ -7,6 +7,7 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
+|**identity** | [**Identity**](Identity.md) |  |  [optional] |
 |**id** | **List&lt;String&gt;** | Table identifier path (namespace + table name) |  [optional] |
 |**srcVersion** | **Integer** | Optional source version to refresh from |  [optional] |
 |**maxRowsPerFragment** | **Integer** | Optional maximum rows per fragment |  [optional] |

--- a/java/lance-namespace-apache-client/src/main/java/org/lance/namespace/model/AddVirtualColumnEntry.java
+++ b/java/lance-namespace-apache-client/src/main/java/org/lance/namespace/model/AddVirtualColumnEntry.java
@@ -13,14 +13,19 @@
  */
 package org.lance.namespace.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import org.openapitools.jackson.nullable.JsonNullable;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.StringJoiner;
 
@@ -31,7 +36,12 @@ import java.util.StringJoiner;
   AddVirtualColumnEntry.JSON_PROPERTY_IMAGE,
   AddVirtualColumnEntry.JSON_PROPERTY_UDF,
   AddVirtualColumnEntry.JSON_PROPERTY_UDF_NAME,
-  AddVirtualColumnEntry.JSON_PROPERTY_UDF_VERSION
+  AddVirtualColumnEntry.JSON_PROPERTY_UDF_VERSION,
+  AddVirtualColumnEntry.JSON_PROPERTY_UDF_BACKEND,
+  AddVirtualColumnEntry.JSON_PROPERTY_AUTO_BACKFILL,
+  AddVirtualColumnEntry.JSON_PROPERTY_MANIFEST,
+  AddVirtualColumnEntry.JSON_PROPERTY_MANIFEST_CHECKSUM,
+  AddVirtualColumnEntry.JSON_PROPERTY_FIELD_METADATA
 })
 @javax.annotation.Generated(
     value = "org.openapitools.codegen.languages.JavaClientCodegen",
@@ -54,6 +64,29 @@ public class AddVirtualColumnEntry {
 
   public static final String JSON_PROPERTY_UDF_VERSION = "udf_version";
   @javax.annotation.Nonnull private String udfVersion;
+
+  public static final String JSON_PROPERTY_UDF_BACKEND = "udf_backend";
+
+  @javax.annotation.Nullable
+  private JsonNullable<String> udfBackend = JsonNullable.<String>undefined();
+
+  public static final String JSON_PROPERTY_AUTO_BACKFILL = "auto_backfill";
+
+  @javax.annotation.Nullable
+  private JsonNullable<Boolean> autoBackfill = JsonNullable.<Boolean>undefined();
+
+  public static final String JSON_PROPERTY_MANIFEST = "manifest";
+
+  @javax.annotation.Nullable
+  private JsonNullable<String> manifest = JsonNullable.<String>undefined();
+
+  public static final String JSON_PROPERTY_MANIFEST_CHECKSUM = "manifest_checksum";
+
+  @javax.annotation.Nullable
+  private JsonNullable<String> manifestChecksum = JsonNullable.<String>undefined();
+
+  public static final String JSON_PROPERTY_FIELD_METADATA = "field_metadata";
+  @javax.annotation.Nullable private Map<String, String> fieldMetadata = new HashMap<>();
 
   public AddVirtualColumnEntry() {}
 
@@ -209,6 +242,168 @@ public class AddVirtualColumnEntry {
     this.udfVersion = udfVersion;
   }
 
+  public AddVirtualColumnEntry udfBackend(@javax.annotation.Nullable String udfBackend) {
+    this.udfBackend = JsonNullable.<String>of(udfBackend);
+
+    return this;
+  }
+
+  /**
+   * UDF backend type (e.g. DockerUDFSpecV1)
+   *
+   * @return udfBackend
+   */
+  @javax.annotation.Nullable
+  @JsonIgnore
+  public String getUdfBackend() {
+    return udfBackend.orElse(null);
+  }
+
+  @JsonProperty(JSON_PROPERTY_UDF_BACKEND)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public JsonNullable<String> getUdfBackend_JsonNullable() {
+    return udfBackend;
+  }
+
+  @JsonProperty(JSON_PROPERTY_UDF_BACKEND)
+  public void setUdfBackend_JsonNullable(JsonNullable<String> udfBackend) {
+    this.udfBackend = udfBackend;
+  }
+
+  public void setUdfBackend(@javax.annotation.Nullable String udfBackend) {
+    this.udfBackend = JsonNullable.<String>of(udfBackend);
+  }
+
+  public AddVirtualColumnEntry autoBackfill(@javax.annotation.Nullable Boolean autoBackfill) {
+    this.autoBackfill = JsonNullable.<Boolean>of(autoBackfill);
+
+    return this;
+  }
+
+  /**
+   * Whether to automatically backfill the column after creation
+   *
+   * @return autoBackfill
+   */
+  @javax.annotation.Nullable
+  @JsonIgnore
+  public Boolean getAutoBackfill() {
+    return autoBackfill.orElse(null);
+  }
+
+  @JsonProperty(JSON_PROPERTY_AUTO_BACKFILL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public JsonNullable<Boolean> getAutoBackfill_JsonNullable() {
+    return autoBackfill;
+  }
+
+  @JsonProperty(JSON_PROPERTY_AUTO_BACKFILL)
+  public void setAutoBackfill_JsonNullable(JsonNullable<Boolean> autoBackfill) {
+    this.autoBackfill = autoBackfill;
+  }
+
+  public void setAutoBackfill(@javax.annotation.Nullable Boolean autoBackfill) {
+    this.autoBackfill = JsonNullable.<Boolean>of(autoBackfill);
+  }
+
+  public AddVirtualColumnEntry manifest(@javax.annotation.Nullable String manifest) {
+    this.manifest = JsonNullable.<String>of(manifest);
+
+    return this;
+  }
+
+  /**
+   * JSON-serialized manifest for the UDF environment
+   *
+   * @return manifest
+   */
+  @javax.annotation.Nullable
+  @JsonIgnore
+  public String getManifest() {
+    return manifest.orElse(null);
+  }
+
+  @JsonProperty(JSON_PROPERTY_MANIFEST)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public JsonNullable<String> getManifest_JsonNullable() {
+    return manifest;
+  }
+
+  @JsonProperty(JSON_PROPERTY_MANIFEST)
+  public void setManifest_JsonNullable(JsonNullable<String> manifest) {
+    this.manifest = manifest;
+  }
+
+  public void setManifest(@javax.annotation.Nullable String manifest) {
+    this.manifest = JsonNullable.<String>of(manifest);
+  }
+
+  public AddVirtualColumnEntry manifestChecksum(
+      @javax.annotation.Nullable String manifestChecksum) {
+    this.manifestChecksum = JsonNullable.<String>of(manifestChecksum);
+
+    return this;
+  }
+
+  /**
+   * SHA-256 checksum of the manifest content
+   *
+   * @return manifestChecksum
+   */
+  @javax.annotation.Nullable
+  @JsonIgnore
+  public String getManifestChecksum() {
+    return manifestChecksum.orElse(null);
+  }
+
+  @JsonProperty(JSON_PROPERTY_MANIFEST_CHECKSUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public JsonNullable<String> getManifestChecksum_JsonNullable() {
+    return manifestChecksum;
+  }
+
+  @JsonProperty(JSON_PROPERTY_MANIFEST_CHECKSUM)
+  public void setManifestChecksum_JsonNullable(JsonNullable<String> manifestChecksum) {
+    this.manifestChecksum = manifestChecksum;
+  }
+
+  public void setManifestChecksum(@javax.annotation.Nullable String manifestChecksum) {
+    this.manifestChecksum = JsonNullable.<String>of(manifestChecksum);
+  }
+
+  public AddVirtualColumnEntry fieldMetadata(
+      @javax.annotation.Nullable Map<String, String> fieldMetadata) {
+
+    this.fieldMetadata = fieldMetadata;
+    return this;
+  }
+
+  public AddVirtualColumnEntry putFieldMetadataItem(String key, String fieldMetadataItem) {
+    if (this.fieldMetadata == null) {
+      this.fieldMetadata = new HashMap<>();
+    }
+    this.fieldMetadata.put(key, fieldMetadataItem);
+    return this;
+  }
+
+  /**
+   * User-supplied field metadata (string key-value pairs)
+   *
+   * @return fieldMetadata
+   */
+  @javax.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_FIELD_METADATA)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public Map<String, String> getFieldMetadata() {
+    return fieldMetadata;
+  }
+
+  @JsonProperty(JSON_PROPERTY_FIELD_METADATA)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setFieldMetadata(@javax.annotation.Nullable Map<String, String> fieldMetadata) {
+    this.fieldMetadata = fieldMetadata;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -223,12 +418,44 @@ public class AddVirtualColumnEntry {
         && Objects.equals(this.image, addVirtualColumnEntry.image)
         && Objects.equals(this.udf, addVirtualColumnEntry.udf)
         && Objects.equals(this.udfName, addVirtualColumnEntry.udfName)
-        && Objects.equals(this.udfVersion, addVirtualColumnEntry.udfVersion);
+        && Objects.equals(this.udfVersion, addVirtualColumnEntry.udfVersion)
+        && equalsNullable(this.udfBackend, addVirtualColumnEntry.udfBackend)
+        && equalsNullable(this.autoBackfill, addVirtualColumnEntry.autoBackfill)
+        && equalsNullable(this.manifest, addVirtualColumnEntry.manifest)
+        && equalsNullable(this.manifestChecksum, addVirtualColumnEntry.manifestChecksum)
+        && Objects.equals(this.fieldMetadata, addVirtualColumnEntry.fieldMetadata);
+  }
+
+  private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
+    return a == b
+        || (a != null
+            && b != null
+            && a.isPresent()
+            && b.isPresent()
+            && Objects.deepEquals(a.get(), b.get()));
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(inputColumns, dataType, image, udf, udfName, udfVersion);
+    return Objects.hash(
+        inputColumns,
+        dataType,
+        image,
+        udf,
+        udfName,
+        udfVersion,
+        hashCodeNullable(udfBackend),
+        hashCodeNullable(autoBackfill),
+        hashCodeNullable(manifest),
+        hashCodeNullable(manifestChecksum),
+        fieldMetadata);
+  }
+
+  private static <T> int hashCodeNullable(JsonNullable<T> a) {
+    if (a == null) {
+      return 1;
+    }
+    return a.isPresent() ? Arrays.deepHashCode(new Object[] {a.get()}) : 31;
   }
 
   @Override
@@ -241,6 +468,11 @@ public class AddVirtualColumnEntry {
     sb.append("    udf: ").append(toIndentedString(udf)).append("\n");
     sb.append("    udfName: ").append(toIndentedString(udfName)).append("\n");
     sb.append("    udfVersion: ").append(toIndentedString(udfVersion)).append("\n");
+    sb.append("    udfBackend: ").append(toIndentedString(udfBackend)).append("\n");
+    sb.append("    autoBackfill: ").append(toIndentedString(autoBackfill)).append("\n");
+    sb.append("    manifest: ").append(toIndentedString(manifest)).append("\n");
+    sb.append("    manifestChecksum: ").append(toIndentedString(manifestChecksum)).append("\n");
+    sb.append("    fieldMetadata: ").append(toIndentedString(fieldMetadata)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -382,6 +614,92 @@ public class AddVirtualColumnEntry {
       } catch (UnsupportedEncodingException e) {
         // Should never happen, UTF-8 is always supported
         throw new RuntimeException(e);
+      }
+    }
+
+    // add `udf_backend` to the URL query string
+    if (getUdfBackend() != null) {
+      try {
+        joiner.add(
+            String.format(
+                "%sudf_backend%s=%s",
+                prefix,
+                suffix,
+                URLEncoder.encode(String.valueOf(getUdfBackend()), "UTF-8")
+                    .replaceAll("\\+", "%20")));
+      } catch (UnsupportedEncodingException e) {
+        // Should never happen, UTF-8 is always supported
+        throw new RuntimeException(e);
+      }
+    }
+
+    // add `auto_backfill` to the URL query string
+    if (getAutoBackfill() != null) {
+      try {
+        joiner.add(
+            String.format(
+                "%sauto_backfill%s=%s",
+                prefix,
+                suffix,
+                URLEncoder.encode(String.valueOf(getAutoBackfill()), "UTF-8")
+                    .replaceAll("\\+", "%20")));
+      } catch (UnsupportedEncodingException e) {
+        // Should never happen, UTF-8 is always supported
+        throw new RuntimeException(e);
+      }
+    }
+
+    // add `manifest` to the URL query string
+    if (getManifest() != null) {
+      try {
+        joiner.add(
+            String.format(
+                "%smanifest%s=%s",
+                prefix,
+                suffix,
+                URLEncoder.encode(String.valueOf(getManifest()), "UTF-8")
+                    .replaceAll("\\+", "%20")));
+      } catch (UnsupportedEncodingException e) {
+        // Should never happen, UTF-8 is always supported
+        throw new RuntimeException(e);
+      }
+    }
+
+    // add `manifest_checksum` to the URL query string
+    if (getManifestChecksum() != null) {
+      try {
+        joiner.add(
+            String.format(
+                "%smanifest_checksum%s=%s",
+                prefix,
+                suffix,
+                URLEncoder.encode(String.valueOf(getManifestChecksum()), "UTF-8")
+                    .replaceAll("\\+", "%20")));
+      } catch (UnsupportedEncodingException e) {
+        // Should never happen, UTF-8 is always supported
+        throw new RuntimeException(e);
+      }
+    }
+
+    // add `field_metadata` to the URL query string
+    if (getFieldMetadata() != null) {
+      for (String _key : getFieldMetadata().keySet()) {
+        try {
+          joiner.add(
+              String.format(
+                  "%sfield_metadata%s%s=%s",
+                  prefix,
+                  suffix,
+                  "".equals(suffix)
+                      ? ""
+                      : String.format("%s%d%s", containerPrefix, _key, containerSuffix),
+                  getFieldMetadata().get(_key),
+                  URLEncoder.encode(String.valueOf(getFieldMetadata().get(_key)), "UTF-8")
+                      .replaceAll("\\+", "%20")));
+        } catch (UnsupportedEncodingException e) {
+          // Should never happen, UTF-8 is always supported
+          throw new RuntimeException(e);
+        }
       }
     }
 

--- a/java/lance-namespace-apache-client/src/main/java/org/lance/namespace/model/AlterTableAddColumnsRequest.java
+++ b/java/lance-namespace-apache-client/src/main/java/org/lance/namespace/model/AlterTableAddColumnsRequest.java
@@ -26,6 +26,7 @@ import java.util.StringJoiner;
 
 /** AlterTableAddColumnsRequest */
 @JsonPropertyOrder({
+  AlterTableAddColumnsRequest.JSON_PROPERTY_IDENTITY,
   AlterTableAddColumnsRequest.JSON_PROPERTY_ID,
   AlterTableAddColumnsRequest.JSON_PROPERTY_NEW_COLUMNS
 })
@@ -33,6 +34,9 @@ import java.util.StringJoiner;
     value = "org.openapitools.codegen.languages.JavaClientCodegen",
     comments = "Generator version: 7.12.0")
 public class AlterTableAddColumnsRequest {
+  public static final String JSON_PROPERTY_IDENTITY = "identity";
+  @javax.annotation.Nullable private Identity identity;
+
   public static final String JSON_PROPERTY_ID = "id";
   @javax.annotation.Nullable private List<String> id = new ArrayList<>();
 
@@ -40,6 +44,30 @@ public class AlterTableAddColumnsRequest {
   @javax.annotation.Nonnull private List<AddColumnsEntry> newColumns = new ArrayList<>();
 
   public AlterTableAddColumnsRequest() {}
+
+  public AlterTableAddColumnsRequest identity(@javax.annotation.Nullable Identity identity) {
+
+    this.identity = identity;
+    return this;
+  }
+
+  /**
+   * Get identity
+   *
+   * @return identity
+   */
+  @javax.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_IDENTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public Identity getIdentity() {
+    return identity;
+  }
+
+  @JsonProperty(JSON_PROPERTY_IDENTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setIdentity(@javax.annotation.Nullable Identity identity) {
+    this.identity = identity;
+  }
 
   public AlterTableAddColumnsRequest id(@javax.annotation.Nullable List<String> id) {
 
@@ -115,19 +143,21 @@ public class AlterTableAddColumnsRequest {
       return false;
     }
     AlterTableAddColumnsRequest alterTableAddColumnsRequest = (AlterTableAddColumnsRequest) o;
-    return Objects.equals(this.id, alterTableAddColumnsRequest.id)
+    return Objects.equals(this.identity, alterTableAddColumnsRequest.identity)
+        && Objects.equals(this.id, alterTableAddColumnsRequest.id)
         && Objects.equals(this.newColumns, alterTableAddColumnsRequest.newColumns);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, newColumns);
+    return Objects.hash(identity, id, newColumns);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class AlterTableAddColumnsRequest {\n");
+    sb.append("    identity: ").append(toIndentedString(identity)).append("\n");
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    newColumns: ").append(toIndentedString(newColumns)).append("\n");
     sb.append("}");
@@ -175,6 +205,11 @@ public class AlterTableAddColumnsRequest {
     }
 
     StringJoiner joiner = new StringJoiner("&");
+
+    // add `identity` to the URL query string
+    if (getIdentity() != null) {
+      joiner.add(getIdentity().toUrlQueryString(prefix + "identity" + suffix));
+    }
 
     // add `id` to the URL query string
     if (getId() != null) {

--- a/java/lance-namespace-apache-client/src/main/java/org/lance/namespace/model/AlterTableAlterColumnsRequest.java
+++ b/java/lance-namespace-apache-client/src/main/java/org/lance/namespace/model/AlterTableAlterColumnsRequest.java
@@ -26,6 +26,7 @@ import java.util.StringJoiner;
 
 /** AlterTableAlterColumnsRequest */
 @JsonPropertyOrder({
+  AlterTableAlterColumnsRequest.JSON_PROPERTY_IDENTITY,
   AlterTableAlterColumnsRequest.JSON_PROPERTY_ID,
   AlterTableAlterColumnsRequest.JSON_PROPERTY_ALTERATIONS
 })
@@ -33,6 +34,9 @@ import java.util.StringJoiner;
     value = "org.openapitools.codegen.languages.JavaClientCodegen",
     comments = "Generator version: 7.12.0")
 public class AlterTableAlterColumnsRequest {
+  public static final String JSON_PROPERTY_IDENTITY = "identity";
+  @javax.annotation.Nullable private Identity identity;
+
   public static final String JSON_PROPERTY_ID = "id";
   @javax.annotation.Nullable private List<String> id = new ArrayList<>();
 
@@ -40,6 +44,30 @@ public class AlterTableAlterColumnsRequest {
   @javax.annotation.Nonnull private List<AlterColumnsEntry> alterations = new ArrayList<>();
 
   public AlterTableAlterColumnsRequest() {}
+
+  public AlterTableAlterColumnsRequest identity(@javax.annotation.Nullable Identity identity) {
+
+    this.identity = identity;
+    return this;
+  }
+
+  /**
+   * Get identity
+   *
+   * @return identity
+   */
+  @javax.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_IDENTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public Identity getIdentity() {
+    return identity;
+  }
+
+  @JsonProperty(JSON_PROPERTY_IDENTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setIdentity(@javax.annotation.Nullable Identity identity) {
+    this.identity = identity;
+  }
 
   public AlterTableAlterColumnsRequest id(@javax.annotation.Nullable List<String> id) {
 
@@ -115,19 +143,21 @@ public class AlterTableAlterColumnsRequest {
       return false;
     }
     AlterTableAlterColumnsRequest alterTableAlterColumnsRequest = (AlterTableAlterColumnsRequest) o;
-    return Objects.equals(this.id, alterTableAlterColumnsRequest.id)
+    return Objects.equals(this.identity, alterTableAlterColumnsRequest.identity)
+        && Objects.equals(this.id, alterTableAlterColumnsRequest.id)
         && Objects.equals(this.alterations, alterTableAlterColumnsRequest.alterations);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, alterations);
+    return Objects.hash(identity, id, alterations);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class AlterTableAlterColumnsRequest {\n");
+    sb.append("    identity: ").append(toIndentedString(identity)).append("\n");
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    alterations: ").append(toIndentedString(alterations)).append("\n");
     sb.append("}");
@@ -175,6 +205,11 @@ public class AlterTableAlterColumnsRequest {
     }
 
     StringJoiner joiner = new StringJoiner("&");
+
+    // add `identity` to the URL query string
+    if (getIdentity() != null) {
+      joiner.add(getIdentity().toUrlQueryString(prefix + "identity" + suffix));
+    }
 
     // add `id` to the URL query string
     if (getId() != null) {

--- a/java/lance-namespace-apache-client/src/main/java/org/lance/namespace/model/AlterTableBackfillColumnsRequest.java
+++ b/java/lance-namespace-apache-client/src/main/java/org/lance/namespace/model/AlterTableBackfillColumnsRequest.java
@@ -30,6 +30,7 @@ import java.util.StringJoiner;
 
 /** AlterTableBackfillColumnsRequest */
 @JsonPropertyOrder({
+  AlterTableBackfillColumnsRequest.JSON_PROPERTY_IDENTITY,
   AlterTableBackfillColumnsRequest.JSON_PROPERTY_ID,
   AlterTableBackfillColumnsRequest.JSON_PROPERTY_COLUMN,
   AlterTableBackfillColumnsRequest.JSON_PROPERTY_WHERE,
@@ -50,6 +51,9 @@ import java.util.StringJoiner;
     value = "org.openapitools.codegen.languages.JavaClientCodegen",
     comments = "Generator version: 7.12.0")
 public class AlterTableBackfillColumnsRequest {
+  public static final String JSON_PROPERTY_IDENTITY = "identity";
+  @javax.annotation.Nullable private Identity identity;
+
   public static final String JSON_PROPERTY_ID = "id";
   @javax.annotation.Nullable private List<String> id = new ArrayList<>();
 
@@ -122,6 +126,30 @@ public class AlterTableBackfillColumnsRequest {
   private JsonNullable<String> manifest = JsonNullable.<String>undefined();
 
   public AlterTableBackfillColumnsRequest() {}
+
+  public AlterTableBackfillColumnsRequest identity(@javax.annotation.Nullable Identity identity) {
+
+    this.identity = identity;
+    return this;
+  }
+
+  /**
+   * Get identity
+   *
+   * @return identity
+   */
+  @javax.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_IDENTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public Identity getIdentity() {
+    return identity;
+  }
+
+  @JsonProperty(JSON_PROPERTY_IDENTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setIdentity(@javax.annotation.Nullable Identity identity) {
+    this.identity = identity;
+  }
 
   public AlterTableBackfillColumnsRequest id(@javax.annotation.Nullable List<String> id) {
 
@@ -619,7 +647,8 @@ public class AlterTableBackfillColumnsRequest {
     }
     AlterTableBackfillColumnsRequest alterTableBackfillColumnsRequest =
         (AlterTableBackfillColumnsRequest) o;
-    return Objects.equals(this.id, alterTableBackfillColumnsRequest.id)
+    return Objects.equals(this.identity, alterTableBackfillColumnsRequest.identity)
+        && Objects.equals(this.id, alterTableBackfillColumnsRequest.id)
         && Objects.equals(this.column, alterTableBackfillColumnsRequest.column)
         && equalsNullable(this.where, alterTableBackfillColumnsRequest.where)
         && equalsNullable(this.concurrency, alterTableBackfillColumnsRequest.concurrency)
@@ -654,6 +683,7 @@ public class AlterTableBackfillColumnsRequest {
   @Override
   public int hashCode() {
     return Objects.hash(
+        identity,
         id,
         column,
         hashCodeNullable(where),
@@ -682,6 +712,7 @@ public class AlterTableBackfillColumnsRequest {
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class AlterTableBackfillColumnsRequest {\n");
+    sb.append("    identity: ").append(toIndentedString(identity)).append("\n");
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    column: ").append(toIndentedString(column)).append("\n");
     sb.append("    where: ").append(toIndentedString(where)).append("\n");
@@ -746,6 +777,11 @@ public class AlterTableBackfillColumnsRequest {
     }
 
     StringJoiner joiner = new StringJoiner("&");
+
+    // add `identity` to the URL query string
+    if (getIdentity() != null) {
+      joiner.add(getIdentity().toUrlQueryString(prefix + "identity" + suffix));
+    }
 
     // add `id` to the URL query string
     if (getId() != null) {

--- a/java/lance-namespace-apache-client/src/main/java/org/lance/namespace/model/AlterVirtualColumnEntry.java
+++ b/java/lance-namespace-apache-client/src/main/java/org/lance/namespace/model/AlterVirtualColumnEntry.java
@@ -23,7 +23,9 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.StringJoiner;
 
@@ -33,7 +35,12 @@ import java.util.StringJoiner;
   AlterVirtualColumnEntry.JSON_PROPERTY_IMAGE,
   AlterVirtualColumnEntry.JSON_PROPERTY_UDF,
   AlterVirtualColumnEntry.JSON_PROPERTY_UDF_NAME,
-  AlterVirtualColumnEntry.JSON_PROPERTY_UDF_VERSION
+  AlterVirtualColumnEntry.JSON_PROPERTY_UDF_VERSION,
+  AlterVirtualColumnEntry.JSON_PROPERTY_UDF_BACKEND,
+  AlterVirtualColumnEntry.JSON_PROPERTY_AUTO_BACKFILL,
+  AlterVirtualColumnEntry.JSON_PROPERTY_MANIFEST,
+  AlterVirtualColumnEntry.JSON_PROPERTY_MANIFEST_CHECKSUM,
+  AlterVirtualColumnEntry.JSON_PROPERTY_FIELD_METADATA
 })
 @javax.annotation.Generated(
     value = "org.openapitools.codegen.languages.JavaClientCodegen",
@@ -59,6 +66,29 @@ public class AlterVirtualColumnEntry {
 
   @javax.annotation.Nullable
   private JsonNullable<String> udfVersion = JsonNullable.<String>undefined();
+
+  public static final String JSON_PROPERTY_UDF_BACKEND = "udf_backend";
+
+  @javax.annotation.Nullable
+  private JsonNullable<String> udfBackend = JsonNullable.<String>undefined();
+
+  public static final String JSON_PROPERTY_AUTO_BACKFILL = "auto_backfill";
+
+  @javax.annotation.Nullable
+  private JsonNullable<Boolean> autoBackfill = JsonNullable.<Boolean>undefined();
+
+  public static final String JSON_PROPERTY_MANIFEST = "manifest";
+
+  @javax.annotation.Nullable
+  private JsonNullable<String> manifest = JsonNullable.<String>undefined();
+
+  public static final String JSON_PROPERTY_MANIFEST_CHECKSUM = "manifest_checksum";
+
+  @javax.annotation.Nullable
+  private JsonNullable<String> manifestChecksum = JsonNullable.<String>undefined();
+
+  public static final String JSON_PROPERTY_FIELD_METADATA = "field_metadata";
+  @javax.annotation.Nullable private Map<String, String> fieldMetadata = new HashMap<>();
 
   public AlterVirtualColumnEntry() {}
 
@@ -235,6 +265,168 @@ public class AlterVirtualColumnEntry {
     this.udfVersion = JsonNullable.<String>of(udfVersion);
   }
 
+  public AlterVirtualColumnEntry udfBackend(@javax.annotation.Nullable String udfBackend) {
+    this.udfBackend = JsonNullable.<String>of(udfBackend);
+
+    return this;
+  }
+
+  /**
+   * UDF backend type (e.g. DockerUDFSpecV1) (optional)
+   *
+   * @return udfBackend
+   */
+  @javax.annotation.Nullable
+  @JsonIgnore
+  public String getUdfBackend() {
+    return udfBackend.orElse(null);
+  }
+
+  @JsonProperty(JSON_PROPERTY_UDF_BACKEND)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public JsonNullable<String> getUdfBackend_JsonNullable() {
+    return udfBackend;
+  }
+
+  @JsonProperty(JSON_PROPERTY_UDF_BACKEND)
+  public void setUdfBackend_JsonNullable(JsonNullable<String> udfBackend) {
+    this.udfBackend = udfBackend;
+  }
+
+  public void setUdfBackend(@javax.annotation.Nullable String udfBackend) {
+    this.udfBackend = JsonNullable.<String>of(udfBackend);
+  }
+
+  public AlterVirtualColumnEntry autoBackfill(@javax.annotation.Nullable Boolean autoBackfill) {
+    this.autoBackfill = JsonNullable.<Boolean>of(autoBackfill);
+
+    return this;
+  }
+
+  /**
+   * Whether to automatically backfill the column (optional)
+   *
+   * @return autoBackfill
+   */
+  @javax.annotation.Nullable
+  @JsonIgnore
+  public Boolean getAutoBackfill() {
+    return autoBackfill.orElse(null);
+  }
+
+  @JsonProperty(JSON_PROPERTY_AUTO_BACKFILL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public JsonNullable<Boolean> getAutoBackfill_JsonNullable() {
+    return autoBackfill;
+  }
+
+  @JsonProperty(JSON_PROPERTY_AUTO_BACKFILL)
+  public void setAutoBackfill_JsonNullable(JsonNullable<Boolean> autoBackfill) {
+    this.autoBackfill = autoBackfill;
+  }
+
+  public void setAutoBackfill(@javax.annotation.Nullable Boolean autoBackfill) {
+    this.autoBackfill = JsonNullable.<Boolean>of(autoBackfill);
+  }
+
+  public AlterVirtualColumnEntry manifest(@javax.annotation.Nullable String manifest) {
+    this.manifest = JsonNullable.<String>of(manifest);
+
+    return this;
+  }
+
+  /**
+   * JSON-serialized manifest for the UDF environment (optional)
+   *
+   * @return manifest
+   */
+  @javax.annotation.Nullable
+  @JsonIgnore
+  public String getManifest() {
+    return manifest.orElse(null);
+  }
+
+  @JsonProperty(JSON_PROPERTY_MANIFEST)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public JsonNullable<String> getManifest_JsonNullable() {
+    return manifest;
+  }
+
+  @JsonProperty(JSON_PROPERTY_MANIFEST)
+  public void setManifest_JsonNullable(JsonNullable<String> manifest) {
+    this.manifest = manifest;
+  }
+
+  public void setManifest(@javax.annotation.Nullable String manifest) {
+    this.manifest = JsonNullable.<String>of(manifest);
+  }
+
+  public AlterVirtualColumnEntry manifestChecksum(
+      @javax.annotation.Nullable String manifestChecksum) {
+    this.manifestChecksum = JsonNullable.<String>of(manifestChecksum);
+
+    return this;
+  }
+
+  /**
+   * SHA-256 checksum of the manifest content (optional)
+   *
+   * @return manifestChecksum
+   */
+  @javax.annotation.Nullable
+  @JsonIgnore
+  public String getManifestChecksum() {
+    return manifestChecksum.orElse(null);
+  }
+
+  @JsonProperty(JSON_PROPERTY_MANIFEST_CHECKSUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public JsonNullable<String> getManifestChecksum_JsonNullable() {
+    return manifestChecksum;
+  }
+
+  @JsonProperty(JSON_PROPERTY_MANIFEST_CHECKSUM)
+  public void setManifestChecksum_JsonNullable(JsonNullable<String> manifestChecksum) {
+    this.manifestChecksum = manifestChecksum;
+  }
+
+  public void setManifestChecksum(@javax.annotation.Nullable String manifestChecksum) {
+    this.manifestChecksum = JsonNullable.<String>of(manifestChecksum);
+  }
+
+  public AlterVirtualColumnEntry fieldMetadata(
+      @javax.annotation.Nullable Map<String, String> fieldMetadata) {
+
+    this.fieldMetadata = fieldMetadata;
+    return this;
+  }
+
+  public AlterVirtualColumnEntry putFieldMetadataItem(String key, String fieldMetadataItem) {
+    if (this.fieldMetadata == null) {
+      this.fieldMetadata = new HashMap<>();
+    }
+    this.fieldMetadata.put(key, fieldMetadataItem);
+    return this;
+  }
+
+  /**
+   * User-supplied field metadata (optional)
+   *
+   * @return fieldMetadata
+   */
+  @javax.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_FIELD_METADATA)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public Map<String, String> getFieldMetadata() {
+    return fieldMetadata;
+  }
+
+  @JsonProperty(JSON_PROPERTY_FIELD_METADATA)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setFieldMetadata(@javax.annotation.Nullable Map<String, String> fieldMetadata) {
+    this.fieldMetadata = fieldMetadata;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -248,7 +440,12 @@ public class AlterVirtualColumnEntry {
         && equalsNullable(this.image, alterVirtualColumnEntry.image)
         && equalsNullable(this.udf, alterVirtualColumnEntry.udf)
         && equalsNullable(this.udfName, alterVirtualColumnEntry.udfName)
-        && equalsNullable(this.udfVersion, alterVirtualColumnEntry.udfVersion);
+        && equalsNullable(this.udfVersion, alterVirtualColumnEntry.udfVersion)
+        && equalsNullable(this.udfBackend, alterVirtualColumnEntry.udfBackend)
+        && equalsNullable(this.autoBackfill, alterVirtualColumnEntry.autoBackfill)
+        && equalsNullable(this.manifest, alterVirtualColumnEntry.manifest)
+        && equalsNullable(this.manifestChecksum, alterVirtualColumnEntry.manifestChecksum)
+        && Objects.equals(this.fieldMetadata, alterVirtualColumnEntry.fieldMetadata);
   }
 
   private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
@@ -267,7 +464,12 @@ public class AlterVirtualColumnEntry {
         hashCodeNullable(image),
         hashCodeNullable(udf),
         hashCodeNullable(udfName),
-        hashCodeNullable(udfVersion));
+        hashCodeNullable(udfVersion),
+        hashCodeNullable(udfBackend),
+        hashCodeNullable(autoBackfill),
+        hashCodeNullable(manifest),
+        hashCodeNullable(manifestChecksum),
+        fieldMetadata);
   }
 
   private static <T> int hashCodeNullable(JsonNullable<T> a) {
@@ -286,6 +488,11 @@ public class AlterVirtualColumnEntry {
     sb.append("    udf: ").append(toIndentedString(udf)).append("\n");
     sb.append("    udfName: ").append(toIndentedString(udfName)).append("\n");
     sb.append("    udfVersion: ").append(toIndentedString(udfVersion)).append("\n");
+    sb.append("    udfBackend: ").append(toIndentedString(udfBackend)).append("\n");
+    sb.append("    autoBackfill: ").append(toIndentedString(autoBackfill)).append("\n");
+    sb.append("    manifest: ").append(toIndentedString(manifest)).append("\n");
+    sb.append("    manifestChecksum: ").append(toIndentedString(manifestChecksum)).append("\n");
+    sb.append("    fieldMetadata: ").append(toIndentedString(fieldMetadata)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -411,6 +618,92 @@ public class AlterVirtualColumnEntry {
       } catch (UnsupportedEncodingException e) {
         // Should never happen, UTF-8 is always supported
         throw new RuntimeException(e);
+      }
+    }
+
+    // add `udf_backend` to the URL query string
+    if (getUdfBackend() != null) {
+      try {
+        joiner.add(
+            String.format(
+                "%sudf_backend%s=%s",
+                prefix,
+                suffix,
+                URLEncoder.encode(String.valueOf(getUdfBackend()), "UTF-8")
+                    .replaceAll("\\+", "%20")));
+      } catch (UnsupportedEncodingException e) {
+        // Should never happen, UTF-8 is always supported
+        throw new RuntimeException(e);
+      }
+    }
+
+    // add `auto_backfill` to the URL query string
+    if (getAutoBackfill() != null) {
+      try {
+        joiner.add(
+            String.format(
+                "%sauto_backfill%s=%s",
+                prefix,
+                suffix,
+                URLEncoder.encode(String.valueOf(getAutoBackfill()), "UTF-8")
+                    .replaceAll("\\+", "%20")));
+      } catch (UnsupportedEncodingException e) {
+        // Should never happen, UTF-8 is always supported
+        throw new RuntimeException(e);
+      }
+    }
+
+    // add `manifest` to the URL query string
+    if (getManifest() != null) {
+      try {
+        joiner.add(
+            String.format(
+                "%smanifest%s=%s",
+                prefix,
+                suffix,
+                URLEncoder.encode(String.valueOf(getManifest()), "UTF-8")
+                    .replaceAll("\\+", "%20")));
+      } catch (UnsupportedEncodingException e) {
+        // Should never happen, UTF-8 is always supported
+        throw new RuntimeException(e);
+      }
+    }
+
+    // add `manifest_checksum` to the URL query string
+    if (getManifestChecksum() != null) {
+      try {
+        joiner.add(
+            String.format(
+                "%smanifest_checksum%s=%s",
+                prefix,
+                suffix,
+                URLEncoder.encode(String.valueOf(getManifestChecksum()), "UTF-8")
+                    .replaceAll("\\+", "%20")));
+      } catch (UnsupportedEncodingException e) {
+        // Should never happen, UTF-8 is always supported
+        throw new RuntimeException(e);
+      }
+    }
+
+    // add `field_metadata` to the URL query string
+    if (getFieldMetadata() != null) {
+      for (String _key : getFieldMetadata().keySet()) {
+        try {
+          joiner.add(
+              String.format(
+                  "%sfield_metadata%s%s=%s",
+                  prefix,
+                  suffix,
+                  "".equals(suffix)
+                      ? ""
+                      : String.format("%s%d%s", containerPrefix, _key, containerSuffix),
+                  getFieldMetadata().get(_key),
+                  URLEncoder.encode(String.valueOf(getFieldMetadata().get(_key)), "UTF-8")
+                      .replaceAll("\\+", "%20")));
+        } catch (UnsupportedEncodingException e) {
+          // Should never happen, UTF-8 is always supported
+          throw new RuntimeException(e);
+        }
       }
     }
 

--- a/java/lance-namespace-apache-client/src/main/java/org/lance/namespace/model/RefreshMaterializedViewRequest.java
+++ b/java/lance-namespace-apache-client/src/main/java/org/lance/namespace/model/RefreshMaterializedViewRequest.java
@@ -29,6 +29,7 @@ import java.util.StringJoiner;
 
 /** RefreshMaterializedViewRequest */
 @JsonPropertyOrder({
+  RefreshMaterializedViewRequest.JSON_PROPERTY_IDENTITY,
   RefreshMaterializedViewRequest.JSON_PROPERTY_ID,
   RefreshMaterializedViewRequest.JSON_PROPERTY_SRC_VERSION,
   RefreshMaterializedViewRequest.JSON_PROPERTY_MAX_ROWS_PER_FRAGMENT,
@@ -41,6 +42,9 @@ import java.util.StringJoiner;
     value = "org.openapitools.codegen.languages.JavaClientCodegen",
     comments = "Generator version: 7.12.0")
 public class RefreshMaterializedViewRequest {
+  public static final String JSON_PROPERTY_IDENTITY = "identity";
+  @javax.annotation.Nullable private Identity identity;
+
   public static final String JSON_PROPERTY_ID = "id";
   @javax.annotation.Nullable private List<String> id = new ArrayList<>();
 
@@ -75,6 +79,30 @@ public class RefreshMaterializedViewRequest {
   private JsonNullable<String> manifest = JsonNullable.<String>undefined();
 
   public RefreshMaterializedViewRequest() {}
+
+  public RefreshMaterializedViewRequest identity(@javax.annotation.Nullable Identity identity) {
+
+    this.identity = identity;
+    return this;
+  }
+
+  /**
+   * Get identity
+   *
+   * @return identity
+   */
+  @javax.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_IDENTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public Identity getIdentity() {
+    return identity;
+  }
+
+  @JsonProperty(JSON_PROPERTY_IDENTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setIdentity(@javax.annotation.Nullable Identity identity) {
+    this.identity = identity;
+  }
 
   public RefreshMaterializedViewRequest id(@javax.annotation.Nullable List<String> id) {
 
@@ -315,7 +343,8 @@ public class RefreshMaterializedViewRequest {
     }
     RefreshMaterializedViewRequest refreshMaterializedViewRequest =
         (RefreshMaterializedViewRequest) o;
-    return Objects.equals(this.id, refreshMaterializedViewRequest.id)
+    return Objects.equals(this.identity, refreshMaterializedViewRequest.identity)
+        && Objects.equals(this.id, refreshMaterializedViewRequest.id)
         && equalsNullable(this.srcVersion, refreshMaterializedViewRequest.srcVersion)
         && equalsNullable(
             this.maxRowsPerFragment, refreshMaterializedViewRequest.maxRowsPerFragment)
@@ -338,6 +367,7 @@ public class RefreshMaterializedViewRequest {
   @Override
   public int hashCode() {
     return Objects.hash(
+        identity,
         id,
         hashCodeNullable(srcVersion),
         hashCodeNullable(maxRowsPerFragment),
@@ -358,6 +388,7 @@ public class RefreshMaterializedViewRequest {
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class RefreshMaterializedViewRequest {\n");
+    sb.append("    identity: ").append(toIndentedString(identity)).append("\n");
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    srcVersion: ").append(toIndentedString(srcVersion)).append("\n");
     sb.append("    maxRowsPerFragment: ").append(toIndentedString(maxRowsPerFragment)).append("\n");
@@ -412,6 +443,11 @@ public class RefreshMaterializedViewRequest {
     }
 
     StringJoiner joiner = new StringJoiner("&");
+
+    // add `identity` to the URL query string
+    if (getIdentity() != null) {
+      joiner.add(getIdentity().toUrlQueryString(prefix + "identity" + suffix));
+    }
 
     // add `id` to the URL query string
     if (getId() != null) {

--- a/java/lance-namespace-async-client/api/openapi.yaml
+++ b/java/lance-namespace-async-client/api/openapi.yaml
@@ -7004,33 +7004,50 @@ components:
       - analysis
     AlterTableAddColumnsRequest:
       example:
+        identity:
+          api_key: api_key
+          auth_token: auth_token
         new_columns:
         - expression: expression
           name: name
           virtual_column:
             image: image
+            field_metadata:
+              key: field_metadata
+            manifest_checksum: manifest_checksum
             udf: udf
             udf_name: udf_name
+            manifest: manifest
             input_columns:
             - input_columns
             - input_columns
             data_type: "{}"
+            udf_backend: udf_backend
+            auto_backfill: true
             udf_version: udf_version
         - expression: expression
           name: name
           virtual_column:
             image: image
+            field_metadata:
+              key: field_metadata
+            manifest_checksum: manifest_checksum
             udf: udf
             udf_name: udf_name
+            manifest: manifest
             input_columns:
             - input_columns
             - input_columns
             data_type: "{}"
+            udf_backend: udf_backend
+            auto_backfill: true
             udf_version: udf_version
         id:
         - id
         - id
       properties:
+        identity:
+          $ref: '#/components/schemas/Identity'
         id:
           description: Table identifier path (namespace + table name)
           items:
@@ -7049,12 +7066,18 @@ components:
         name: name
         virtual_column:
           image: image
+          field_metadata:
+            key: field_metadata
+          manifest_checksum: manifest_checksum
           udf: udf
           udf_name: udf_name
+          manifest: manifest
           input_columns:
           - input_columns
           - input_columns
           data_type: "{}"
+          udf_backend: udf_backend
+          auto_backfill: true
           udf_version: udf_version
       properties:
         name:
@@ -7072,12 +7095,18 @@ components:
     AddVirtualColumnEntry:
       example:
         image: image
+        field_metadata:
+          key: field_metadata
+        manifest_checksum: manifest_checksum
         udf: udf
         udf_name: udf_name
+        manifest: manifest
         input_columns:
         - input_columns
         - input_columns
         data_type: "{}"
+        udf_backend: udf_backend
+        auto_backfill: true
         udf_version: udf_version
       properties:
         input_columns:
@@ -7100,6 +7129,26 @@ components:
         udf_version:
           description: Version of the UDF
           type: string
+        udf_backend:
+          description: UDF backend type (e.g. DockerUDFSpecV1)
+          nullable: true
+          type: string
+        auto_backfill:
+          description: Whether to automatically backfill the column after creation
+          nullable: true
+          type: boolean
+        manifest:
+          description: JSON-serialized manifest for the UDF environment
+          nullable: true
+          type: string
+        manifest_checksum:
+          description: SHA-256 checksum of the manifest content
+          nullable: true
+          type: string
+        field_metadata:
+          additionalProperties:
+            type: string
+          description: User-supplied field metadata (string key-value pairs)
       required:
       - data_type
       - image
@@ -7120,6 +7169,9 @@ components:
       - version
     AlterTableAlterColumnsRequest:
       example:
+        identity:
+          api_key: api_key
+          auth_token: auth_token
         alterations:
         - path: path
           nullable: true
@@ -7127,11 +7179,17 @@ components:
           data_type: "{}"
           virtual_column:
             image: image
+            field_metadata:
+              key: field_metadata
+            manifest_checksum: manifest_checksum
             udf: udf
             udf_name: udf_name
+            manifest: manifest
             input_columns:
             - input_columns
             - input_columns
+            udf_backend: udf_backend
+            auto_backfill: true
             udf_version: udf_version
         - path: path
           nullable: true
@@ -7139,16 +7197,24 @@ components:
           data_type: "{}"
           virtual_column:
             image: image
+            field_metadata:
+              key: field_metadata
+            manifest_checksum: manifest_checksum
             udf: udf
             udf_name: udf_name
+            manifest: manifest
             input_columns:
             - input_columns
             - input_columns
+            udf_backend: udf_backend
+            auto_backfill: true
             udf_version: udf_version
         id:
         - id
         - id
       properties:
+        identity:
+          $ref: '#/components/schemas/Identity'
         id:
           description: Table identifier path (namespace + table name)
           items:
@@ -7169,11 +7235,17 @@ components:
         data_type: "{}"
         virtual_column:
           image: image
+          field_metadata:
+            key: field_metadata
+          manifest_checksum: manifest_checksum
           udf: udf
           udf_name: udf_name
+          manifest: manifest
           input_columns:
           - input_columns
           - input_columns
+          udf_backend: udf_backend
+          auto_backfill: true
           udf_version: udf_version
       properties:
         path:
@@ -7198,11 +7270,17 @@ components:
     AlterVirtualColumnEntry:
       example:
         image: image
+        field_metadata:
+          key: field_metadata
+        manifest_checksum: manifest_checksum
         udf: udf
         udf_name: udf_name
+        manifest: manifest
         input_columns:
         - input_columns
         - input_columns
+        udf_backend: udf_backend
+        auto_backfill: true
         udf_version: udf_version
       properties:
         input_columns:
@@ -7227,6 +7305,26 @@ components:
           description: Version of the UDF (optional)
           nullable: true
           type: string
+        udf_backend:
+          description: UDF backend type (e.g. DockerUDFSpecV1) (optional)
+          nullable: true
+          type: string
+        auto_backfill:
+          description: Whether to automatically backfill the column (optional)
+          nullable: true
+          type: boolean
+        manifest:
+          description: JSON-serialized manifest for the UDF environment (optional)
+          nullable: true
+          type: string
+        manifest_checksum:
+          description: SHA-256 checksum of the manifest content (optional)
+          nullable: true
+          type: string
+        field_metadata:
+          additionalProperties:
+            type: string
+          description: User-supplied field metadata (optional)
     AlterTableAlterColumnsResponse:
       example:
         version: 0
@@ -7252,12 +7350,17 @@ components:
         commit_granularity: 2
         task_size: 7
         batch_checkpoint_flush_interval_seconds: 5.637376656633329
+        identity:
+          api_key: api_key
+          auth_token: auth_token
         where: where
         id:
         - id
         - id
         intra_applier_concurrency: 6
       properties:
+        identity:
+          $ref: '#/components/schemas/Identity'
         id:
           description: Table identifier path (namespace + table name)
           items:
@@ -7333,6 +7436,9 @@ components:
       example:
         src_version: 0
         cluster: cluster
+        identity:
+          api_key: api_key
+          auth_token: auth_token
         manifest: manifest
         id:
         - id
@@ -7341,6 +7447,8 @@ components:
         intra_applier_concurrency: 5
         concurrency: 1
       properties:
+        identity:
+          $ref: '#/components/schemas/Identity'
         id:
           description: Table identifier path (namespace + table name)
           items:

--- a/java/lance-namespace-async-client/docs/AddVirtualColumnEntry.md
+++ b/java/lance-namespace-async-client/docs/AddVirtualColumnEntry.md
@@ -13,6 +13,11 @@
 |**udf** | **String** | Base64 encoded pickled UDF |  |
 |**udfName** | **String** | Name of the UDF |  |
 |**udfVersion** | **String** | Version of the UDF |  |
+|**udfBackend** | **String** | UDF backend type (e.g. DockerUDFSpecV1) |  [optional] |
+|**autoBackfill** | **Boolean** | Whether to automatically backfill the column after creation |  [optional] |
+|**manifest** | **String** | JSON-serialized manifest for the UDF environment |  [optional] |
+|**manifestChecksum** | **String** | SHA-256 checksum of the manifest content |  [optional] |
+|**fieldMetadata** | **Map&lt;String, String&gt;** | User-supplied field metadata (string key-value pairs) |  [optional] |
 
 
 

--- a/java/lance-namespace-async-client/docs/AlterTableAddColumnsRequest.md
+++ b/java/lance-namespace-async-client/docs/AlterTableAddColumnsRequest.md
@@ -7,6 +7,7 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
+|**identity** | [**Identity**](Identity.md) |  |  [optional] |
 |**id** | **List&lt;String&gt;** | Table identifier path (namespace + table name) |  [optional] |
 |**newColumns** | [**List&lt;AddColumnsEntry&gt;**](AddColumnsEntry.md) | List of new columns to add to the table |  |
 

--- a/java/lance-namespace-async-client/docs/AlterTableAlterColumnsRequest.md
+++ b/java/lance-namespace-async-client/docs/AlterTableAlterColumnsRequest.md
@@ -7,6 +7,7 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
+|**identity** | [**Identity**](Identity.md) |  |  [optional] |
 |**id** | **List&lt;String&gt;** | Table identifier path (namespace + table name) |  [optional] |
 |**alterations** | [**List&lt;AlterColumnsEntry&gt;**](AlterColumnsEntry.md) | List of column alterations to apply to the table |  |
 

--- a/java/lance-namespace-async-client/docs/AlterTableBackfillColumnsRequest.md
+++ b/java/lance-namespace-async-client/docs/AlterTableBackfillColumnsRequest.md
@@ -7,6 +7,7 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
+|**identity** | [**Identity**](Identity.md) |  |  [optional] |
 |**id** | **List&lt;String&gt;** | Table identifier path (namespace + table name) |  [optional] |
 |**column** | **String** | Column name to backfill |  |
 |**where** | **String** | Optional WHERE clause filter |  [optional] |

--- a/java/lance-namespace-async-client/docs/AlterVirtualColumnEntry.md
+++ b/java/lance-namespace-async-client/docs/AlterVirtualColumnEntry.md
@@ -12,6 +12,11 @@
 |**udf** | **String** | Base64 encoded pickled UDF (optional) |  [optional] |
 |**udfName** | **String** | Name of the UDF (optional) |  [optional] |
 |**udfVersion** | **String** | Version of the UDF (optional) |  [optional] |
+|**udfBackend** | **String** | UDF backend type (e.g. DockerUDFSpecV1) (optional) |  [optional] |
+|**autoBackfill** | **Boolean** | Whether to automatically backfill the column (optional) |  [optional] |
+|**manifest** | **String** | JSON-serialized manifest for the UDF environment (optional) |  [optional] |
+|**manifestChecksum** | **String** | SHA-256 checksum of the manifest content (optional) |  [optional] |
+|**fieldMetadata** | **Map&lt;String, String&gt;** | User-supplied field metadata (optional) |  [optional] |
 
 
 

--- a/java/lance-namespace-async-client/docs/RefreshMaterializedViewRequest.md
+++ b/java/lance-namespace-async-client/docs/RefreshMaterializedViewRequest.md
@@ -7,6 +7,7 @@
 
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
+|**identity** | [**Identity**](Identity.md) |  |  [optional] |
 |**id** | **List&lt;String&gt;** | Table identifier path (namespace + table name) |  [optional] |
 |**srcVersion** | **Integer** | Optional source version to refresh from |  [optional] |
 |**maxRowsPerFragment** | **Integer** | Optional maximum rows per fragment |  [optional] |

--- a/java/lance-namespace-async-client/src/main/java/org/lance/namespace/model/AddVirtualColumnEntry.java
+++ b/java/lance-namespace-async-client/src/main/java/org/lance/namespace/model/AddVirtualColumnEntry.java
@@ -15,12 +15,17 @@ package org.lance.namespace.model;
 
 import org.lance.namespace.client.async.ApiClient;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import org.openapitools.jackson.nullable.JsonNullable;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.StringJoiner;
 
@@ -31,7 +36,12 @@ import java.util.StringJoiner;
   AddVirtualColumnEntry.JSON_PROPERTY_IMAGE,
   AddVirtualColumnEntry.JSON_PROPERTY_UDF,
   AddVirtualColumnEntry.JSON_PROPERTY_UDF_NAME,
-  AddVirtualColumnEntry.JSON_PROPERTY_UDF_VERSION
+  AddVirtualColumnEntry.JSON_PROPERTY_UDF_VERSION,
+  AddVirtualColumnEntry.JSON_PROPERTY_UDF_BACKEND,
+  AddVirtualColumnEntry.JSON_PROPERTY_AUTO_BACKFILL,
+  AddVirtualColumnEntry.JSON_PROPERTY_MANIFEST,
+  AddVirtualColumnEntry.JSON_PROPERTY_MANIFEST_CHECKSUM,
+  AddVirtualColumnEntry.JSON_PROPERTY_FIELD_METADATA
 })
 @javax.annotation.Generated(
     value = "org.openapitools.codegen.languages.JavaClientCodegen",
@@ -54,6 +64,21 @@ public class AddVirtualColumnEntry {
 
   public static final String JSON_PROPERTY_UDF_VERSION = "udf_version";
   @javax.annotation.Nonnull private String udfVersion;
+
+  public static final String JSON_PROPERTY_UDF_BACKEND = "udf_backend";
+  private JsonNullable<String> udfBackend = JsonNullable.<String>undefined();
+
+  public static final String JSON_PROPERTY_AUTO_BACKFILL = "auto_backfill";
+  private JsonNullable<Boolean> autoBackfill = JsonNullable.<Boolean>undefined();
+
+  public static final String JSON_PROPERTY_MANIFEST = "manifest";
+  private JsonNullable<String> manifest = JsonNullable.<String>undefined();
+
+  public static final String JSON_PROPERTY_MANIFEST_CHECKSUM = "manifest_checksum";
+  private JsonNullable<String> manifestChecksum = JsonNullable.<String>undefined();
+
+  public static final String JSON_PROPERTY_FIELD_METADATA = "field_metadata";
+  @javax.annotation.Nullable private Map<String, String> fieldMetadata = new HashMap<>();
 
   public AddVirtualColumnEntry() {}
 
@@ -203,6 +228,163 @@ public class AddVirtualColumnEntry {
     this.udfVersion = udfVersion;
   }
 
+  public AddVirtualColumnEntry udfBackend(@javax.annotation.Nullable String udfBackend) {
+    this.udfBackend = JsonNullable.<String>of(udfBackend);
+    return this;
+  }
+
+  /**
+   * UDF backend type (e.g. DockerUDFSpecV1)
+   *
+   * @return udfBackend
+   */
+  @javax.annotation.Nullable
+  @JsonIgnore
+  public String getUdfBackend() {
+    return udfBackend.orElse(null);
+  }
+
+  @JsonProperty(JSON_PROPERTY_UDF_BACKEND)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public JsonNullable<String> getUdfBackend_JsonNullable() {
+    return udfBackend;
+  }
+
+  @JsonProperty(JSON_PROPERTY_UDF_BACKEND)
+  public void setUdfBackend_JsonNullable(JsonNullable<String> udfBackend) {
+    this.udfBackend = udfBackend;
+  }
+
+  public void setUdfBackend(@javax.annotation.Nullable String udfBackend) {
+    this.udfBackend = JsonNullable.<String>of(udfBackend);
+  }
+
+  public AddVirtualColumnEntry autoBackfill(@javax.annotation.Nullable Boolean autoBackfill) {
+    this.autoBackfill = JsonNullable.<Boolean>of(autoBackfill);
+    return this;
+  }
+
+  /**
+   * Whether to automatically backfill the column after creation
+   *
+   * @return autoBackfill
+   */
+  @javax.annotation.Nullable
+  @JsonIgnore
+  public Boolean getAutoBackfill() {
+    return autoBackfill.orElse(null);
+  }
+
+  @JsonProperty(JSON_PROPERTY_AUTO_BACKFILL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public JsonNullable<Boolean> getAutoBackfill_JsonNullable() {
+    return autoBackfill;
+  }
+
+  @JsonProperty(JSON_PROPERTY_AUTO_BACKFILL)
+  public void setAutoBackfill_JsonNullable(JsonNullable<Boolean> autoBackfill) {
+    this.autoBackfill = autoBackfill;
+  }
+
+  public void setAutoBackfill(@javax.annotation.Nullable Boolean autoBackfill) {
+    this.autoBackfill = JsonNullable.<Boolean>of(autoBackfill);
+  }
+
+  public AddVirtualColumnEntry manifest(@javax.annotation.Nullable String manifest) {
+    this.manifest = JsonNullable.<String>of(manifest);
+    return this;
+  }
+
+  /**
+   * JSON-serialized manifest for the UDF environment
+   *
+   * @return manifest
+   */
+  @javax.annotation.Nullable
+  @JsonIgnore
+  public String getManifest() {
+    return manifest.orElse(null);
+  }
+
+  @JsonProperty(JSON_PROPERTY_MANIFEST)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public JsonNullable<String> getManifest_JsonNullable() {
+    return manifest;
+  }
+
+  @JsonProperty(JSON_PROPERTY_MANIFEST)
+  public void setManifest_JsonNullable(JsonNullable<String> manifest) {
+    this.manifest = manifest;
+  }
+
+  public void setManifest(@javax.annotation.Nullable String manifest) {
+    this.manifest = JsonNullable.<String>of(manifest);
+  }
+
+  public AddVirtualColumnEntry manifestChecksum(
+      @javax.annotation.Nullable String manifestChecksum) {
+    this.manifestChecksum = JsonNullable.<String>of(manifestChecksum);
+    return this;
+  }
+
+  /**
+   * SHA-256 checksum of the manifest content
+   *
+   * @return manifestChecksum
+   */
+  @javax.annotation.Nullable
+  @JsonIgnore
+  public String getManifestChecksum() {
+    return manifestChecksum.orElse(null);
+  }
+
+  @JsonProperty(JSON_PROPERTY_MANIFEST_CHECKSUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public JsonNullable<String> getManifestChecksum_JsonNullable() {
+    return manifestChecksum;
+  }
+
+  @JsonProperty(JSON_PROPERTY_MANIFEST_CHECKSUM)
+  public void setManifestChecksum_JsonNullable(JsonNullable<String> manifestChecksum) {
+    this.manifestChecksum = manifestChecksum;
+  }
+
+  public void setManifestChecksum(@javax.annotation.Nullable String manifestChecksum) {
+    this.manifestChecksum = JsonNullable.<String>of(manifestChecksum);
+  }
+
+  public AddVirtualColumnEntry fieldMetadata(
+      @javax.annotation.Nullable Map<String, String> fieldMetadata) {
+    this.fieldMetadata = fieldMetadata;
+    return this;
+  }
+
+  public AddVirtualColumnEntry putFieldMetadataItem(String key, String fieldMetadataItem) {
+    if (this.fieldMetadata == null) {
+      this.fieldMetadata = new HashMap<>();
+    }
+    this.fieldMetadata.put(key, fieldMetadataItem);
+    return this;
+  }
+
+  /**
+   * User-supplied field metadata (string key-value pairs)
+   *
+   * @return fieldMetadata
+   */
+  @javax.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_FIELD_METADATA)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public Map<String, String> getFieldMetadata() {
+    return fieldMetadata;
+  }
+
+  @JsonProperty(JSON_PROPERTY_FIELD_METADATA)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setFieldMetadata(@javax.annotation.Nullable Map<String, String> fieldMetadata) {
+    this.fieldMetadata = fieldMetadata;
+  }
+
   /** Return true if this AddVirtualColumnEntry object is equal to o. */
   @Override
   public boolean equals(Object o) {
@@ -218,12 +400,44 @@ public class AddVirtualColumnEntry {
         && Objects.equals(this.image, addVirtualColumnEntry.image)
         && Objects.equals(this.udf, addVirtualColumnEntry.udf)
         && Objects.equals(this.udfName, addVirtualColumnEntry.udfName)
-        && Objects.equals(this.udfVersion, addVirtualColumnEntry.udfVersion);
+        && Objects.equals(this.udfVersion, addVirtualColumnEntry.udfVersion)
+        && equalsNullable(this.udfBackend, addVirtualColumnEntry.udfBackend)
+        && equalsNullable(this.autoBackfill, addVirtualColumnEntry.autoBackfill)
+        && equalsNullable(this.manifest, addVirtualColumnEntry.manifest)
+        && equalsNullable(this.manifestChecksum, addVirtualColumnEntry.manifestChecksum)
+        && Objects.equals(this.fieldMetadata, addVirtualColumnEntry.fieldMetadata);
+  }
+
+  private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
+    return a == b
+        || (a != null
+            && b != null
+            && a.isPresent()
+            && b.isPresent()
+            && Objects.deepEquals(a.get(), b.get()));
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(inputColumns, dataType, image, udf, udfName, udfVersion);
+    return Objects.hash(
+        inputColumns,
+        dataType,
+        image,
+        udf,
+        udfName,
+        udfVersion,
+        hashCodeNullable(udfBackend),
+        hashCodeNullable(autoBackfill),
+        hashCodeNullable(manifest),
+        hashCodeNullable(manifestChecksum),
+        fieldMetadata);
+  }
+
+  private static <T> int hashCodeNullable(JsonNullable<T> a) {
+    if (a == null) {
+      return 1;
+    }
+    return a.isPresent() ? Arrays.deepHashCode(new Object[] {a.get()}) : 31;
   }
 
   @Override
@@ -236,6 +450,11 @@ public class AddVirtualColumnEntry {
     sb.append("    udf: ").append(toIndentedString(udf)).append("\n");
     sb.append("    udfName: ").append(toIndentedString(udfName)).append("\n");
     sb.append("    udfVersion: ").append(toIndentedString(udfVersion)).append("\n");
+    sb.append("    udfBackend: ").append(toIndentedString(udfBackend)).append("\n");
+    sb.append("    autoBackfill: ").append(toIndentedString(autoBackfill)).append("\n");
+    sb.append("    manifest: ").append(toIndentedString(manifest)).append("\n");
+    sb.append("    manifestChecksum: ").append(toIndentedString(manifestChecksum)).append("\n");
+    sb.append("    fieldMetadata: ").append(toIndentedString(fieldMetadata)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -335,6 +554,54 @@ public class AddVirtualColumnEntry {
           String.format(
               "%sudf_version%s=%s",
               prefix, suffix, ApiClient.urlEncode(ApiClient.valueToString(getUdfVersion()))));
+    }
+
+    // add `udf_backend` to the URL query string
+    if (getUdfBackend() != null) {
+      joiner.add(
+          String.format(
+              "%sudf_backend%s=%s",
+              prefix, suffix, ApiClient.urlEncode(ApiClient.valueToString(getUdfBackend()))));
+    }
+
+    // add `auto_backfill` to the URL query string
+    if (getAutoBackfill() != null) {
+      joiner.add(
+          String.format(
+              "%sauto_backfill%s=%s",
+              prefix, suffix, ApiClient.urlEncode(ApiClient.valueToString(getAutoBackfill()))));
+    }
+
+    // add `manifest` to the URL query string
+    if (getManifest() != null) {
+      joiner.add(
+          String.format(
+              "%smanifest%s=%s",
+              prefix, suffix, ApiClient.urlEncode(ApiClient.valueToString(getManifest()))));
+    }
+
+    // add `manifest_checksum` to the URL query string
+    if (getManifestChecksum() != null) {
+      joiner.add(
+          String.format(
+              "%smanifest_checksum%s=%s",
+              prefix, suffix, ApiClient.urlEncode(ApiClient.valueToString(getManifestChecksum()))));
+    }
+
+    // add `field_metadata` to the URL query string
+    if (getFieldMetadata() != null) {
+      for (String _key : getFieldMetadata().keySet()) {
+        joiner.add(
+            String.format(
+                "%sfield_metadata%s%s=%s",
+                prefix,
+                suffix,
+                "".equals(suffix)
+                    ? ""
+                    : String.format("%s%d%s", containerPrefix, _key, containerSuffix),
+                getFieldMetadata().get(_key),
+                ApiClient.urlEncode(ApiClient.valueToString(getFieldMetadata().get(_key)))));
+      }
     }
 
     return joiner.toString();

--- a/java/lance-namespace-async-client/src/main/java/org/lance/namespace/model/AlterTableAddColumnsRequest.java
+++ b/java/lance-namespace-async-client/src/main/java/org/lance/namespace/model/AlterTableAddColumnsRequest.java
@@ -26,6 +26,7 @@ import java.util.StringJoiner;
 
 /** AlterTableAddColumnsRequest */
 @JsonPropertyOrder({
+  AlterTableAddColumnsRequest.JSON_PROPERTY_IDENTITY,
   AlterTableAddColumnsRequest.JSON_PROPERTY_ID,
   AlterTableAddColumnsRequest.JSON_PROPERTY_NEW_COLUMNS
 })
@@ -33,6 +34,9 @@ import java.util.StringJoiner;
     value = "org.openapitools.codegen.languages.JavaClientCodegen",
     comments = "Generator version: 7.12.0")
 public class AlterTableAddColumnsRequest {
+  public static final String JSON_PROPERTY_IDENTITY = "identity";
+  @javax.annotation.Nullable private Identity identity;
+
   public static final String JSON_PROPERTY_ID = "id";
   @javax.annotation.Nullable private List<String> id = new ArrayList<>();
 
@@ -40,6 +44,29 @@ public class AlterTableAddColumnsRequest {
   @javax.annotation.Nonnull private List<AddColumnsEntry> newColumns = new ArrayList<>();
 
   public AlterTableAddColumnsRequest() {}
+
+  public AlterTableAddColumnsRequest identity(@javax.annotation.Nullable Identity identity) {
+    this.identity = identity;
+    return this;
+  }
+
+  /**
+   * Get identity
+   *
+   * @return identity
+   */
+  @javax.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_IDENTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public Identity getIdentity() {
+    return identity;
+  }
+
+  @JsonProperty(JSON_PROPERTY_IDENTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setIdentity(@javax.annotation.Nullable Identity identity) {
+    this.identity = identity;
+  }
 
   public AlterTableAddColumnsRequest id(@javax.annotation.Nullable List<String> id) {
     this.id = id;
@@ -114,19 +141,21 @@ public class AlterTableAddColumnsRequest {
       return false;
     }
     AlterTableAddColumnsRequest alterTableAddColumnsRequest = (AlterTableAddColumnsRequest) o;
-    return Objects.equals(this.id, alterTableAddColumnsRequest.id)
+    return Objects.equals(this.identity, alterTableAddColumnsRequest.identity)
+        && Objects.equals(this.id, alterTableAddColumnsRequest.id)
         && Objects.equals(this.newColumns, alterTableAddColumnsRequest.newColumns);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, newColumns);
+    return Objects.hash(identity, id, newColumns);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class AlterTableAddColumnsRequest {\n");
+    sb.append("    identity: ").append(toIndentedString(identity)).append("\n");
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    newColumns: ").append(toIndentedString(newColumns)).append("\n");
     sb.append("}");
@@ -174,6 +203,11 @@ public class AlterTableAddColumnsRequest {
     }
 
     StringJoiner joiner = new StringJoiner("&");
+
+    // add `identity` to the URL query string
+    if (getIdentity() != null) {
+      joiner.add(getIdentity().toUrlQueryString(prefix + "identity" + suffix));
+    }
 
     // add `id` to the URL query string
     if (getId() != null) {

--- a/java/lance-namespace-async-client/src/main/java/org/lance/namespace/model/AlterTableAlterColumnsRequest.java
+++ b/java/lance-namespace-async-client/src/main/java/org/lance/namespace/model/AlterTableAlterColumnsRequest.java
@@ -26,6 +26,7 @@ import java.util.StringJoiner;
 
 /** AlterTableAlterColumnsRequest */
 @JsonPropertyOrder({
+  AlterTableAlterColumnsRequest.JSON_PROPERTY_IDENTITY,
   AlterTableAlterColumnsRequest.JSON_PROPERTY_ID,
   AlterTableAlterColumnsRequest.JSON_PROPERTY_ALTERATIONS
 })
@@ -33,6 +34,9 @@ import java.util.StringJoiner;
     value = "org.openapitools.codegen.languages.JavaClientCodegen",
     comments = "Generator version: 7.12.0")
 public class AlterTableAlterColumnsRequest {
+  public static final String JSON_PROPERTY_IDENTITY = "identity";
+  @javax.annotation.Nullable private Identity identity;
+
   public static final String JSON_PROPERTY_ID = "id";
   @javax.annotation.Nullable private List<String> id = new ArrayList<>();
 
@@ -40,6 +44,29 @@ public class AlterTableAlterColumnsRequest {
   @javax.annotation.Nonnull private List<AlterColumnsEntry> alterations = new ArrayList<>();
 
   public AlterTableAlterColumnsRequest() {}
+
+  public AlterTableAlterColumnsRequest identity(@javax.annotation.Nullable Identity identity) {
+    this.identity = identity;
+    return this;
+  }
+
+  /**
+   * Get identity
+   *
+   * @return identity
+   */
+  @javax.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_IDENTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public Identity getIdentity() {
+    return identity;
+  }
+
+  @JsonProperty(JSON_PROPERTY_IDENTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setIdentity(@javax.annotation.Nullable Identity identity) {
+    this.identity = identity;
+  }
 
   public AlterTableAlterColumnsRequest id(@javax.annotation.Nullable List<String> id) {
     this.id = id;
@@ -114,19 +141,21 @@ public class AlterTableAlterColumnsRequest {
       return false;
     }
     AlterTableAlterColumnsRequest alterTableAlterColumnsRequest = (AlterTableAlterColumnsRequest) o;
-    return Objects.equals(this.id, alterTableAlterColumnsRequest.id)
+    return Objects.equals(this.identity, alterTableAlterColumnsRequest.identity)
+        && Objects.equals(this.id, alterTableAlterColumnsRequest.id)
         && Objects.equals(this.alterations, alterTableAlterColumnsRequest.alterations);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, alterations);
+    return Objects.hash(identity, id, alterations);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class AlterTableAlterColumnsRequest {\n");
+    sb.append("    identity: ").append(toIndentedString(identity)).append("\n");
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    alterations: ").append(toIndentedString(alterations)).append("\n");
     sb.append("}");
@@ -174,6 +203,11 @@ public class AlterTableAlterColumnsRequest {
     }
 
     StringJoiner joiner = new StringJoiner("&");
+
+    // add `identity` to the URL query string
+    if (getIdentity() != null) {
+      joiner.add(getIdentity().toUrlQueryString(prefix + "identity" + suffix));
+    }
 
     // add `id` to the URL query string
     if (getId() != null) {

--- a/java/lance-namespace-async-client/src/main/java/org/lance/namespace/model/AlterTableBackfillColumnsRequest.java
+++ b/java/lance-namespace-async-client/src/main/java/org/lance/namespace/model/AlterTableBackfillColumnsRequest.java
@@ -30,6 +30,7 @@ import java.util.StringJoiner;
 
 /** AlterTableBackfillColumnsRequest */
 @JsonPropertyOrder({
+  AlterTableBackfillColumnsRequest.JSON_PROPERTY_IDENTITY,
   AlterTableBackfillColumnsRequest.JSON_PROPERTY_ID,
   AlterTableBackfillColumnsRequest.JSON_PROPERTY_COLUMN,
   AlterTableBackfillColumnsRequest.JSON_PROPERTY_WHERE,
@@ -50,6 +51,9 @@ import java.util.StringJoiner;
     value = "org.openapitools.codegen.languages.JavaClientCodegen",
     comments = "Generator version: 7.12.0")
 public class AlterTableBackfillColumnsRequest {
+  public static final String JSON_PROPERTY_IDENTITY = "identity";
+  @javax.annotation.Nullable private Identity identity;
+
   public static final String JSON_PROPERTY_ID = "id";
   @javax.annotation.Nullable private List<String> id = new ArrayList<>();
 
@@ -98,6 +102,29 @@ public class AlterTableBackfillColumnsRequest {
   private JsonNullable<String> manifest = JsonNullable.<String>undefined();
 
   public AlterTableBackfillColumnsRequest() {}
+
+  public AlterTableBackfillColumnsRequest identity(@javax.annotation.Nullable Identity identity) {
+    this.identity = identity;
+    return this;
+  }
+
+  /**
+   * Get identity
+   *
+   * @return identity
+   */
+  @javax.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_IDENTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public Identity getIdentity() {
+    return identity;
+  }
+
+  @JsonProperty(JSON_PROPERTY_IDENTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setIdentity(@javax.annotation.Nullable Identity identity) {
+    this.identity = identity;
+  }
 
   public AlterTableBackfillColumnsRequest id(@javax.annotation.Nullable List<String> id) {
     this.id = id;
@@ -581,7 +608,8 @@ public class AlterTableBackfillColumnsRequest {
     }
     AlterTableBackfillColumnsRequest alterTableBackfillColumnsRequest =
         (AlterTableBackfillColumnsRequest) o;
-    return Objects.equals(this.id, alterTableBackfillColumnsRequest.id)
+    return Objects.equals(this.identity, alterTableBackfillColumnsRequest.identity)
+        && Objects.equals(this.id, alterTableBackfillColumnsRequest.id)
         && Objects.equals(this.column, alterTableBackfillColumnsRequest.column)
         && equalsNullable(this.where, alterTableBackfillColumnsRequest.where)
         && equalsNullable(this.concurrency, alterTableBackfillColumnsRequest.concurrency)
@@ -616,6 +644,7 @@ public class AlterTableBackfillColumnsRequest {
   @Override
   public int hashCode() {
     return Objects.hash(
+        identity,
         id,
         column,
         hashCodeNullable(where),
@@ -644,6 +673,7 @@ public class AlterTableBackfillColumnsRequest {
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class AlterTableBackfillColumnsRequest {\n");
+    sb.append("    identity: ").append(toIndentedString(identity)).append("\n");
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    column: ").append(toIndentedString(column)).append("\n");
     sb.append("    where: ").append(toIndentedString(where)).append("\n");
@@ -708,6 +738,11 @@ public class AlterTableBackfillColumnsRequest {
     }
 
     StringJoiner joiner = new StringJoiner("&");
+
+    // add `identity` to the URL query string
+    if (getIdentity() != null) {
+      joiner.add(getIdentity().toUrlQueryString(prefix + "identity" + suffix));
+    }
 
     // add `id` to the URL query string
     if (getId() != null) {

--- a/java/lance-namespace-async-client/src/main/java/org/lance/namespace/model/AlterVirtualColumnEntry.java
+++ b/java/lance-namespace-async-client/src/main/java/org/lance/namespace/model/AlterVirtualColumnEntry.java
@@ -23,7 +23,9 @@ import org.openapitools.jackson.nullable.JsonNullable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.StringJoiner;
 
@@ -33,7 +35,12 @@ import java.util.StringJoiner;
   AlterVirtualColumnEntry.JSON_PROPERTY_IMAGE,
   AlterVirtualColumnEntry.JSON_PROPERTY_UDF,
   AlterVirtualColumnEntry.JSON_PROPERTY_UDF_NAME,
-  AlterVirtualColumnEntry.JSON_PROPERTY_UDF_VERSION
+  AlterVirtualColumnEntry.JSON_PROPERTY_UDF_VERSION,
+  AlterVirtualColumnEntry.JSON_PROPERTY_UDF_BACKEND,
+  AlterVirtualColumnEntry.JSON_PROPERTY_AUTO_BACKFILL,
+  AlterVirtualColumnEntry.JSON_PROPERTY_MANIFEST,
+  AlterVirtualColumnEntry.JSON_PROPERTY_MANIFEST_CHECKSUM,
+  AlterVirtualColumnEntry.JSON_PROPERTY_FIELD_METADATA
 })
 @javax.annotation.Generated(
     value = "org.openapitools.codegen.languages.JavaClientCodegen",
@@ -53,6 +60,21 @@ public class AlterVirtualColumnEntry {
 
   public static final String JSON_PROPERTY_UDF_VERSION = "udf_version";
   private JsonNullable<String> udfVersion = JsonNullable.<String>undefined();
+
+  public static final String JSON_PROPERTY_UDF_BACKEND = "udf_backend";
+  private JsonNullable<String> udfBackend = JsonNullable.<String>undefined();
+
+  public static final String JSON_PROPERTY_AUTO_BACKFILL = "auto_backfill";
+  private JsonNullable<Boolean> autoBackfill = JsonNullable.<Boolean>undefined();
+
+  public static final String JSON_PROPERTY_MANIFEST = "manifest";
+  private JsonNullable<String> manifest = JsonNullable.<String>undefined();
+
+  public static final String JSON_PROPERTY_MANIFEST_CHECKSUM = "manifest_checksum";
+  private JsonNullable<String> manifestChecksum = JsonNullable.<String>undefined();
+
+  public static final String JSON_PROPERTY_FIELD_METADATA = "field_metadata";
+  @javax.annotation.Nullable private Map<String, String> fieldMetadata = new HashMap<>();
 
   public AlterVirtualColumnEntry() {}
 
@@ -224,6 +246,163 @@ public class AlterVirtualColumnEntry {
     this.udfVersion = JsonNullable.<String>of(udfVersion);
   }
 
+  public AlterVirtualColumnEntry udfBackend(@javax.annotation.Nullable String udfBackend) {
+    this.udfBackend = JsonNullable.<String>of(udfBackend);
+    return this;
+  }
+
+  /**
+   * UDF backend type (e.g. DockerUDFSpecV1) (optional)
+   *
+   * @return udfBackend
+   */
+  @javax.annotation.Nullable
+  @JsonIgnore
+  public String getUdfBackend() {
+    return udfBackend.orElse(null);
+  }
+
+  @JsonProperty(JSON_PROPERTY_UDF_BACKEND)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public JsonNullable<String> getUdfBackend_JsonNullable() {
+    return udfBackend;
+  }
+
+  @JsonProperty(JSON_PROPERTY_UDF_BACKEND)
+  public void setUdfBackend_JsonNullable(JsonNullable<String> udfBackend) {
+    this.udfBackend = udfBackend;
+  }
+
+  public void setUdfBackend(@javax.annotation.Nullable String udfBackend) {
+    this.udfBackend = JsonNullable.<String>of(udfBackend);
+  }
+
+  public AlterVirtualColumnEntry autoBackfill(@javax.annotation.Nullable Boolean autoBackfill) {
+    this.autoBackfill = JsonNullable.<Boolean>of(autoBackfill);
+    return this;
+  }
+
+  /**
+   * Whether to automatically backfill the column (optional)
+   *
+   * @return autoBackfill
+   */
+  @javax.annotation.Nullable
+  @JsonIgnore
+  public Boolean getAutoBackfill() {
+    return autoBackfill.orElse(null);
+  }
+
+  @JsonProperty(JSON_PROPERTY_AUTO_BACKFILL)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public JsonNullable<Boolean> getAutoBackfill_JsonNullable() {
+    return autoBackfill;
+  }
+
+  @JsonProperty(JSON_PROPERTY_AUTO_BACKFILL)
+  public void setAutoBackfill_JsonNullable(JsonNullable<Boolean> autoBackfill) {
+    this.autoBackfill = autoBackfill;
+  }
+
+  public void setAutoBackfill(@javax.annotation.Nullable Boolean autoBackfill) {
+    this.autoBackfill = JsonNullable.<Boolean>of(autoBackfill);
+  }
+
+  public AlterVirtualColumnEntry manifest(@javax.annotation.Nullable String manifest) {
+    this.manifest = JsonNullable.<String>of(manifest);
+    return this;
+  }
+
+  /**
+   * JSON-serialized manifest for the UDF environment (optional)
+   *
+   * @return manifest
+   */
+  @javax.annotation.Nullable
+  @JsonIgnore
+  public String getManifest() {
+    return manifest.orElse(null);
+  }
+
+  @JsonProperty(JSON_PROPERTY_MANIFEST)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public JsonNullable<String> getManifest_JsonNullable() {
+    return manifest;
+  }
+
+  @JsonProperty(JSON_PROPERTY_MANIFEST)
+  public void setManifest_JsonNullable(JsonNullable<String> manifest) {
+    this.manifest = manifest;
+  }
+
+  public void setManifest(@javax.annotation.Nullable String manifest) {
+    this.manifest = JsonNullable.<String>of(manifest);
+  }
+
+  public AlterVirtualColumnEntry manifestChecksum(
+      @javax.annotation.Nullable String manifestChecksum) {
+    this.manifestChecksum = JsonNullable.<String>of(manifestChecksum);
+    return this;
+  }
+
+  /**
+   * SHA-256 checksum of the manifest content (optional)
+   *
+   * @return manifestChecksum
+   */
+  @javax.annotation.Nullable
+  @JsonIgnore
+  public String getManifestChecksum() {
+    return manifestChecksum.orElse(null);
+  }
+
+  @JsonProperty(JSON_PROPERTY_MANIFEST_CHECKSUM)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public JsonNullable<String> getManifestChecksum_JsonNullable() {
+    return manifestChecksum;
+  }
+
+  @JsonProperty(JSON_PROPERTY_MANIFEST_CHECKSUM)
+  public void setManifestChecksum_JsonNullable(JsonNullable<String> manifestChecksum) {
+    this.manifestChecksum = manifestChecksum;
+  }
+
+  public void setManifestChecksum(@javax.annotation.Nullable String manifestChecksum) {
+    this.manifestChecksum = JsonNullable.<String>of(manifestChecksum);
+  }
+
+  public AlterVirtualColumnEntry fieldMetadata(
+      @javax.annotation.Nullable Map<String, String> fieldMetadata) {
+    this.fieldMetadata = fieldMetadata;
+    return this;
+  }
+
+  public AlterVirtualColumnEntry putFieldMetadataItem(String key, String fieldMetadataItem) {
+    if (this.fieldMetadata == null) {
+      this.fieldMetadata = new HashMap<>();
+    }
+    this.fieldMetadata.put(key, fieldMetadataItem);
+    return this;
+  }
+
+  /**
+   * User-supplied field metadata (optional)
+   *
+   * @return fieldMetadata
+   */
+  @javax.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_FIELD_METADATA)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public Map<String, String> getFieldMetadata() {
+    return fieldMetadata;
+  }
+
+  @JsonProperty(JSON_PROPERTY_FIELD_METADATA)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setFieldMetadata(@javax.annotation.Nullable Map<String, String> fieldMetadata) {
+    this.fieldMetadata = fieldMetadata;
+  }
+
   /** Return true if this AlterVirtualColumnEntry object is equal to o. */
   @Override
   public boolean equals(Object o) {
@@ -238,7 +417,12 @@ public class AlterVirtualColumnEntry {
         && equalsNullable(this.image, alterVirtualColumnEntry.image)
         && equalsNullable(this.udf, alterVirtualColumnEntry.udf)
         && equalsNullable(this.udfName, alterVirtualColumnEntry.udfName)
-        && equalsNullable(this.udfVersion, alterVirtualColumnEntry.udfVersion);
+        && equalsNullable(this.udfVersion, alterVirtualColumnEntry.udfVersion)
+        && equalsNullable(this.udfBackend, alterVirtualColumnEntry.udfBackend)
+        && equalsNullable(this.autoBackfill, alterVirtualColumnEntry.autoBackfill)
+        && equalsNullable(this.manifest, alterVirtualColumnEntry.manifest)
+        && equalsNullable(this.manifestChecksum, alterVirtualColumnEntry.manifestChecksum)
+        && Objects.equals(this.fieldMetadata, alterVirtualColumnEntry.fieldMetadata);
   }
 
   private static <T> boolean equalsNullable(JsonNullable<T> a, JsonNullable<T> b) {
@@ -257,7 +441,12 @@ public class AlterVirtualColumnEntry {
         hashCodeNullable(image),
         hashCodeNullable(udf),
         hashCodeNullable(udfName),
-        hashCodeNullable(udfVersion));
+        hashCodeNullable(udfVersion),
+        hashCodeNullable(udfBackend),
+        hashCodeNullable(autoBackfill),
+        hashCodeNullable(manifest),
+        hashCodeNullable(manifestChecksum),
+        fieldMetadata);
   }
 
   private static <T> int hashCodeNullable(JsonNullable<T> a) {
@@ -276,6 +465,11 @@ public class AlterVirtualColumnEntry {
     sb.append("    udf: ").append(toIndentedString(udf)).append("\n");
     sb.append("    udfName: ").append(toIndentedString(udfName)).append("\n");
     sb.append("    udfVersion: ").append(toIndentedString(udfVersion)).append("\n");
+    sb.append("    udfBackend: ").append(toIndentedString(udfBackend)).append("\n");
+    sb.append("    autoBackfill: ").append(toIndentedString(autoBackfill)).append("\n");
+    sb.append("    manifest: ").append(toIndentedString(manifest)).append("\n");
+    sb.append("    manifestChecksum: ").append(toIndentedString(manifestChecksum)).append("\n");
+    sb.append("    fieldMetadata: ").append(toIndentedString(fieldMetadata)).append("\n");
     sb.append("}");
     return sb.toString();
   }
@@ -367,6 +561,54 @@ public class AlterVirtualColumnEntry {
           String.format(
               "%sudf_version%s=%s",
               prefix, suffix, ApiClient.urlEncode(ApiClient.valueToString(getUdfVersion()))));
+    }
+
+    // add `udf_backend` to the URL query string
+    if (getUdfBackend() != null) {
+      joiner.add(
+          String.format(
+              "%sudf_backend%s=%s",
+              prefix, suffix, ApiClient.urlEncode(ApiClient.valueToString(getUdfBackend()))));
+    }
+
+    // add `auto_backfill` to the URL query string
+    if (getAutoBackfill() != null) {
+      joiner.add(
+          String.format(
+              "%sauto_backfill%s=%s",
+              prefix, suffix, ApiClient.urlEncode(ApiClient.valueToString(getAutoBackfill()))));
+    }
+
+    // add `manifest` to the URL query string
+    if (getManifest() != null) {
+      joiner.add(
+          String.format(
+              "%smanifest%s=%s",
+              prefix, suffix, ApiClient.urlEncode(ApiClient.valueToString(getManifest()))));
+    }
+
+    // add `manifest_checksum` to the URL query string
+    if (getManifestChecksum() != null) {
+      joiner.add(
+          String.format(
+              "%smanifest_checksum%s=%s",
+              prefix, suffix, ApiClient.urlEncode(ApiClient.valueToString(getManifestChecksum()))));
+    }
+
+    // add `field_metadata` to the URL query string
+    if (getFieldMetadata() != null) {
+      for (String _key : getFieldMetadata().keySet()) {
+        joiner.add(
+            String.format(
+                "%sfield_metadata%s%s=%s",
+                prefix,
+                suffix,
+                "".equals(suffix)
+                    ? ""
+                    : String.format("%s%d%s", containerPrefix, _key, containerSuffix),
+                getFieldMetadata().get(_key),
+                ApiClient.urlEncode(ApiClient.valueToString(getFieldMetadata().get(_key)))));
+      }
     }
 
     return joiner.toString();

--- a/java/lance-namespace-async-client/src/main/java/org/lance/namespace/model/RefreshMaterializedViewRequest.java
+++ b/java/lance-namespace-async-client/src/main/java/org/lance/namespace/model/RefreshMaterializedViewRequest.java
@@ -29,6 +29,7 @@ import java.util.StringJoiner;
 
 /** RefreshMaterializedViewRequest */
 @JsonPropertyOrder({
+  RefreshMaterializedViewRequest.JSON_PROPERTY_IDENTITY,
   RefreshMaterializedViewRequest.JSON_PROPERTY_ID,
   RefreshMaterializedViewRequest.JSON_PROPERTY_SRC_VERSION,
   RefreshMaterializedViewRequest.JSON_PROPERTY_MAX_ROWS_PER_FRAGMENT,
@@ -41,6 +42,9 @@ import java.util.StringJoiner;
     value = "org.openapitools.codegen.languages.JavaClientCodegen",
     comments = "Generator version: 7.12.0")
 public class RefreshMaterializedViewRequest {
+  public static final String JSON_PROPERTY_IDENTITY = "identity";
+  @javax.annotation.Nullable private Identity identity;
+
   public static final String JSON_PROPERTY_ID = "id";
   @javax.annotation.Nullable private List<String> id = new ArrayList<>();
 
@@ -63,6 +67,29 @@ public class RefreshMaterializedViewRequest {
   private JsonNullable<String> manifest = JsonNullable.<String>undefined();
 
   public RefreshMaterializedViewRequest() {}
+
+  public RefreshMaterializedViewRequest identity(@javax.annotation.Nullable Identity identity) {
+    this.identity = identity;
+    return this;
+  }
+
+  /**
+   * Get identity
+   *
+   * @return identity
+   */
+  @javax.annotation.Nullable
+  @JsonProperty(JSON_PROPERTY_IDENTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public Identity getIdentity() {
+    return identity;
+  }
+
+  @JsonProperty(JSON_PROPERTY_IDENTITY)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setIdentity(@javax.annotation.Nullable Identity identity) {
+    this.identity = identity;
+  }
 
   public RefreshMaterializedViewRequest id(@javax.annotation.Nullable List<String> id) {
     this.id = id;
@@ -297,7 +324,8 @@ public class RefreshMaterializedViewRequest {
     }
     RefreshMaterializedViewRequest refreshMaterializedViewRequest =
         (RefreshMaterializedViewRequest) o;
-    return Objects.equals(this.id, refreshMaterializedViewRequest.id)
+    return Objects.equals(this.identity, refreshMaterializedViewRequest.identity)
+        && Objects.equals(this.id, refreshMaterializedViewRequest.id)
         && equalsNullable(this.srcVersion, refreshMaterializedViewRequest.srcVersion)
         && equalsNullable(
             this.maxRowsPerFragment, refreshMaterializedViewRequest.maxRowsPerFragment)
@@ -320,6 +348,7 @@ public class RefreshMaterializedViewRequest {
   @Override
   public int hashCode() {
     return Objects.hash(
+        identity,
         id,
         hashCodeNullable(srcVersion),
         hashCodeNullable(maxRowsPerFragment),
@@ -340,6 +369,7 @@ public class RefreshMaterializedViewRequest {
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class RefreshMaterializedViewRequest {\n");
+    sb.append("    identity: ").append(toIndentedString(identity)).append("\n");
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    srcVersion: ").append(toIndentedString(srcVersion)).append("\n");
     sb.append("    maxRowsPerFragment: ").append(toIndentedString(maxRowsPerFragment)).append("\n");
@@ -394,6 +424,11 @@ public class RefreshMaterializedViewRequest {
     }
 
     StringJoiner joiner = new StringJoiner("&");
+
+    // add `identity` to the URL query string
+    if (getIdentity() != null) {
+      joiner.add(getIdentity().toUrlQueryString(prefix + "identity" + suffix));
+    }
 
     // add `id` to the URL query string
     if (getId() != null) {

--- a/java/lance-namespace-springboot-server/src/main/java/org/lance/namespace/server/springboot/model/AddVirtualColumnEntry.java
+++ b/java/lance-namespace-springboot-server/src/main/java/org/lance/namespace/server/springboot/model/AddVirtualColumnEntry.java
@@ -21,7 +21,9 @@ import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 /** AddVirtualColumnEntry */
@@ -41,6 +43,16 @@ public class AddVirtualColumnEntry {
   private String udfName;
 
   private String udfVersion;
+
+  private String udfBackend = null;
+
+  private Boolean autoBackfill = null;
+
+  private String manifest = null;
+
+  private String manifestChecksum = null;
+
+  @Valid private Map<String, String> fieldMetadata = new HashMap<>();
 
   public AddVirtualColumnEntry() {
     super();
@@ -214,6 +226,129 @@ public class AddVirtualColumnEntry {
     this.udfVersion = udfVersion;
   }
 
+  public AddVirtualColumnEntry udfBackend(String udfBackend) {
+    this.udfBackend = udfBackend;
+    return this;
+  }
+
+  /**
+   * UDF backend type (e.g. DockerUDFSpecV1)
+   *
+   * @return udfBackend
+   */
+  @Schema(
+      name = "udf_backend",
+      description = "UDF backend type (e.g. DockerUDFSpecV1)",
+      requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @JsonProperty("udf_backend")
+  public String getUdfBackend() {
+    return udfBackend;
+  }
+
+  public void setUdfBackend(String udfBackend) {
+    this.udfBackend = udfBackend;
+  }
+
+  public AddVirtualColumnEntry autoBackfill(Boolean autoBackfill) {
+    this.autoBackfill = autoBackfill;
+    return this;
+  }
+
+  /**
+   * Whether to automatically backfill the column after creation
+   *
+   * @return autoBackfill
+   */
+  @Schema(
+      name = "auto_backfill",
+      description = "Whether to automatically backfill the column after creation",
+      requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @JsonProperty("auto_backfill")
+  public Boolean getAutoBackfill() {
+    return autoBackfill;
+  }
+
+  public void setAutoBackfill(Boolean autoBackfill) {
+    this.autoBackfill = autoBackfill;
+  }
+
+  public AddVirtualColumnEntry manifest(String manifest) {
+    this.manifest = manifest;
+    return this;
+  }
+
+  /**
+   * JSON-serialized manifest for the UDF environment
+   *
+   * @return manifest
+   */
+  @Schema(
+      name = "manifest",
+      description = "JSON-serialized manifest for the UDF environment",
+      requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @JsonProperty("manifest")
+  public String getManifest() {
+    return manifest;
+  }
+
+  public void setManifest(String manifest) {
+    this.manifest = manifest;
+  }
+
+  public AddVirtualColumnEntry manifestChecksum(String manifestChecksum) {
+    this.manifestChecksum = manifestChecksum;
+    return this;
+  }
+
+  /**
+   * SHA-256 checksum of the manifest content
+   *
+   * @return manifestChecksum
+   */
+  @Schema(
+      name = "manifest_checksum",
+      description = "SHA-256 checksum of the manifest content",
+      requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @JsonProperty("manifest_checksum")
+  public String getManifestChecksum() {
+    return manifestChecksum;
+  }
+
+  public void setManifestChecksum(String manifestChecksum) {
+    this.manifestChecksum = manifestChecksum;
+  }
+
+  public AddVirtualColumnEntry fieldMetadata(Map<String, String> fieldMetadata) {
+    this.fieldMetadata = fieldMetadata;
+    return this;
+  }
+
+  public AddVirtualColumnEntry putFieldMetadataItem(String key, String fieldMetadataItem) {
+    if (this.fieldMetadata == null) {
+      this.fieldMetadata = new HashMap<>();
+    }
+    this.fieldMetadata.put(key, fieldMetadataItem);
+    return this;
+  }
+
+  /**
+   * User-supplied field metadata (string key-value pairs)
+   *
+   * @return fieldMetadata
+   */
+  @Schema(
+      name = "field_metadata",
+      description = "User-supplied field metadata (string key-value pairs)",
+      requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @JsonProperty("field_metadata")
+  public Map<String, String> getFieldMetadata() {
+    return fieldMetadata;
+  }
+
+  public void setFieldMetadata(Map<String, String> fieldMetadata) {
+    this.fieldMetadata = fieldMetadata;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -228,12 +363,28 @@ public class AddVirtualColumnEntry {
         && Objects.equals(this.image, addVirtualColumnEntry.image)
         && Objects.equals(this.udf, addVirtualColumnEntry.udf)
         && Objects.equals(this.udfName, addVirtualColumnEntry.udfName)
-        && Objects.equals(this.udfVersion, addVirtualColumnEntry.udfVersion);
+        && Objects.equals(this.udfVersion, addVirtualColumnEntry.udfVersion)
+        && Objects.equals(this.udfBackend, addVirtualColumnEntry.udfBackend)
+        && Objects.equals(this.autoBackfill, addVirtualColumnEntry.autoBackfill)
+        && Objects.equals(this.manifest, addVirtualColumnEntry.manifest)
+        && Objects.equals(this.manifestChecksum, addVirtualColumnEntry.manifestChecksum)
+        && Objects.equals(this.fieldMetadata, addVirtualColumnEntry.fieldMetadata);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(inputColumns, dataType, image, udf, udfName, udfVersion);
+    return Objects.hash(
+        inputColumns,
+        dataType,
+        image,
+        udf,
+        udfName,
+        udfVersion,
+        udfBackend,
+        autoBackfill,
+        manifest,
+        manifestChecksum,
+        fieldMetadata);
   }
 
   @Override
@@ -246,6 +397,11 @@ public class AddVirtualColumnEntry {
     sb.append("    udf: ").append(toIndentedString(udf)).append("\n");
     sb.append("    udfName: ").append(toIndentedString(udfName)).append("\n");
     sb.append("    udfVersion: ").append(toIndentedString(udfVersion)).append("\n");
+    sb.append("    udfBackend: ").append(toIndentedString(udfBackend)).append("\n");
+    sb.append("    autoBackfill: ").append(toIndentedString(autoBackfill)).append("\n");
+    sb.append("    manifest: ").append(toIndentedString(manifest)).append("\n");
+    sb.append("    manifestChecksum: ").append(toIndentedString(manifestChecksum)).append("\n");
+    sb.append("    fieldMetadata: ").append(toIndentedString(fieldMetadata)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/java/lance-namespace-springboot-server/src/main/java/org/lance/namespace/server/springboot/model/AlterTableAddColumnsRequest.java
+++ b/java/lance-namespace-springboot-server/src/main/java/org/lance/namespace/server/springboot/model/AlterTableAddColumnsRequest.java
@@ -30,6 +30,8 @@ import java.util.Objects;
     comments = "Generator version: 7.12.0")
 public class AlterTableAddColumnsRequest {
 
+  private Identity identity;
+
   @Valid private List<String> id = new ArrayList<>();
 
   @Valid private List<@Valid AddColumnsEntry> newColumns = new ArrayList<>();
@@ -41,6 +43,27 @@ public class AlterTableAddColumnsRequest {
   /** Constructor with only required parameters */
   public AlterTableAddColumnsRequest(List<@Valid AddColumnsEntry> newColumns) {
     this.newColumns = newColumns;
+  }
+
+  public AlterTableAddColumnsRequest identity(Identity identity) {
+    this.identity = identity;
+    return this;
+  }
+
+  /**
+   * Get identity
+   *
+   * @return identity
+   */
+  @Valid
+  @Schema(name = "identity", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @JsonProperty("identity")
+  public Identity getIdentity() {
+    return identity;
+  }
+
+  public void setIdentity(Identity identity) {
+    this.identity = identity;
   }
 
   public AlterTableAddColumnsRequest id(List<String> id) {
@@ -116,19 +139,21 @@ public class AlterTableAddColumnsRequest {
       return false;
     }
     AlterTableAddColumnsRequest alterTableAddColumnsRequest = (AlterTableAddColumnsRequest) o;
-    return Objects.equals(this.id, alterTableAddColumnsRequest.id)
+    return Objects.equals(this.identity, alterTableAddColumnsRequest.identity)
+        && Objects.equals(this.id, alterTableAddColumnsRequest.id)
         && Objects.equals(this.newColumns, alterTableAddColumnsRequest.newColumns);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, newColumns);
+    return Objects.hash(identity, id, newColumns);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class AlterTableAddColumnsRequest {\n");
+    sb.append("    identity: ").append(toIndentedString(identity)).append("\n");
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    newColumns: ").append(toIndentedString(newColumns)).append("\n");
     sb.append("}");

--- a/java/lance-namespace-springboot-server/src/main/java/org/lance/namespace/server/springboot/model/AlterTableAlterColumnsRequest.java
+++ b/java/lance-namespace-springboot-server/src/main/java/org/lance/namespace/server/springboot/model/AlterTableAlterColumnsRequest.java
@@ -30,6 +30,8 @@ import java.util.Objects;
     comments = "Generator version: 7.12.0")
 public class AlterTableAlterColumnsRequest {
 
+  private Identity identity;
+
   @Valid private List<String> id = new ArrayList<>();
 
   @Valid private List<@Valid AlterColumnsEntry> alterations = new ArrayList<>();
@@ -41,6 +43,27 @@ public class AlterTableAlterColumnsRequest {
   /** Constructor with only required parameters */
   public AlterTableAlterColumnsRequest(List<@Valid AlterColumnsEntry> alterations) {
     this.alterations = alterations;
+  }
+
+  public AlterTableAlterColumnsRequest identity(Identity identity) {
+    this.identity = identity;
+    return this;
+  }
+
+  /**
+   * Get identity
+   *
+   * @return identity
+   */
+  @Valid
+  @Schema(name = "identity", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @JsonProperty("identity")
+  public Identity getIdentity() {
+    return identity;
+  }
+
+  public void setIdentity(Identity identity) {
+    this.identity = identity;
   }
 
   public AlterTableAlterColumnsRequest id(List<String> id) {
@@ -116,19 +139,21 @@ public class AlterTableAlterColumnsRequest {
       return false;
     }
     AlterTableAlterColumnsRequest alterTableAlterColumnsRequest = (AlterTableAlterColumnsRequest) o;
-    return Objects.equals(this.id, alterTableAlterColumnsRequest.id)
+    return Objects.equals(this.identity, alterTableAlterColumnsRequest.identity)
+        && Objects.equals(this.id, alterTableAlterColumnsRequest.id)
         && Objects.equals(this.alterations, alterTableAlterColumnsRequest.alterations);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, alterations);
+    return Objects.hash(identity, id, alterations);
   }
 
   @Override
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class AlterTableAlterColumnsRequest {\n");
+    sb.append("    identity: ").append(toIndentedString(identity)).append("\n");
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    alterations: ").append(toIndentedString(alterations)).append("\n");
     sb.append("}");

--- a/java/lance-namespace-springboot-server/src/main/java/org/lance/namespace/server/springboot/model/AlterTableBackfillColumnsRequest.java
+++ b/java/lance-namespace-springboot-server/src/main/java/org/lance/namespace/server/springboot/model/AlterTableBackfillColumnsRequest.java
@@ -31,6 +31,8 @@ import java.util.Objects;
     comments = "Generator version: 7.12.0")
 public class AlterTableBackfillColumnsRequest {
 
+  private Identity identity;
+
   @Valid private List<String> id = new ArrayList<>();
 
   private String column;
@@ -68,6 +70,27 @@ public class AlterTableBackfillColumnsRequest {
   /** Constructor with only required parameters */
   public AlterTableBackfillColumnsRequest(String column) {
     this.column = column;
+  }
+
+  public AlterTableBackfillColumnsRequest identity(Identity identity) {
+    this.identity = identity;
+    return this;
+  }
+
+  /**
+   * Get identity
+   *
+   * @return identity
+   */
+  @Valid
+  @Schema(name = "identity", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @JsonProperty("identity")
+  public Identity getIdentity() {
+    return identity;
+  }
+
+  public void setIdentity(Identity identity) {
+    this.identity = identity;
   }
 
   public AlterTableBackfillColumnsRequest id(List<String> id) {
@@ -437,7 +460,8 @@ public class AlterTableBackfillColumnsRequest {
     }
     AlterTableBackfillColumnsRequest alterTableBackfillColumnsRequest =
         (AlterTableBackfillColumnsRequest) o;
-    return Objects.equals(this.id, alterTableBackfillColumnsRequest.id)
+    return Objects.equals(this.identity, alterTableBackfillColumnsRequest.identity)
+        && Objects.equals(this.id, alterTableBackfillColumnsRequest.id)
         && Objects.equals(this.column, alterTableBackfillColumnsRequest.column)
         && Objects.equals(this.where, alterTableBackfillColumnsRequest.where)
         && Objects.equals(this.concurrency, alterTableBackfillColumnsRequest.concurrency)
@@ -463,6 +487,7 @@ public class AlterTableBackfillColumnsRequest {
   @Override
   public int hashCode() {
     return Objects.hash(
+        identity,
         id,
         column,
         where,
@@ -484,6 +509,7 @@ public class AlterTableBackfillColumnsRequest {
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class AlterTableBackfillColumnsRequest {\n");
+    sb.append("    identity: ").append(toIndentedString(identity)).append("\n");
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    column: ").append(toIndentedString(column)).append("\n");
     sb.append("    where: ").append(toIndentedString(where)).append("\n");

--- a/java/lance-namespace-springboot-server/src/main/java/org/lance/namespace/server/springboot/model/AlterVirtualColumnEntry.java
+++ b/java/lance-namespace-springboot-server/src/main/java/org/lance/namespace/server/springboot/model/AlterVirtualColumnEntry.java
@@ -21,7 +21,9 @@ import jakarta.validation.constraints.*;
 
 import java.util.*;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 /** AlterVirtualColumnEntry */
@@ -39,6 +41,16 @@ public class AlterVirtualColumnEntry {
   private String udfName = null;
 
   private String udfVersion = null;
+
+  private String udfBackend = null;
+
+  private Boolean autoBackfill = null;
+
+  private String manifest = null;
+
+  private String manifestChecksum = null;
+
+  @Valid private Map<String, String> fieldMetadata = new HashMap<>();
 
   public AlterVirtualColumnEntry inputColumns(List<String> inputColumns) {
     this.inputColumns = inputColumns;
@@ -163,6 +175,129 @@ public class AlterVirtualColumnEntry {
     this.udfVersion = udfVersion;
   }
 
+  public AlterVirtualColumnEntry udfBackend(String udfBackend) {
+    this.udfBackend = udfBackend;
+    return this;
+  }
+
+  /**
+   * UDF backend type (e.g. DockerUDFSpecV1) (optional)
+   *
+   * @return udfBackend
+   */
+  @Schema(
+      name = "udf_backend",
+      description = "UDF backend type (e.g. DockerUDFSpecV1) (optional)",
+      requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @JsonProperty("udf_backend")
+  public String getUdfBackend() {
+    return udfBackend;
+  }
+
+  public void setUdfBackend(String udfBackend) {
+    this.udfBackend = udfBackend;
+  }
+
+  public AlterVirtualColumnEntry autoBackfill(Boolean autoBackfill) {
+    this.autoBackfill = autoBackfill;
+    return this;
+  }
+
+  /**
+   * Whether to automatically backfill the column (optional)
+   *
+   * @return autoBackfill
+   */
+  @Schema(
+      name = "auto_backfill",
+      description = "Whether to automatically backfill the column (optional)",
+      requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @JsonProperty("auto_backfill")
+  public Boolean getAutoBackfill() {
+    return autoBackfill;
+  }
+
+  public void setAutoBackfill(Boolean autoBackfill) {
+    this.autoBackfill = autoBackfill;
+  }
+
+  public AlterVirtualColumnEntry manifest(String manifest) {
+    this.manifest = manifest;
+    return this;
+  }
+
+  /**
+   * JSON-serialized manifest for the UDF environment (optional)
+   *
+   * @return manifest
+   */
+  @Schema(
+      name = "manifest",
+      description = "JSON-serialized manifest for the UDF environment (optional)",
+      requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @JsonProperty("manifest")
+  public String getManifest() {
+    return manifest;
+  }
+
+  public void setManifest(String manifest) {
+    this.manifest = manifest;
+  }
+
+  public AlterVirtualColumnEntry manifestChecksum(String manifestChecksum) {
+    this.manifestChecksum = manifestChecksum;
+    return this;
+  }
+
+  /**
+   * SHA-256 checksum of the manifest content (optional)
+   *
+   * @return manifestChecksum
+   */
+  @Schema(
+      name = "manifest_checksum",
+      description = "SHA-256 checksum of the manifest content (optional)",
+      requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @JsonProperty("manifest_checksum")
+  public String getManifestChecksum() {
+    return manifestChecksum;
+  }
+
+  public void setManifestChecksum(String manifestChecksum) {
+    this.manifestChecksum = manifestChecksum;
+  }
+
+  public AlterVirtualColumnEntry fieldMetadata(Map<String, String> fieldMetadata) {
+    this.fieldMetadata = fieldMetadata;
+    return this;
+  }
+
+  public AlterVirtualColumnEntry putFieldMetadataItem(String key, String fieldMetadataItem) {
+    if (this.fieldMetadata == null) {
+      this.fieldMetadata = new HashMap<>();
+    }
+    this.fieldMetadata.put(key, fieldMetadataItem);
+    return this;
+  }
+
+  /**
+   * User-supplied field metadata (optional)
+   *
+   * @return fieldMetadata
+   */
+  @Schema(
+      name = "field_metadata",
+      description = "User-supplied field metadata (optional)",
+      requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @JsonProperty("field_metadata")
+  public Map<String, String> getFieldMetadata() {
+    return fieldMetadata;
+  }
+
+  public void setFieldMetadata(Map<String, String> fieldMetadata) {
+    this.fieldMetadata = fieldMetadata;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -176,12 +311,27 @@ public class AlterVirtualColumnEntry {
         && Objects.equals(this.image, alterVirtualColumnEntry.image)
         && Objects.equals(this.udf, alterVirtualColumnEntry.udf)
         && Objects.equals(this.udfName, alterVirtualColumnEntry.udfName)
-        && Objects.equals(this.udfVersion, alterVirtualColumnEntry.udfVersion);
+        && Objects.equals(this.udfVersion, alterVirtualColumnEntry.udfVersion)
+        && Objects.equals(this.udfBackend, alterVirtualColumnEntry.udfBackend)
+        && Objects.equals(this.autoBackfill, alterVirtualColumnEntry.autoBackfill)
+        && Objects.equals(this.manifest, alterVirtualColumnEntry.manifest)
+        && Objects.equals(this.manifestChecksum, alterVirtualColumnEntry.manifestChecksum)
+        && Objects.equals(this.fieldMetadata, alterVirtualColumnEntry.fieldMetadata);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(inputColumns, image, udf, udfName, udfVersion);
+    return Objects.hash(
+        inputColumns,
+        image,
+        udf,
+        udfName,
+        udfVersion,
+        udfBackend,
+        autoBackfill,
+        manifest,
+        manifestChecksum,
+        fieldMetadata);
   }
 
   @Override
@@ -193,6 +343,11 @@ public class AlterVirtualColumnEntry {
     sb.append("    udf: ").append(toIndentedString(udf)).append("\n");
     sb.append("    udfName: ").append(toIndentedString(udfName)).append("\n");
     sb.append("    udfVersion: ").append(toIndentedString(udfVersion)).append("\n");
+    sb.append("    udfBackend: ").append(toIndentedString(udfBackend)).append("\n");
+    sb.append("    autoBackfill: ").append(toIndentedString(autoBackfill)).append("\n");
+    sb.append("    manifest: ").append(toIndentedString(manifest)).append("\n");
+    sb.append("    manifestChecksum: ").append(toIndentedString(manifestChecksum)).append("\n");
+    sb.append("    fieldMetadata: ").append(toIndentedString(fieldMetadata)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/java/lance-namespace-springboot-server/src/main/java/org/lance/namespace/server/springboot/model/RefreshMaterializedViewRequest.java
+++ b/java/lance-namespace-springboot-server/src/main/java/org/lance/namespace/server/springboot/model/RefreshMaterializedViewRequest.java
@@ -30,6 +30,8 @@ import java.util.Objects;
     comments = "Generator version: 7.12.0")
 public class RefreshMaterializedViewRequest {
 
+  private Identity identity;
+
   @Valid private List<String> id = new ArrayList<>();
 
   private Integer srcVersion = null;
@@ -43,6 +45,27 @@ public class RefreshMaterializedViewRequest {
   private String cluster = null;
 
   private String manifest = null;
+
+  public RefreshMaterializedViewRequest identity(Identity identity) {
+    this.identity = identity;
+    return this;
+  }
+
+  /**
+   * Get identity
+   *
+   * @return identity
+   */
+  @Valid
+  @Schema(name = "identity", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @JsonProperty("identity")
+  public Identity getIdentity() {
+    return identity;
+  }
+
+  public void setIdentity(Identity identity) {
+    this.identity = identity;
+  }
 
   public RefreshMaterializedViewRequest id(List<String> id) {
     this.id = id;
@@ -223,7 +246,8 @@ public class RefreshMaterializedViewRequest {
     }
     RefreshMaterializedViewRequest refreshMaterializedViewRequest =
         (RefreshMaterializedViewRequest) o;
-    return Objects.equals(this.id, refreshMaterializedViewRequest.id)
+    return Objects.equals(this.identity, refreshMaterializedViewRequest.identity)
+        && Objects.equals(this.id, refreshMaterializedViewRequest.id)
         && Objects.equals(this.srcVersion, refreshMaterializedViewRequest.srcVersion)
         && Objects.equals(
             this.maxRowsPerFragment, refreshMaterializedViewRequest.maxRowsPerFragment)
@@ -237,6 +261,7 @@ public class RefreshMaterializedViewRequest {
   @Override
   public int hashCode() {
     return Objects.hash(
+        identity,
         id,
         srcVersion,
         maxRowsPerFragment,
@@ -250,6 +275,7 @@ public class RefreshMaterializedViewRequest {
   public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("class RefreshMaterializedViewRequest {\n");
+    sb.append("    identity: ").append(toIndentedString(identity)).append("\n");
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    srcVersion: ").append(toIndentedString(srcVersion)).append("\n");
     sb.append("    maxRowsPerFragment: ").append(toIndentedString(maxRowsPerFragment)).append("\n");

--- a/python/lance_namespace_urllib3_client/docs/AddVirtualColumnEntry.md
+++ b/python/lance_namespace_urllib3_client/docs/AddVirtualColumnEntry.md
@@ -11,6 +11,11 @@ Name | Type | Description | Notes
 **udf** | **str** | Base64 encoded pickled UDF | 
 **udf_name** | **str** | Name of the UDF | 
 **udf_version** | **str** | Version of the UDF | 
+**udf_backend** | **str** | UDF backend type (e.g. DockerUDFSpecV1) | [optional] 
+**auto_backfill** | **bool** | Whether to automatically backfill the column after creation | [optional] 
+**manifest** | **str** | JSON-serialized manifest for the UDF environment | [optional] 
+**manifest_checksum** | **str** | SHA-256 checksum of the manifest content | [optional] 
+**field_metadata** | **Dict[str, str]** | User-supplied field metadata (string key-value pairs) | [optional] 
 
 ## Example
 

--- a/python/lance_namespace_urllib3_client/docs/AlterTableAddColumnsRequest.md
+++ b/python/lance_namespace_urllib3_client/docs/AlterTableAddColumnsRequest.md
@@ -5,6 +5,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**identity** | [**Identity**](Identity.md) |  | [optional] 
 **id** | **List[str]** | Table identifier path (namespace + table name) | [optional] 
 **new_columns** | [**List[AddColumnsEntry]**](AddColumnsEntry.md) | List of new columns to add to the table | 
 

--- a/python/lance_namespace_urllib3_client/docs/AlterTableAlterColumnsRequest.md
+++ b/python/lance_namespace_urllib3_client/docs/AlterTableAlterColumnsRequest.md
@@ -5,6 +5,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**identity** | [**Identity**](Identity.md) |  | [optional] 
 **id** | **List[str]** | Table identifier path (namespace + table name) | [optional] 
 **alterations** | [**List[AlterColumnsEntry]**](AlterColumnsEntry.md) | List of column alterations to apply to the table | 
 

--- a/python/lance_namespace_urllib3_client/docs/AlterTableBackfillColumnsRequest.md
+++ b/python/lance_namespace_urllib3_client/docs/AlterTableBackfillColumnsRequest.md
@@ -5,6 +5,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**identity** | [**Identity**](Identity.md) |  | [optional] 
 **id** | **List[str]** | Table identifier path (namespace + table name) | [optional] 
 **column** | **str** | Column name to backfill | 
 **where** | **str** | Optional WHERE clause filter | [optional] 

--- a/python/lance_namespace_urllib3_client/docs/AlterVirtualColumnEntry.md
+++ b/python/lance_namespace_urllib3_client/docs/AlterVirtualColumnEntry.md
@@ -10,6 +10,11 @@ Name | Type | Description | Notes
 **udf** | **str** | Base64 encoded pickled UDF (optional) | [optional] 
 **udf_name** | **str** | Name of the UDF (optional) | [optional] 
 **udf_version** | **str** | Version of the UDF (optional) | [optional] 
+**udf_backend** | **str** | UDF backend type (e.g. DockerUDFSpecV1) (optional) | [optional] 
+**auto_backfill** | **bool** | Whether to automatically backfill the column (optional) | [optional] 
+**manifest** | **str** | JSON-serialized manifest for the UDF environment (optional) | [optional] 
+**manifest_checksum** | **str** | SHA-256 checksum of the manifest content (optional) | [optional] 
+**field_metadata** | **Dict[str, str]** | User-supplied field metadata (optional) | [optional] 
 
 ## Example
 

--- a/python/lance_namespace_urllib3_client/docs/RefreshMaterializedViewRequest.md
+++ b/python/lance_namespace_urllib3_client/docs/RefreshMaterializedViewRequest.md
@@ -5,6 +5,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**identity** | [**Identity**](Identity.md) |  | [optional] 
 **id** | **List[str]** | Table identifier path (namespace + table name) | [optional] 
 **src_version** | **int** | Optional source version to refresh from | [optional] 
 **max_rows_per_fragment** | **int** | Optional maximum rows per fragment | [optional] 

--- a/python/lance_namespace_urllib3_client/lance_namespace_urllib3_client/models/add_virtual_column_entry.py
+++ b/python/lance_namespace_urllib3_client/lance_namespace_urllib3_client/models/add_virtual_column_entry.py
@@ -17,8 +17,8 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, Field, StrictStr
-from typing import Any, ClassVar, Dict, List
+from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictStr
+from typing import Any, ClassVar, Dict, List, Optional
 from typing import Optional, Set
 from typing_extensions import Self
 
@@ -32,7 +32,12 @@ class AddVirtualColumnEntry(BaseModel):
     udf: StrictStr = Field(description="Base64 encoded pickled UDF")
     udf_name: StrictStr = Field(description="Name of the UDF")
     udf_version: StrictStr = Field(description="Version of the UDF")
-    __properties: ClassVar[List[str]] = ["input_columns", "data_type", "image", "udf", "udf_name", "udf_version"]
+    udf_backend: Optional[StrictStr] = Field(default=None, description="UDF backend type (e.g. DockerUDFSpecV1)")
+    auto_backfill: Optional[StrictBool] = Field(default=None, description="Whether to automatically backfill the column after creation")
+    manifest: Optional[StrictStr] = Field(default=None, description="JSON-serialized manifest for the UDF environment")
+    manifest_checksum: Optional[StrictStr] = Field(default=None, description="SHA-256 checksum of the manifest content")
+    field_metadata: Optional[Dict[str, StrictStr]] = Field(default=None, description="User-supplied field metadata (string key-value pairs)")
+    __properties: ClassVar[List[str]] = ["input_columns", "data_type", "image", "udf", "udf_name", "udf_version", "udf_backend", "auto_backfill", "manifest", "manifest_checksum", "field_metadata"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -73,6 +78,26 @@ class AddVirtualColumnEntry(BaseModel):
             exclude=excluded_fields,
             exclude_none=True,
         )
+        # set to None if udf_backend (nullable) is None
+        # and model_fields_set contains the field
+        if self.udf_backend is None and "udf_backend" in self.model_fields_set:
+            _dict['udf_backend'] = None
+
+        # set to None if auto_backfill (nullable) is None
+        # and model_fields_set contains the field
+        if self.auto_backfill is None and "auto_backfill" in self.model_fields_set:
+            _dict['auto_backfill'] = None
+
+        # set to None if manifest (nullable) is None
+        # and model_fields_set contains the field
+        if self.manifest is None and "manifest" in self.model_fields_set:
+            _dict['manifest'] = None
+
+        # set to None if manifest_checksum (nullable) is None
+        # and model_fields_set contains the field
+        if self.manifest_checksum is None and "manifest_checksum" in self.model_fields_set:
+            _dict['manifest_checksum'] = None
+
         return _dict
 
     @classmethod
@@ -90,7 +115,12 @@ class AddVirtualColumnEntry(BaseModel):
             "image": obj.get("image"),
             "udf": obj.get("udf"),
             "udf_name": obj.get("udf_name"),
-            "udf_version": obj.get("udf_version")
+            "udf_version": obj.get("udf_version"),
+            "udf_backend": obj.get("udf_backend"),
+            "auto_backfill": obj.get("auto_backfill"),
+            "manifest": obj.get("manifest"),
+            "manifest_checksum": obj.get("manifest_checksum"),
+            "field_metadata": obj.get("field_metadata")
         })
         return _obj
 

--- a/python/lance_namespace_urllib3_client/lance_namespace_urllib3_client/models/alter_table_add_columns_request.py
+++ b/python/lance_namespace_urllib3_client/lance_namespace_urllib3_client/models/alter_table_add_columns_request.py
@@ -20,6 +20,7 @@ import json
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional
 from lance_namespace_urllib3_client.models.add_columns_entry import AddColumnsEntry
+from lance_namespace_urllib3_client.models.identity import Identity
 from typing import Optional, Set
 from typing_extensions import Self
 
@@ -27,9 +28,10 @@ class AlterTableAddColumnsRequest(BaseModel):
     """
     AlterTableAddColumnsRequest
     """ # noqa: E501
+    identity: Optional[Identity] = None
     id: Optional[List[StrictStr]] = Field(default=None, description="Table identifier path (namespace + table name)")
     new_columns: List[AddColumnsEntry] = Field(description="List of new columns to add to the table")
-    __properties: ClassVar[List[str]] = ["id", "new_columns"]
+    __properties: ClassVar[List[str]] = ["identity", "id", "new_columns"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -70,6 +72,9 @@ class AlterTableAddColumnsRequest(BaseModel):
             exclude=excluded_fields,
             exclude_none=True,
         )
+        # override the default output from pydantic by calling `to_dict()` of identity
+        if self.identity:
+            _dict['identity'] = self.identity.to_dict()
         # override the default output from pydantic by calling `to_dict()` of each item in new_columns (list)
         _items = []
         if self.new_columns:
@@ -89,6 +94,7 @@ class AlterTableAddColumnsRequest(BaseModel):
             return cls.model_validate(obj)
 
         _obj = cls.model_validate({
+            "identity": Identity.from_dict(obj["identity"]) if obj.get("identity") is not None else None,
             "id": obj.get("id"),
             "new_columns": [AddColumnsEntry.from_dict(_item) for _item in obj["new_columns"]] if obj.get("new_columns") is not None else None
         })

--- a/python/lance_namespace_urllib3_client/lance_namespace_urllib3_client/models/alter_table_alter_columns_request.py
+++ b/python/lance_namespace_urllib3_client/lance_namespace_urllib3_client/models/alter_table_alter_columns_request.py
@@ -20,6 +20,7 @@ import json
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional
 from lance_namespace_urllib3_client.models.alter_columns_entry import AlterColumnsEntry
+from lance_namespace_urllib3_client.models.identity import Identity
 from typing import Optional, Set
 from typing_extensions import Self
 
@@ -27,9 +28,10 @@ class AlterTableAlterColumnsRequest(BaseModel):
     """
     AlterTableAlterColumnsRequest
     """ # noqa: E501
+    identity: Optional[Identity] = None
     id: Optional[List[StrictStr]] = Field(default=None, description="Table identifier path (namespace + table name)")
     alterations: List[AlterColumnsEntry] = Field(description="List of column alterations to apply to the table")
-    __properties: ClassVar[List[str]] = ["id", "alterations"]
+    __properties: ClassVar[List[str]] = ["identity", "id", "alterations"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -70,6 +72,9 @@ class AlterTableAlterColumnsRequest(BaseModel):
             exclude=excluded_fields,
             exclude_none=True,
         )
+        # override the default output from pydantic by calling `to_dict()` of identity
+        if self.identity:
+            _dict['identity'] = self.identity.to_dict()
         # override the default output from pydantic by calling `to_dict()` of each item in alterations (list)
         _items = []
         if self.alterations:
@@ -89,6 +94,7 @@ class AlterTableAlterColumnsRequest(BaseModel):
             return cls.model_validate(obj)
 
         _obj = cls.model_validate({
+            "identity": Identity.from_dict(obj["identity"]) if obj.get("identity") is not None else None,
             "id": obj.get("id"),
             "alterations": [AlterColumnsEntry.from_dict(_item) for _item in obj["alterations"]] if obj.get("alterations") is not None else None
         })

--- a/python/lance_namespace_urllib3_client/lance_namespace_urllib3_client/models/alter_table_backfill_columns_request.py
+++ b/python/lance_namespace_urllib3_client/lance_namespace_urllib3_client/models/alter_table_backfill_columns_request.py
@@ -19,6 +19,7 @@ import json
 
 from pydantic import BaseModel, ConfigDict, Field, StrictFloat, StrictInt, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional, Union
+from lance_namespace_urllib3_client.models.identity import Identity
 from typing import Optional, Set
 from typing_extensions import Self
 
@@ -26,6 +27,7 @@ class AlterTableBackfillColumnsRequest(BaseModel):
     """
     AlterTableBackfillColumnsRequest
     """ # noqa: E501
+    identity: Optional[Identity] = None
     id: Optional[List[StrictStr]] = Field(default=None, description="Table identifier path (namespace + table name)")
     column: StrictStr = Field(description="Column name to backfill")
     where: Optional[StrictStr] = Field(default=None, description="Optional WHERE clause filter")
@@ -41,7 +43,7 @@ class AlterTableBackfillColumnsRequest(BaseModel):
     commit_granularity: Optional[StrictInt] = Field(default=None, description="Optional commit granularity")
     cluster: Optional[StrictStr] = Field(default=None, description="Optional cluster name")
     manifest: Optional[StrictStr] = Field(default=None, description="Optional manifest name")
-    __properties: ClassVar[List[str]] = ["id", "column", "where", "concurrency", "intra_applier_concurrency", "min_checkpoint_size", "max_checkpoint_size", "batch_checkpoint_flush_interval_seconds", "read_version", "task_size", "num_frags", "checkpoint_size", "commit_granularity", "cluster", "manifest"]
+    __properties: ClassVar[List[str]] = ["identity", "id", "column", "where", "concurrency", "intra_applier_concurrency", "min_checkpoint_size", "max_checkpoint_size", "batch_checkpoint_flush_interval_seconds", "read_version", "task_size", "num_frags", "checkpoint_size", "commit_granularity", "cluster", "manifest"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -82,6 +84,9 @@ class AlterTableBackfillColumnsRequest(BaseModel):
             exclude=excluded_fields,
             exclude_none=True,
         )
+        # override the default output from pydantic by calling `to_dict()` of identity
+        if self.identity:
+            _dict['identity'] = self.identity.to_dict()
         # set to None if where (nullable) is None
         # and model_fields_set contains the field
         if self.where is None and "where" in self.model_fields_set:
@@ -159,6 +164,7 @@ class AlterTableBackfillColumnsRequest(BaseModel):
             return cls.model_validate(obj)
 
         _obj = cls.model_validate({
+            "identity": Identity.from_dict(obj["identity"]) if obj.get("identity") is not None else None,
             "id": obj.get("id"),
             "column": obj.get("column"),
             "where": obj.get("where"),

--- a/python/lance_namespace_urllib3_client/lance_namespace_urllib3_client/models/alter_virtual_column_entry.py
+++ b/python/lance_namespace_urllib3_client/lance_namespace_urllib3_client/models/alter_virtual_column_entry.py
@@ -17,7 +17,7 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, Field, StrictStr
+from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional
 from typing import Optional, Set
 from typing_extensions import Self
@@ -31,7 +31,12 @@ class AlterVirtualColumnEntry(BaseModel):
     udf: Optional[StrictStr] = Field(default=None, description="Base64 encoded pickled UDF (optional)")
     udf_name: Optional[StrictStr] = Field(default=None, description="Name of the UDF (optional)")
     udf_version: Optional[StrictStr] = Field(default=None, description="Version of the UDF (optional)")
-    __properties: ClassVar[List[str]] = ["input_columns", "image", "udf", "udf_name", "udf_version"]
+    udf_backend: Optional[StrictStr] = Field(default=None, description="UDF backend type (e.g. DockerUDFSpecV1) (optional)")
+    auto_backfill: Optional[StrictBool] = Field(default=None, description="Whether to automatically backfill the column (optional)")
+    manifest: Optional[StrictStr] = Field(default=None, description="JSON-serialized manifest for the UDF environment (optional)")
+    manifest_checksum: Optional[StrictStr] = Field(default=None, description="SHA-256 checksum of the manifest content (optional)")
+    field_metadata: Optional[Dict[str, StrictStr]] = Field(default=None, description="User-supplied field metadata (optional)")
+    __properties: ClassVar[List[str]] = ["input_columns", "image", "udf", "udf_name", "udf_version", "udf_backend", "auto_backfill", "manifest", "manifest_checksum", "field_metadata"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -97,6 +102,26 @@ class AlterVirtualColumnEntry(BaseModel):
         if self.udf_version is None and "udf_version" in self.model_fields_set:
             _dict['udf_version'] = None
 
+        # set to None if udf_backend (nullable) is None
+        # and model_fields_set contains the field
+        if self.udf_backend is None and "udf_backend" in self.model_fields_set:
+            _dict['udf_backend'] = None
+
+        # set to None if auto_backfill (nullable) is None
+        # and model_fields_set contains the field
+        if self.auto_backfill is None and "auto_backfill" in self.model_fields_set:
+            _dict['auto_backfill'] = None
+
+        # set to None if manifest (nullable) is None
+        # and model_fields_set contains the field
+        if self.manifest is None and "manifest" in self.model_fields_set:
+            _dict['manifest'] = None
+
+        # set to None if manifest_checksum (nullable) is None
+        # and model_fields_set contains the field
+        if self.manifest_checksum is None and "manifest_checksum" in self.model_fields_set:
+            _dict['manifest_checksum'] = None
+
         return _dict
 
     @classmethod
@@ -113,7 +138,12 @@ class AlterVirtualColumnEntry(BaseModel):
             "image": obj.get("image"),
             "udf": obj.get("udf"),
             "udf_name": obj.get("udf_name"),
-            "udf_version": obj.get("udf_version")
+            "udf_version": obj.get("udf_version"),
+            "udf_backend": obj.get("udf_backend"),
+            "auto_backfill": obj.get("auto_backfill"),
+            "manifest": obj.get("manifest"),
+            "manifest_checksum": obj.get("manifest_checksum"),
+            "field_metadata": obj.get("field_metadata")
         })
         return _obj
 

--- a/python/lance_namespace_urllib3_client/lance_namespace_urllib3_client/models/refresh_materialized_view_request.py
+++ b/python/lance_namespace_urllib3_client/lance_namespace_urllib3_client/models/refresh_materialized_view_request.py
@@ -19,6 +19,7 @@ import json
 
 from pydantic import BaseModel, ConfigDict, Field, StrictInt, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional
+from lance_namespace_urllib3_client.models.identity import Identity
 from typing import Optional, Set
 from typing_extensions import Self
 
@@ -26,6 +27,7 @@ class RefreshMaterializedViewRequest(BaseModel):
     """
     RefreshMaterializedViewRequest
     """ # noqa: E501
+    identity: Optional[Identity] = None
     id: Optional[List[StrictStr]] = Field(default=None, description="Table identifier path (namespace + table name)")
     src_version: Optional[StrictInt] = Field(default=None, description="Optional source version to refresh from")
     max_rows_per_fragment: Optional[StrictInt] = Field(default=None, description="Optional maximum rows per fragment")
@@ -33,7 +35,7 @@ class RefreshMaterializedViewRequest(BaseModel):
     intra_applier_concurrency: Optional[StrictInt] = Field(default=None, description="Optional intra-applier concurrency override")
     cluster: Optional[StrictStr] = Field(default=None, description="Optional cluster name")
     manifest: Optional[StrictStr] = Field(default=None, description="Optional manifest name")
-    __properties: ClassVar[List[str]] = ["id", "src_version", "max_rows_per_fragment", "concurrency", "intra_applier_concurrency", "cluster", "manifest"]
+    __properties: ClassVar[List[str]] = ["identity", "id", "src_version", "max_rows_per_fragment", "concurrency", "intra_applier_concurrency", "cluster", "manifest"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -74,6 +76,9 @@ class RefreshMaterializedViewRequest(BaseModel):
             exclude=excluded_fields,
             exclude_none=True,
         )
+        # override the default output from pydantic by calling `to_dict()` of identity
+        if self.identity:
+            _dict['identity'] = self.identity.to_dict()
         # set to None if src_version (nullable) is None
         # and model_fields_set contains the field
         if self.src_version is None and "src_version" in self.model_fields_set:
@@ -116,6 +121,7 @@ class RefreshMaterializedViewRequest(BaseModel):
             return cls.model_validate(obj)
 
         _obj = cls.model_validate({
+            "identity": Identity.from_dict(obj["identity"]) if obj.get("identity") is not None else None,
             "id": obj.get("id"),
             "src_version": obj.get("src_version"),
             "max_rows_per_fragment": obj.get("max_rows_per_fragment"),

--- a/python/lance_namespace_urllib3_client/test/test_add_columns_entry.py
+++ b/python/lance_namespace_urllib3_client/test/test_add_columns_entry.py
@@ -45,7 +45,14 @@ class TestAddColumnsEntry(unittest.TestCase):
                     image = '', 
                     udf = '', 
                     udf_name = '', 
-                    udf_version = '', )
+                    udf_version = '', 
+                    udf_backend = '', 
+                    auto_backfill = True, 
+                    manifest = '', 
+                    manifest_checksum = '', 
+                    field_metadata = {
+                        'key' : ''
+                        }, )
             )
         else:
             return AddColumnsEntry(

--- a/python/lance_namespace_urllib3_client/test/test_add_virtual_column_entry.py
+++ b/python/lance_namespace_urllib3_client/test/test_add_virtual_column_entry.py
@@ -42,7 +42,14 @@ class TestAddVirtualColumnEntry(unittest.TestCase):
                 image = '',
                 udf = '',
                 udf_name = '',
-                udf_version = ''
+                udf_version = '',
+                udf_backend = '',
+                auto_backfill = True,
+                manifest = '',
+                manifest_checksum = '',
+                field_metadata = {
+                    'key' : ''
+                    }
             )
         else:
             return AddVirtualColumnEntry(

--- a/python/lance_namespace_urllib3_client/test/test_alter_columns_entry.py
+++ b/python/lance_namespace_urllib3_client/test/test_alter_columns_entry.py
@@ -46,7 +46,14 @@ class TestAlterColumnsEntry(unittest.TestCase):
                     image = '', 
                     udf = '', 
                     udf_name = '', 
-                    udf_version = '', )
+                    udf_version = '', 
+                    udf_backend = '', 
+                    auto_backfill = True, 
+                    manifest = '', 
+                    manifest_checksum = '', 
+                    field_metadata = {
+                        'key' : ''
+                        }, )
             )
         else:
             return AlterColumnsEntry(

--- a/python/lance_namespace_urllib3_client/test/test_alter_table_add_columns_request.py
+++ b/python/lance_namespace_urllib3_client/test/test_alter_table_add_columns_request.py
@@ -35,6 +35,9 @@ class TestAlterTableAddColumnsRequest(unittest.TestCase):
         model = AlterTableAddColumnsRequest()
         if include_optional:
             return AlterTableAddColumnsRequest(
+                identity = lance_namespace_urllib3_client.models.identity.Identity(
+                    api_key = '', 
+                    auth_token = '', ),
                 id = [
                     ''
                     ],
@@ -50,7 +53,14 @@ class TestAlterTableAddColumnsRequest(unittest.TestCase):
                             image = '', 
                             udf = '', 
                             udf_name = '', 
-                            udf_version = '', ), )
+                            udf_version = '', 
+                            udf_backend = '', 
+                            auto_backfill = True, 
+                            manifest = '', 
+                            manifest_checksum = '', 
+                            field_metadata = {
+                                'key' : ''
+                                }, ), )
                     ]
             )
         else:
@@ -67,7 +77,14 @@ class TestAlterTableAddColumnsRequest(unittest.TestCase):
                             image = '', 
                             udf = '', 
                             udf_name = '', 
-                            udf_version = '', ), )
+                            udf_version = '', 
+                            udf_backend = '', 
+                            auto_backfill = True, 
+                            manifest = '', 
+                            manifest_checksum = '', 
+                            field_metadata = {
+                                'key' : ''
+                                }, ), )
                     ],
         )
         """

--- a/python/lance_namespace_urllib3_client/test/test_alter_table_alter_columns_request.py
+++ b/python/lance_namespace_urllib3_client/test/test_alter_table_alter_columns_request.py
@@ -35,6 +35,9 @@ class TestAlterTableAlterColumnsRequest(unittest.TestCase):
         model = AlterTableAlterColumnsRequest()
         if include_optional:
             return AlterTableAlterColumnsRequest(
+                identity = lance_namespace_urllib3_client.models.identity.Identity(
+                    api_key = '', 
+                    auth_token = '', ),
                 id = [
                     ''
                     ],
@@ -51,7 +54,14 @@ class TestAlterTableAlterColumnsRequest(unittest.TestCase):
                             image = '', 
                             udf = '', 
                             udf_name = '', 
-                            udf_version = '', ), )
+                            udf_version = '', 
+                            udf_backend = '', 
+                            auto_backfill = True, 
+                            manifest = '', 
+                            manifest_checksum = '', 
+                            field_metadata = {
+                                'key' : ''
+                                }, ), )
                     ]
             )
         else:
@@ -69,7 +79,14 @@ class TestAlterTableAlterColumnsRequest(unittest.TestCase):
                             image = '', 
                             udf = '', 
                             udf_name = '', 
-                            udf_version = '', ), )
+                            udf_version = '', 
+                            udf_backend = '', 
+                            auto_backfill = True, 
+                            manifest = '', 
+                            manifest_checksum = '', 
+                            field_metadata = {
+                                'key' : ''
+                                }, ), )
                     ],
         )
         """

--- a/python/lance_namespace_urllib3_client/test/test_alter_table_backfill_columns_request.py
+++ b/python/lance_namespace_urllib3_client/test/test_alter_table_backfill_columns_request.py
@@ -35,6 +35,9 @@ class TestAlterTableBackfillColumnsRequest(unittest.TestCase):
         model = AlterTableBackfillColumnsRequest()
         if include_optional:
             return AlterTableBackfillColumnsRequest(
+                identity = lance_namespace_urllib3_client.models.identity.Identity(
+                    api_key = '', 
+                    auth_token = '', ),
                 id = [
                     ''
                     ],

--- a/python/lance_namespace_urllib3_client/test/test_alter_virtual_column_entry.py
+++ b/python/lance_namespace_urllib3_client/test/test_alter_virtual_column_entry.py
@@ -41,7 +41,14 @@ class TestAlterVirtualColumnEntry(unittest.TestCase):
                 image = '',
                 udf = '',
                 udf_name = '',
-                udf_version = ''
+                udf_version = '',
+                udf_backend = '',
+                auto_backfill = True,
+                manifest = '',
+                manifest_checksum = '',
+                field_metadata = {
+                    'key' : ''
+                    }
             )
         else:
             return AlterVirtualColumnEntry(

--- a/python/lance_namespace_urllib3_client/test/test_refresh_materialized_view_request.py
+++ b/python/lance_namespace_urllib3_client/test/test_refresh_materialized_view_request.py
@@ -35,6 +35,9 @@ class TestRefreshMaterializedViewRequest(unittest.TestCase):
         model = RefreshMaterializedViewRequest()
         if include_optional:
             return RefreshMaterializedViewRequest(
+                identity = lance_namespace_urllib3_client.models.identity.Identity(
+                    api_key = '', 
+                    auth_token = '', ),
                 id = [
                     ''
                     ],

--- a/rust/lance-namespace-reqwest-client/docs/AddVirtualColumnEntry.md
+++ b/rust/lance-namespace-reqwest-client/docs/AddVirtualColumnEntry.md
@@ -10,6 +10,11 @@ Name | Type | Description | Notes
 **udf** | **String** | Base64 encoded pickled UDF | 
 **udf_name** | **String** | Name of the UDF | 
 **udf_version** | **String** | Version of the UDF | 
+**udf_backend** | Option<**String**> | UDF backend type (e.g. DockerUDFSpecV1) | [optional]
+**auto_backfill** | Option<**bool**> | Whether to automatically backfill the column after creation | [optional]
+**manifest** | Option<**String**> | JSON-serialized manifest for the UDF environment | [optional]
+**manifest_checksum** | Option<**String**> | SHA-256 checksum of the manifest content | [optional]
+**field_metadata** | Option<**std::collections::HashMap<String, String>**> | User-supplied field metadata (string key-value pairs) | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/rust/lance-namespace-reqwest-client/docs/AlterTableAddColumnsRequest.md
+++ b/rust/lance-namespace-reqwest-client/docs/AlterTableAddColumnsRequest.md
@@ -4,6 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**identity** | Option<[**models::Identity**](Identity.md)> |  | [optional]
 **id** | Option<**Vec<String>**> | Table identifier path (namespace + table name) | [optional]
 **new_columns** | [**Vec<models::AddColumnsEntry>**](AddColumnsEntry.md) | List of new columns to add to the table | 
 

--- a/rust/lance-namespace-reqwest-client/docs/AlterTableAlterColumnsRequest.md
+++ b/rust/lance-namespace-reqwest-client/docs/AlterTableAlterColumnsRequest.md
@@ -4,6 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**identity** | Option<[**models::Identity**](Identity.md)> |  | [optional]
 **id** | Option<**Vec<String>**> | Table identifier path (namespace + table name) | [optional]
 **alterations** | [**Vec<models::AlterColumnsEntry>**](AlterColumnsEntry.md) | List of column alterations to apply to the table | 
 

--- a/rust/lance-namespace-reqwest-client/docs/AlterTableBackfillColumnsRequest.md
+++ b/rust/lance-namespace-reqwest-client/docs/AlterTableBackfillColumnsRequest.md
@@ -4,6 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**identity** | Option<[**models::Identity**](Identity.md)> |  | [optional]
 **id** | Option<**Vec<String>**> | Table identifier path (namespace + table name) | [optional]
 **column** | **String** | Column name to backfill | 
 **r#where** | Option<**String**> | Optional WHERE clause filter | [optional]

--- a/rust/lance-namespace-reqwest-client/docs/AlterVirtualColumnEntry.md
+++ b/rust/lance-namespace-reqwest-client/docs/AlterVirtualColumnEntry.md
@@ -9,6 +9,11 @@ Name | Type | Description | Notes
 **udf** | Option<**String**> | Base64 encoded pickled UDF (optional) | [optional]
 **udf_name** | Option<**String**> | Name of the UDF (optional) | [optional]
 **udf_version** | Option<**String**> | Version of the UDF (optional) | [optional]
+**udf_backend** | Option<**String**> | UDF backend type (e.g. DockerUDFSpecV1) (optional) | [optional]
+**auto_backfill** | Option<**bool**> | Whether to automatically backfill the column (optional) | [optional]
+**manifest** | Option<**String**> | JSON-serialized manifest for the UDF environment (optional) | [optional]
+**manifest_checksum** | Option<**String**> | SHA-256 checksum of the manifest content (optional) | [optional]
+**field_metadata** | Option<**std::collections::HashMap<String, String>**> | User-supplied field metadata (optional) | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/rust/lance-namespace-reqwest-client/docs/RefreshMaterializedViewRequest.md
+++ b/rust/lance-namespace-reqwest-client/docs/RefreshMaterializedViewRequest.md
@@ -4,6 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**identity** | Option<[**models::Identity**](Identity.md)> |  | [optional]
 **id** | Option<**Vec<String>**> | Table identifier path (namespace + table name) | [optional]
 **src_version** | Option<**i32**> | Optional source version to refresh from | [optional]
 **max_rows_per_fragment** | Option<**i32**> | Optional maximum rows per fragment | [optional]

--- a/rust/lance-namespace-reqwest-client/src/models/add_virtual_column_entry.rs
+++ b/rust/lance-namespace-reqwest-client/src/models/add_virtual_column_entry.rs
@@ -31,6 +31,21 @@ pub struct AddVirtualColumnEntry {
     /// Version of the UDF
     #[serde(rename = "udf_version")]
     pub udf_version: String,
+    /// UDF backend type (e.g. DockerUDFSpecV1)
+    #[serde(rename = "udf_backend", default, with = "::serde_with::rust::double_option", skip_serializing_if = "Option::is_none")]
+    pub udf_backend: Option<Option<String>>,
+    /// Whether to automatically backfill the column after creation
+    #[serde(rename = "auto_backfill", default, with = "::serde_with::rust::double_option", skip_serializing_if = "Option::is_none")]
+    pub auto_backfill: Option<Option<bool>>,
+    /// JSON-serialized manifest for the UDF environment
+    #[serde(rename = "manifest", default, with = "::serde_with::rust::double_option", skip_serializing_if = "Option::is_none")]
+    pub manifest: Option<Option<String>>,
+    /// SHA-256 checksum of the manifest content
+    #[serde(rename = "manifest_checksum", default, with = "::serde_with::rust::double_option", skip_serializing_if = "Option::is_none")]
+    pub manifest_checksum: Option<Option<String>>,
+    /// User-supplied field metadata (string key-value pairs)
+    #[serde(rename = "field_metadata", skip_serializing_if = "Option::is_none")]
+    pub field_metadata: Option<std::collections::HashMap<String, String>>,
 }
 
 impl AddVirtualColumnEntry {
@@ -42,6 +57,11 @@ impl AddVirtualColumnEntry {
             udf,
             udf_name,
             udf_version,
+            udf_backend: None,
+            auto_backfill: None,
+            manifest: None,
+            manifest_checksum: None,
+            field_metadata: None,
         }
     }
 }

--- a/rust/lance-namespace-reqwest-client/src/models/alter_table_add_columns_request.rs
+++ b/rust/lance-namespace-reqwest-client/src/models/alter_table_add_columns_request.rs
@@ -13,6 +13,8 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct AlterTableAddColumnsRequest {
+    #[serde(rename = "identity", skip_serializing_if = "Option::is_none")]
+    pub identity: Option<Box<models::Identity>>,
     /// Table identifier path (namespace + table name)
     #[serde(rename = "id", skip_serializing_if = "Option::is_none")]
     pub id: Option<Vec<String>>,
@@ -24,6 +26,7 @@ pub struct AlterTableAddColumnsRequest {
 impl AlterTableAddColumnsRequest {
     pub fn new(new_columns: Vec<models::AddColumnsEntry>) -> AlterTableAddColumnsRequest {
         AlterTableAddColumnsRequest {
+            identity: None,
             id: None,
             new_columns,
         }

--- a/rust/lance-namespace-reqwest-client/src/models/alter_table_alter_columns_request.rs
+++ b/rust/lance-namespace-reqwest-client/src/models/alter_table_alter_columns_request.rs
@@ -13,6 +13,8 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct AlterTableAlterColumnsRequest {
+    #[serde(rename = "identity", skip_serializing_if = "Option::is_none")]
+    pub identity: Option<Box<models::Identity>>,
     /// Table identifier path (namespace + table name)
     #[serde(rename = "id", skip_serializing_if = "Option::is_none")]
     pub id: Option<Vec<String>>,
@@ -24,6 +26,7 @@ pub struct AlterTableAlterColumnsRequest {
 impl AlterTableAlterColumnsRequest {
     pub fn new(alterations: Vec<models::AlterColumnsEntry>) -> AlterTableAlterColumnsRequest {
         AlterTableAlterColumnsRequest {
+            identity: None,
             id: None,
             alterations,
         }

--- a/rust/lance-namespace-reqwest-client/src/models/alter_table_backfill_columns_request.rs
+++ b/rust/lance-namespace-reqwest-client/src/models/alter_table_backfill_columns_request.rs
@@ -13,6 +13,8 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct AlterTableBackfillColumnsRequest {
+    #[serde(rename = "identity", skip_serializing_if = "Option::is_none")]
+    pub identity: Option<Box<models::Identity>>,
     /// Table identifier path (namespace + table name)
     #[serde(rename = "id", skip_serializing_if = "Option::is_none")]
     pub id: Option<Vec<String>>,
@@ -63,6 +65,7 @@ pub struct AlterTableBackfillColumnsRequest {
 impl AlterTableBackfillColumnsRequest {
     pub fn new(column: String) -> AlterTableBackfillColumnsRequest {
         AlterTableBackfillColumnsRequest {
+            identity: None,
             id: None,
             column,
             r#where: None,

--- a/rust/lance-namespace-reqwest-client/src/models/alter_virtual_column_entry.rs
+++ b/rust/lance-namespace-reqwest-client/src/models/alter_virtual_column_entry.rs
@@ -28,6 +28,21 @@ pub struct AlterVirtualColumnEntry {
     /// Version of the UDF (optional)
     #[serde(rename = "udf_version", default, with = "::serde_with::rust::double_option", skip_serializing_if = "Option::is_none")]
     pub udf_version: Option<Option<String>>,
+    /// UDF backend type (e.g. DockerUDFSpecV1) (optional)
+    #[serde(rename = "udf_backend", default, with = "::serde_with::rust::double_option", skip_serializing_if = "Option::is_none")]
+    pub udf_backend: Option<Option<String>>,
+    /// Whether to automatically backfill the column (optional)
+    #[serde(rename = "auto_backfill", default, with = "::serde_with::rust::double_option", skip_serializing_if = "Option::is_none")]
+    pub auto_backfill: Option<Option<bool>>,
+    /// JSON-serialized manifest for the UDF environment (optional)
+    #[serde(rename = "manifest", default, with = "::serde_with::rust::double_option", skip_serializing_if = "Option::is_none")]
+    pub manifest: Option<Option<String>>,
+    /// SHA-256 checksum of the manifest content (optional)
+    #[serde(rename = "manifest_checksum", default, with = "::serde_with::rust::double_option", skip_serializing_if = "Option::is_none")]
+    pub manifest_checksum: Option<Option<String>>,
+    /// User-supplied field metadata (optional)
+    #[serde(rename = "field_metadata", skip_serializing_if = "Option::is_none")]
+    pub field_metadata: Option<std::collections::HashMap<String, String>>,
 }
 
 impl AlterVirtualColumnEntry {
@@ -38,6 +53,11 @@ impl AlterVirtualColumnEntry {
             udf: None,
             udf_name: None,
             udf_version: None,
+            udf_backend: None,
+            auto_backfill: None,
+            manifest: None,
+            manifest_checksum: None,
+            field_metadata: None,
         }
     }
 }

--- a/rust/lance-namespace-reqwest-client/src/models/refresh_materialized_view_request.rs
+++ b/rust/lance-namespace-reqwest-client/src/models/refresh_materialized_view_request.rs
@@ -13,6 +13,8 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize)]
 pub struct RefreshMaterializedViewRequest {
+    #[serde(rename = "identity", skip_serializing_if = "Option::is_none")]
+    pub identity: Option<Box<models::Identity>>,
     /// Table identifier path (namespace + table name)
     #[serde(rename = "id", skip_serializing_if = "Option::is_none")]
     pub id: Option<Vec<String>>,
@@ -39,6 +41,7 @@ pub struct RefreshMaterializedViewRequest {
 impl RefreshMaterializedViewRequest {
     pub fn new() -> RefreshMaterializedViewRequest {
         RefreshMaterializedViewRequest {
+            identity: None,
             id: None,
             src_version: None,
             max_rows_per_fragment: None,


### PR DESCRIPTION
## Summary

- Add optional UDF metadata fields to `AddVirtualColumnEntry` and `AlterVirtualColumnEntry`: `udf_backend`, `auto_backfill`, `manifest`, `manifest_checksum`, `field_metadata`
- Add `identity` field to `AlterTableAddColumnsRequest`, `AlterTableAlterColumnsRequest`, `AlterTableBackfillColumnsRequest`, `RefreshMaterializedViewRequest`
- Regenerate all clients (Rust, Python, Java)

## Test plan

- [x] YAML validates
- [x] All clients build