### PR TITLE
fix(rest): make data_type optional in AlterColumnsEntry

### DIFF
--- a/docs/src/client/operations/models/AlterColumnsEntry.md
+++ b/docs/src/client/operations/models/AlterColumnsEntry.md
@@ -8,7 +8,7 @@
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
 |**path** | **String** | Column path to alter |  |
-|**dataType** | **Object** | New data type for the column using JSON representation (optional) |  |
+|**dataType** | **Object** | New data type for the column using JSON representation (optional) |  [optional] |
 |**rename** | **String** | New name for the column (optional) |  [optional] |
 |**nullable** | **Boolean** | Whether the column should be nullable (optional) |  [optional] |
 |**virtualColumn** | [**AlterVirtualColumnEntry**](AlterVirtualColumnEntry.md) |  |  [optional] |

--- a/docs/src/rest.yaml
+++ b/docs/src/rest.yaml
@@ -4680,7 +4680,6 @@ components:
       type: object
       required:
         - path
-        - data_type
       properties:
         path:
           type: string

--- a/java/lance-namespace-apache-client/api/openapi.yaml
+++ b/java/lance-namespace-apache-client/api/openapi.yaml
@@ -7265,7 +7265,6 @@ components:
         virtual_column:
           $ref: '#/components/schemas/AlterVirtualColumnEntry'
       required:
-      - data_type
       - path
     AlterVirtualColumnEntry:
       example:

--- a/java/lance-namespace-apache-client/docs/AlterColumnsEntry.md
+++ b/java/lance-namespace-apache-client/docs/AlterColumnsEntry.md
@@ -8,7 +8,7 @@
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
 |**path** | **String** | Column path to alter |  |
-|**dataType** | **Object** | New data type for the column using JSON representation (optional) |  |
+|**dataType** | **Object** | New data type for the column using JSON representation (optional) |  [optional] |
 |**rename** | **String** | New name for the column (optional) |  [optional] |
 |**nullable** | **Boolean** | Whether the column should be nullable (optional) |  [optional] |
 |**virtualColumn** | [**AlterVirtualColumnEntry**](AlterVirtualColumnEntry.md) |  |  [optional] |

--- a/java/lance-namespace-apache-client/src/main/java/org/lance/namespace/model/AlterColumnsEntry.java
+++ b/java/lance-namespace-apache-client/src/main/java/org/lance/namespace/model/AlterColumnsEntry.java
@@ -41,7 +41,7 @@ public class AlterColumnsEntry {
   @javax.annotation.Nonnull private String path;
 
   public static final String JSON_PROPERTY_DATA_TYPE = "data_type";
-  @javax.annotation.Nonnull private Object dataType;
+  @javax.annotation.Nullable private Object dataType;
 
   public static final String JSON_PROPERTY_RENAME = "rename";
   @javax.annotation.Nullable private JsonNullable<String> rename = JsonNullable.<String>undefined();
@@ -83,7 +83,7 @@ public class AlterColumnsEntry {
     this.path = path;
   }
 
-  public AlterColumnsEntry dataType(@javax.annotation.Nonnull Object dataType) {
+  public AlterColumnsEntry dataType(@javax.annotation.Nullable Object dataType) {
 
     this.dataType = dataType;
     return this;
@@ -94,16 +94,16 @@ public class AlterColumnsEntry {
    *
    * @return dataType
    */
-  @javax.annotation.Nonnull
+  @javax.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DATA_TYPE)
-  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public Object getDataType() {
     return dataType;
   }
 
   @JsonProperty(JSON_PROPERTY_DATA_TYPE)
-  @JsonInclude(value = JsonInclude.Include.ALWAYS)
-  public void setDataType(@javax.annotation.Nonnull Object dataType) {
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setDataType(@javax.annotation.Nullable Object dataType) {
     this.dataType = dataType;
   }
 

--- a/java/lance-namespace-async-client/api/openapi.yaml
+++ b/java/lance-namespace-async-client/api/openapi.yaml
@@ -7265,7 +7265,6 @@ components:
         virtual_column:
           $ref: '#/components/schemas/AlterVirtualColumnEntry'
       required:
-      - data_type
       - path
     AlterVirtualColumnEntry:
       example:

--- a/java/lance-namespace-async-client/docs/AlterColumnsEntry.md
+++ b/java/lance-namespace-async-client/docs/AlterColumnsEntry.md
@@ -8,7 +8,7 @@
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
 |**path** | **String** | Column path to alter |  |
-|**dataType** | **Object** | New data type for the column using JSON representation (optional) |  |
+|**dataType** | **Object** | New data type for the column using JSON representation (optional) |  [optional] |
 |**rename** | **String** | New name for the column (optional) |  [optional] |
 |**nullable** | **Boolean** | Whether the column should be nullable (optional) |  [optional] |
 |**virtualColumn** | [**AlterVirtualColumnEntry**](AlterVirtualColumnEntry.md) |  |  [optional] |

--- a/java/lance-namespace-async-client/src/main/java/org/lance/namespace/model/AlterColumnsEntry.java
+++ b/java/lance-namespace-async-client/src/main/java/org/lance/namespace/model/AlterColumnsEntry.java
@@ -41,7 +41,7 @@ public class AlterColumnsEntry {
   @javax.annotation.Nonnull private String path;
 
   public static final String JSON_PROPERTY_DATA_TYPE = "data_type";
-  @javax.annotation.Nonnull private Object dataType;
+  @javax.annotation.Nullable private Object dataType;
 
   public static final String JSON_PROPERTY_RENAME = "rename";
   private JsonNullable<String> rename = JsonNullable.<String>undefined();
@@ -78,7 +78,7 @@ public class AlterColumnsEntry {
     this.path = path;
   }
 
-  public AlterColumnsEntry dataType(@javax.annotation.Nonnull Object dataType) {
+  public AlterColumnsEntry dataType(@javax.annotation.Nullable Object dataType) {
     this.dataType = dataType;
     return this;
   }
@@ -88,16 +88,16 @@ public class AlterColumnsEntry {
    *
    * @return dataType
    */
-  @javax.annotation.Nonnull
+  @javax.annotation.Nullable
   @JsonProperty(JSON_PROPERTY_DATA_TYPE)
-  @JsonInclude(value = JsonInclude.Include.ALWAYS)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
   public Object getDataType() {
     return dataType;
   }
 
   @JsonProperty(JSON_PROPERTY_DATA_TYPE)
-  @JsonInclude(value = JsonInclude.Include.ALWAYS)
-  public void setDataType(@javax.annotation.Nonnull Object dataType) {
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public void setDataType(@javax.annotation.Nullable Object dataType) {
     this.dataType = dataType;
   }
 

--- a/java/lance-namespace-springboot-server/src/main/java/org/lance/namespace/server/springboot/model/AlterColumnsEntry.java
+++ b/java/lance-namespace-springboot-server/src/main/java/org/lance/namespace/server/springboot/model/AlterColumnsEntry.java
@@ -43,9 +43,8 @@ public class AlterColumnsEntry {
   }
 
   /** Constructor with only required parameters */
-  public AlterColumnsEntry(String path, Object dataType) {
+  public AlterColumnsEntry(String path) {
     this.path = path;
-    this.dataType = dataType;
   }
 
   public AlterColumnsEntry path(String path) {
@@ -82,11 +81,10 @@ public class AlterColumnsEntry {
    *
    * @return dataType
    */
-  @NotNull
   @Schema(
       name = "data_type",
       description = "New data type for the column using JSON representation (optional)",
-      requiredMode = Schema.RequiredMode.REQUIRED)
+      requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   @JsonProperty("data_type")
   public Object getDataType() {
     return dataType;

--- a/python/lance_namespace_urllib3_client/docs/AlterColumnsEntry.md
+++ b/python/lance_namespace_urllib3_client/docs/AlterColumnsEntry.md
@@ -6,7 +6,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **path** | **str** | Column path to alter | 
-**data_type** | **object** | New data type for the column using JSON representation (optional) | 
+**data_type** | **object** | New data type for the column using JSON representation (optional) | [optional] 
 **rename** | **str** | New name for the column (optional) | [optional] 
 **nullable** | **bool** | Whether the column should be nullable (optional) | [optional] 
 **virtual_column** | [**AlterVirtualColumnEntry**](AlterVirtualColumnEntry.md) |  | [optional] 

--- a/python/lance_namespace_urllib3_client/lance_namespace_urllib3_client/models/alter_columns_entry.py
+++ b/python/lance_namespace_urllib3_client/lance_namespace_urllib3_client/models/alter_columns_entry.py
@@ -28,7 +28,7 @@ class AlterColumnsEntry(BaseModel):
     AlterColumnsEntry
     """ # noqa: E501
     path: StrictStr = Field(description="Column path to alter")
-    data_type: Dict[str, Any] = Field(description="New data type for the column using JSON representation (optional)")
+    data_type: Optional[Dict[str, Any]] = Field(default=None, description="New data type for the column using JSON representation (optional)")
     rename: Optional[StrictStr] = Field(default=None, description="New name for the column (optional)")
     nullable: Optional[StrictBool] = Field(default=None, description="Whether the column should be nullable (optional)")
     virtual_column: Optional[AlterVirtualColumnEntry] = None

--- a/python/lance_namespace_urllib3_client/test/test_alter_columns_entry.py
+++ b/python/lance_namespace_urllib3_client/test/test_alter_columns_entry.py
@@ -58,7 +58,6 @@ class TestAlterColumnsEntry(unittest.TestCase):
         else:
             return AlterColumnsEntry(
                 path = '',
-                data_type = lance_namespace_urllib3_client.models.data_type.data_type(),
         )
         """
 

--- a/rust/lance-namespace-reqwest-client/docs/AlterColumnsEntry.md
+++ b/rust/lance-namespace-reqwest-client/docs/AlterColumnsEntry.md
@@ -5,7 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **path** | **String** | Column path to alter | 
-**data_type** | [**serde_json::Value**](.md) | New data type for the column using JSON representation (optional) | 
+**data_type** | Option<[**serde_json::Value**](.md)> | New data type for the column using JSON representation (optional) | [optional]
 **rename** | Option<**String**> | New name for the column (optional) | [optional]
 **nullable** | Option<**bool**> | Whether the column should be nullable (optional) | [optional]
 **virtual_column** | Option<[**models::AlterVirtualColumnEntry**](AlterVirtualColumnEntry.md)> |  | [optional]

--- a/rust/lance-namespace-reqwest-client/src/models/alter_columns_entry.rs
+++ b/rust/lance-namespace-reqwest-client/src/models/alter_columns_entry.rs
@@ -17,8 +17,8 @@ pub struct AlterColumnsEntry {
     #[serde(rename = "path")]
     pub path: String,
     /// New data type for the column using JSON representation (optional)
-    #[serde(rename = "data_type")]
-    pub data_type: serde_json::Value,
+    #[serde(rename = "data_type", skip_serializing_if = "Option::is_none")]
+    pub data_type: Option<serde_json::Value>,
     /// New name for the column (optional)
     #[serde(rename = "rename", default, with = "::serde_with::rust::double_option", skip_serializing_if = "Option::is_none")]
     pub rename: Option<Option<String>>,
@@ -30,10 +30,10 @@ pub struct AlterColumnsEntry {
 }
 
 impl AlterColumnsEntry {
-    pub fn new(path: String, data_type: serde_json::Value) -> AlterColumnsEntry {
+    pub fn new(path: String) -> AlterColumnsEntry {
         AlterColumnsEntry {
             path,
-            data_type,
+            data_type: None,
             rename: None,
             nullable: None,
             virtual_column: None,


### PR DESCRIPTION
## Summary

Remove `data_type` from `required` in `AlterColumnsEntry`. UDF-only alterations only need `path` + `virtual_column` — forcing `data_type` causes clients to send empty/redundant values that can trigger server-side metadata issues.

## Test plan

- [x] YAML validates
- [x] All clients build