### PR TITLE
feat(test): add Pact contract tests covering Namespace and Table APIs

### DIFF
--- a/.github/workflows/pact.yml
+++ b/.github/workflows/pact.yml
@@ -1,0 +1,307 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Pact Contract Tests
+
+on:
+  push:
+    branches:
+      - main
+      - 'feature/**'
+  pull_request:
+    branches:
+      - main
+
+env:
+  JAVA_VERSION: '17'
+  PACT_JVM_VERSION: '4.6.14'
+
+jobs:
+  # ─────────────────────────────────────────────────────────────────────────
+  # Consumer tests run in 3-way parallel.
+  #
+  # Phase 4 layout: hand-written pact tests now live in dedicated modules
+  # *outside* the code-generated client packages, so `make clean` / codegen
+  # can never wipe them:
+  #   • Java   → java/lance-namespace-pact-tests/
+  #   • Python → python/lance_namespace_pact_tests/
+  #   • Rust   → rust/lance-namespace-pact-tests/
+  # ─────────────────────────────────────────────────────────────────────────
+
+  consumer-java:
+    name: Consumer Contract Tests (Java Apache Client)
+    runs-on: ubuntu-latest
+    env:
+      # Project secrets onto plain env vars so we can reference them inside
+      # `if:` expressions (GitHub Actions disallows `secrets.*` directly there).
+      PACT_BROKER_URL: ${{ secrets.PACT_BROKER_URL }}
+      PACT_BROKER_TOKEN: ${{ secrets.PACT_BROKER_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Run Consumer Pact Tests
+        # -am builds the apache-client + springboot-server reactor deps the
+        # pact-tests module pulls in. We also pass
+        # -Dsurefire.failIfNoSpecifiedTests=false so that surefire does NOT
+        # fail the build when -Dtest=NamespaceApiPactTest matches no test in
+        # the upstream apache-client / springboot-server modules (those
+        # generated modules contain no Pact tests by design — the tests live
+        # only in lance-namespace-pact-tests).
+        working-directory: java
+        run: mvn -pl lance-namespace-pact-tests -am -Dspotless.skip=true -Dsurefire.failIfNoSpecifiedTests=false -Dtest=NamespaceApiPactTest test
+
+      - name: Publish Pacts to Broker
+        # Phase 4 guard: only publish when PACT_BROKER_URL secret is configured.
+        # Reading `env.*` (instead of `secrets.*`) inside `if:` is required by
+        # the workflow validator.
+        if: ${{ env.PACT_BROKER_URL != '' }}
+        working-directory: java
+        run: mvn -pl lance-namespace-pact-tests -Ppact-publish -Dspotless.skip=true pact:publish
+        env:
+          GIT_BRANCH: ${{ github.head_ref || github.ref_name }}
+          GIT_SHORT_SHA: ${{ github.sha }}
+          PACT_CONSUMER_BRANCH: ${{ github.head_ref || github.ref_name }}
+
+      - name: Upload Pact Files
+        uses: actions/upload-artifact@v4
+        with:
+          name: pact-files-java
+          path: java/lance-namespace-pact-tests/target/pacts/
+
+  consumer-python:
+    name: Consumer Contract Tests (Python urllib3 Client)
+    runs-on: ubuntu-latest
+    env:
+      PACT_BROKER_URL: ${{ secrets.PACT_BROKER_URL }}
+      PACT_BROKER_TOKEN: ${{ secrets.PACT_BROKER_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          # pact-python>=3.0 requires Python ≥ 3.10
+          python-version: '3.11'
+
+      - name: Install uv
+        run: pip install uv
+
+      - name: Install dependencies (including pact-python)
+        working-directory: python/lance_namespace_pact_tests
+        # uv "groups" replaced the legacy "extras" mechanism; the pact-tests
+        # package declares `[dependency-groups].dev`.
+        run: uv sync --group dev
+
+      - name: Run Consumer Pact Tests
+        working-directory: python/lance_namespace_pact_tests
+        run: uv run pytest tests/pact_tests -v --tb=short
+        env:
+          PYTHONPATH: .
+
+      - name: Publish Pacts to Broker
+        if: ${{ env.PACT_BROKER_URL != '' }}
+        working-directory: python/lance_namespace_pact_tests
+        run: |
+           uv run pact-broker publish \
+             tests/pact_tests/pacts/lance-namespace-python-urllib3-lance-namespace-server.json \
+             --consumer-app-version="${{ github.sha }}" \
+             --branch="${{ github.head_ref || github.ref_name }}" \
+             --broker-base-url="${{ env.PACT_BROKER_URL }}" \
+             --broker-token="${{ env.PACT_BROKER_TOKEN }}"
+
+      - name: Upload Pact Files
+        uses: actions/upload-artifact@v4
+        with:
+          name: pact-files-python
+          path: python/lance_namespace_pact_tests/tests/pact_tests/pacts/
+
+  consumer-rust:
+    name: Consumer Contract Tests (Rust reqwest Client)
+    runs-on: ubuntu-latest
+    env:
+      PACT_BROKER_URL: ${{ secrets.PACT_BROKER_URL }}
+      PACT_BROKER_TOKEN: ${{ secrets.PACT_BROKER_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            rust/target/
+            rust/lance-namespace-pact-tests/target/
+          # The pact-tests crate is part of the rust/ workspace; key off the
+          # workspace-level Cargo.lock for stable hits across both crates.
+          key: ${{ runner.os }}-cargo-pact-${{ hashFiles('rust/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-pact-
+            ${{ runner.os }}-cargo-
+
+      - name: Run Consumer Pact Tests
+        working-directory: rust
+        run: cargo test -p lance-namespace-pact-tests --tests
+        env:
+          RUST_LOG: pact_consumer=debug
+
+      - name: Publish Pacts to Broker
+        if: ${{ env.PACT_BROKER_URL != '' }}
+        working-directory: rust/lance-namespace-pact-tests
+        run: |
+           # Install pact CLI if not cached
+           if ! command -v pact-broker &> /dev/null; then
+             curl -L https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v2.4.3/pact-2.4.3-linux-x86_64.tar.gz | tar xz
+             export PATH="$PWD/pact/bin:$PATH"
+           fi
+           # pact_consumer 1.x writes to crate-local target/pacts/, not the
+           # workspace-level rust/target/.
+           pact-broker publish \
+             target/pacts/ \
+             --consumer-app-version="${{ github.sha }}" \
+             --branch="${{ github.head_ref || github.ref_name }}" \
+             --broker-base-url="${{ env.PACT_BROKER_URL }}" \
+             --broker-token="${{ env.PACT_BROKER_TOKEN }}"
+
+      - name: Upload Pact Files
+        uses: actions/upload-artifact@v4
+        with:
+          name: pact-files-rust
+          path: rust/lance-namespace-pact-tests/target/pacts/
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # Provider verification: depends on all 3 consumers.
+  #
+  # The provider test is annotated with
+  #   @PactFolder("../../contract-pack/sample-pacts")
+  # (relative to java/lance-namespace-pact-tests/), so we stage every
+  # consumer artifact into contract-pack/sample-pacts/ before running mvn.
+  # ─────────────────────────────────────────────────────────────────────────
+
+  provider-verify:
+    name: Provider Verification Tests (Spring Boot Server)
+    runs-on: ubuntu-latest
+    needs: [consumer-java, consumer-python, consumer-rust]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+
+      # Stage all 3 consumer pacts into the @PactFolder location.
+      - name: Download Java Pact Files
+        uses: actions/download-artifact@v4
+        with:
+          name: pact-files-java
+          path: contract-pack/sample-pacts/
+
+      - name: Download Python Pact Files
+        uses: actions/download-artifact@v4
+        with:
+          name: pact-files-python
+          path: contract-pack/sample-pacts/
+
+      - name: Download Rust Pact Files
+        uses: actions/download-artifact@v4
+        with:
+          name: pact-files-rust
+          path: contract-pack/sample-pacts/
+
+      - name: Show staged pacts
+        run: ls -la contract-pack/sample-pacts/
+
+      - name: Run Provider Pact Verification
+        # -am pulls in apache-client + springboot-server, both required by
+        # the pact-tests module's test classpath (PactTestApplication, fixtures).
+        # See consumer-java for why -Dsurefire.failIfNoSpecifiedTests=false is
+        # required (apache-client / springboot-server contain no PactProviderTest).
+        working-directory: java
+        run: mvn -pl lance-namespace-pact-tests -am -Dspotless.skip=true -Dsurefire.failIfNoSpecifiedTests=false -Dtest=PactProviderTest -Dspring.profiles.active=pact test
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # Can-I-Deploy: only on main with Pact Broker configured
+  # ─────────────────────────────────────────────────────────────────────────
+
+  can-i-deploy:
+    name: Can I Deploy Check
+    runs-on: ubuntu-latest
+    needs: [consumer-java, consumer-python, consumer-rust, provider-verify]
+    env:
+      PACT_BROKER_URL: ${{ secrets.PACT_BROKER_URL }}
+      PACT_BROKER_TOKEN: ${{ secrets.PACT_BROKER_TOKEN }}
+    # Phase 4 guard: at job level we can ONLY use github.* / needs.* / vars.* /
+    # inputs.* — the workflow validator rejects both `secrets.*` AND `env.*`
+    # inside job-level `if:` (env context is not available at job scheduling
+    # time). The "broker configured" check is therefore moved down to the
+    # step level (`if: env.PACT_BROKER_URL != ''`), which IS allowed.
+    if: ${{ github.ref == 'refs/heads/main' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Pact CLI
+        if: ${{ env.PACT_BROKER_URL != '' }}
+        run: |
+           curl -L https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v2.4.3/pact-2.4.3-linux-x86_64.tar.gz | tar xz
+           echo "$PWD/pact/bin" >> $GITHUB_PATH
+
+      - name: Can I Deploy - Consumer (lance-namespace-java-apache)
+        if: ${{ env.PACT_BROKER_URL != '' }}
+        run: |
+           pact-broker can-i-deploy \
+             --broker-base-url=${{ env.PACT_BROKER_URL }} \
+             --broker-token=${{ env.PACT_BROKER_TOKEN }} \
+             --pacticipant=lance-namespace-java-apache \
+             --version=${{ github.sha }} \
+             --to-environment=production
+
+      - name: Can I Deploy - Consumer (lance-namespace-python-urllib3)
+        if: ${{ env.PACT_BROKER_URL != '' }}
+        run: |
+           pact-broker can-i-deploy \
+             --broker-base-url=${{ env.PACT_BROKER_URL }} \
+             --broker-token=${{ env.PACT_BROKER_TOKEN }} \
+             --pacticipant=lance-namespace-python-urllib3 \
+             --version=${{ github.sha }} \
+             --to-environment=production
+
+      - name: Can I Deploy - Consumer (lance-namespace-rust-reqwest)
+        if: ${{ env.PACT_BROKER_URL != '' }}
+        run: |
+           pact-broker can-i-deploy \
+             --broker-base-url=${{ env.PACT_BROKER_URL }} \
+             --broker-token=${{ env.PACT_BROKER_TOKEN }} \
+             --pacticipant=lance-namespace-rust-reqwest \
+             --version=${{ github.sha }} \
+             --to-environment=production
+
+      - name: Can I Deploy - Provider (lance-namespace-server)
+        if: ${{ env.PACT_BROKER_URL != '' }}
+        run: |
+           pact-broker can-i-deploy \
+             --broker-base-url=${{ env.PACT_BROKER_URL }} \
+             --broker-token=${{ env.PACT_BROKER_TOKEN }} \
+             --pacticipant=lance-namespace-server \
+             --version=${{ github.sha }} \
+             --to-environment=production
+
+      - name: No Pact Broker configured — skipping can-i-deploy
+        if: ${{ env.PACT_BROKER_URL == '' }}
+        run: echo "PACT_BROKER_URL is empty (likely a fork without secrets); skipping can-i-deploy."

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: local
+    hooks:
+      - id: pact-state-guard
+        name: Guard against unauthorized Pact provider states
+        language: script
+        entry: ci/pact_state_guard.sh
+        files: '\.java$'
+        pass_filenames: true

--- a/ci/naming_lint.sh
+++ b/ci/naming_lint.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+# Lance Namespace Pact Naming Lint
+# Validates consumer/provider/tag names against contract-pack/naming.lock.yaml
+#
+# Usage:
+#   naming_lint.sh --consumer <name> --provider <name>
+#   naming_lint.sh --consumer lance-namespace-java-apache --provider lance-namespace-server
+#
+# Exit codes:
+#   0 - all names are valid
+#   1 - one or more names violate the naming contract
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Allowed values (frozen from naming.lock.yaml schemaVersion 1.0, 2026-05-09)
+# Do NOT add new values without updating naming.lock.yaml first.
+# ---------------------------------------------------------------------------
+EXPECTED_CONSUMERS=(
+    "lance-namespace-java-apache"
+    "lance-namespace-java-async"
+    "lance-namespace-python-urllib3"
+    "lance-namespace-rust-reqwest"
+)
+EXPECTED_PROVIDER="lance-namespace-server"
+EXPECTED_TAGS=("branch" "git-sha" "deployed")
+
+# ---------------------------------------------------------------------------
+# Parse arguments
+# ---------------------------------------------------------------------------
+CONSUMER=""
+PROVIDER=""
+TAG=""
+
+usage() {
+    echo "Usage: $(basename "$0") --consumer <name> --provider <name> [--tag <tag>]"
+    echo ""
+    echo "  --consumer  Consumer name (e.g. lance-namespace-java-apache)"
+    echo "  --provider  Provider name (e.g. lance-namespace-server)"
+    echo "  --tag       Optional tag to validate (e.g. branch, git-sha, deployed)"
+    echo ""
+    echo "Allowed consumers:"
+    for c in "${EXPECTED_CONSUMERS[@]}"; do
+        echo "  - ${c}"
+    done
+    echo ""
+    echo "Allowed provider:  ${EXPECTED_PROVIDER}"
+    echo ""
+    echo "Allowed tags:      ${EXPECTED_TAGS[*]}"
+}
+
+if [[ $# -eq 0 ]]; then
+    usage >&2
+    exit 1
+fi
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --consumer)
+            CONSUMER="${2:-}"
+            shift 2
+            ;;
+        --provider)
+            PROVIDER="${2:-}"
+            shift 2
+            ;;
+        --tag)
+            TAG="${2:-}"
+            shift 2
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "[ERROR] Unknown argument: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+done
+
+# ---------------------------------------------------------------------------
+# Validation helpers
+# ---------------------------------------------------------------------------
+ERRORS=0
+
+validate_consumer() {
+    local name="$1"
+    for allowed in "${EXPECTED_CONSUMERS[@]}"; do
+        if [[ "${name}" == "${allowed}" ]]; then
+            return 0
+        fi
+    done
+    echo "[ERROR] Consumer name '${name}' is not in the naming contract." >&2
+    echo "        Allowed values: ${EXPECTED_CONSUMERS[*]}" >&2
+    ERRORS=$((ERRORS + 1))
+}
+
+validate_provider() {
+    local name="$1"
+    if [[ "${name}" != "${EXPECTED_PROVIDER}" ]]; then
+        echo "[ERROR] Provider name '${name}' is not in the naming contract." >&2
+        echo "        Allowed value: ${EXPECTED_PROVIDER}" >&2
+        ERRORS=$((ERRORS + 1))
+    fi
+}
+
+validate_tag() {
+    local tag="$1"
+    for allowed in "${EXPECTED_TAGS[@]}"; do
+        if [[ "${tag}" == "${allowed}" ]]; then
+            return 0
+        fi
+    done
+    echo "[ERROR] Tag '${tag}' is not in the naming contract." >&2
+    echo "        Allowed values: ${EXPECTED_TAGS[*]}" >&2
+    ERRORS=$((ERRORS + 1))
+}
+
+# ---------------------------------------------------------------------------
+# Run validations
+# ---------------------------------------------------------------------------
+if [[ -z "${CONSUMER}" && -z "${PROVIDER}" ]]; then
+    echo "[ERROR] At least one of --consumer or --provider must be provided." >&2
+    usage >&2
+    exit 1
+fi
+
+if [[ -n "${CONSUMER}" ]]; then
+    validate_consumer "${CONSUMER}"
+fi
+
+if [[ -n "${PROVIDER}" ]]; then
+    validate_provider "${PROVIDER}"
+fi
+
+if [[ -n "${TAG}" ]]; then
+    validate_tag "${TAG}"
+fi
+
+# ---------------------------------------------------------------------------
+# Result
+# ---------------------------------------------------------------------------
+if [[ "${ERRORS}" -gt 0 ]]; then
+    echo "[FAIL]  Naming lint failed with ${ERRORS} error(s). See above for details." >&2
+    exit 1
+fi
+
+echo "[OK]    All provided names conform to the naming contract."
+exit 0

--- a/ci/openapi_pact_diff.py
+++ b/ci/openapi_pact_diff.py
@@ -1,0 +1,486 @@
+#!/usr/bin/env python3
+"""
+openapi_pact_diff.py — OpenAPI vs Pact field coverage checker.
+
+Usage:
+    python ci/openapi_pact_diff.py \
+        [--broker-url http://localhost:9292] \
+        [--openapi-spec docs/src/rest.yaml] \
+        [--output report.md]
+
+Environment variables:
+    PACT_BROKER_URL   — Pact Broker base URL (overridden by --broker-url)
+    PACT_BROKER_TOKEN — Bearer token for broker authentication
+    PACT_BROKER_USERNAME / PACT_BROKER_PASSWORD — Basic auth alternative
+
+Exit codes:
+    0 — no coverage gaps
+    1 — coverage gaps found or fatal error
+    2 — broker unavailable (graceful skip, no pact data to check)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+try:
+    import yaml  # type: ignore[import]
+    _YAML_AVAILABLE = True
+except ImportError:
+    _YAML_AVAILABLE = False
+
+
+# ---------------------------------------------------------------------------
+# Types
+# ---------------------------------------------------------------------------
+
+Pact = dict[str, Any]
+OpenApiSpec = dict[str, Any]
+FieldSet = set[str]
+
+
+# ---------------------------------------------------------------------------
+# Broker communication
+# ---------------------------------------------------------------------------
+
+def _broker_request(url: str, token: str | None, username: str | None, password: str | None) -> bytes:
+    """Make an authenticated GET request to the Pact Broker."""
+    req = Request(url, headers={"Accept": "application/hal+json, application/json"})
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    elif username and password:
+        import base64
+        creds = base64.b64encode(f"{username}:{password}".encode()).decode()
+        req.add_header("Authorization", f"Basic {creds}")
+    with urlopen(req, timeout=10) as resp:
+        return resp.read()
+
+
+def fetch_pacts(broker_url: str) -> list[Pact]:
+    """
+    Fetch all pacts from the Pact Broker.
+
+    Returns an empty list if the broker is unavailable (graceful skip).
+    """
+    token = os.environ.get("PACT_BROKER_TOKEN")
+    username = os.environ.get("PACT_BROKER_USERNAME")
+    password = os.environ.get("PACT_BROKER_PASSWORD")
+
+    # Step 1 — enumerate all pacts via HAL index
+    try:
+        index_data = _broker_request(f"{broker_url.rstrip('/')}/pacts/latest", token, username, password)
+        index = json.loads(index_data)
+    except (URLError, OSError, json.JSONDecodeError) as exc:
+        print(f"[WARN] Pact Broker unavailable at {broker_url!r}: {exc}", file=sys.stderr)
+        print("[WARN] Skipping broker pact fetch — no broker data to compare.", file=sys.stderr)
+        return []
+
+    pacts: list[Pact] = []
+    links: list[dict[str, Any]] = []
+
+    # HAL _links.pacts or embedded _embedded.pacts
+    if "_links" in index and "pacts" in index["_links"]:
+        links = index["_links"]["pacts"]
+        if isinstance(links, dict):
+            links = [links]
+    elif "_embedded" in index and "pacts" in index["_embedded"]:
+        for item in index["_embedded"]["pacts"]:
+            link = item.get("_links", {}).get("self", {})
+            if link:
+                links.append(link)
+
+    for link in links:
+        href = link.get("href", "")
+        if not href:
+            continue
+        try:
+            pact_data = _broker_request(href, token, username, password)
+            pact = json.loads(pact_data)
+            pacts.append(pact)
+        except (URLError, OSError, json.JSONDecodeError) as exc:
+            print(f"[WARN] Failed to fetch pact from {href!r}: {exc}", file=sys.stderr)
+
+    return pacts
+
+
+# ---------------------------------------------------------------------------
+# OpenAPI parsing
+# ---------------------------------------------------------------------------
+
+def _load_yaml_or_json(path: Path) -> dict[str, Any]:
+    """Load a YAML or JSON file. Prefers PyYAML if available, falls back to JSON."""
+    text = path.read_text(encoding="utf-8")
+    if _YAML_AVAILABLE:
+        return yaml.safe_load(text)
+    # Attempt JSON (works for .json OpenAPI specs)
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as exc:
+        print(f"[ERROR] Cannot parse {path}: PyYAML not installed and file is not valid JSON: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+def _resolve_ref(spec: OpenApiSpec, ref: str) -> dict[str, Any]:
+    """Resolve a $ref string like '#/components/schemas/Foo' within the spec."""
+    if not ref.startswith("#/"):
+        return {}
+    parts = ref.lstrip("#/").split("/")
+    node: Any = spec
+    for part in parts:
+        if isinstance(node, dict) and part in node:
+            node = node[part]
+        else:
+            return {}
+    return node if isinstance(node, dict) else {}
+
+
+def _collect_properties(spec: OpenApiSpec, schema: dict[str, Any]) -> FieldSet:
+    """Recursively collect property names from a schema, resolving $ref."""
+    if "$ref" in schema:
+        schema = _resolve_ref(spec, schema["$ref"])
+
+    fields: FieldSet = set()
+    for prop in schema.get("properties", {}).keys():
+        fields.add(prop)
+    # allOf / oneOf / anyOf
+    for combiner in ("allOf", "oneOf", "anyOf"):
+        for sub in schema.get(combiner, []):
+            fields |= _collect_properties(spec, sub)
+    return fields
+
+
+def _required_fields(spec: OpenApiSpec, schema: dict[str, Any]) -> FieldSet:
+    """Return the set of required field names from a schema."""
+    if "$ref" in schema:
+        schema = _resolve_ref(spec, schema["$ref"])
+    required: FieldSet = set(schema.get("required", []))
+    for combiner in ("allOf", "oneOf", "anyOf"):
+        for sub in schema.get("combiner", []):
+            required |= _required_fields(spec, sub)
+    return required
+
+
+def parse_openapi(spec_path: Path) -> dict[tuple[str, str], dict[str, Any]]:
+    """
+    Parse an OpenAPI spec and return a map of (path, method) → {fields, required_fields}.
+
+    path  — normalized path string (e.g. '/v1/namespace/{id}/list')
+    method — uppercase HTTP method (e.g. 'GET')
+    """
+    spec: OpenApiSpec = _load_yaml_or_json(spec_path)
+    result: dict[tuple[str, str], dict[str, Any]] = {}
+
+    for path_str, path_item in spec.get("paths", {}).items():
+        for method, operation in path_item.items():
+            if method.upper() not in {"GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"}:
+                continue
+            if not isinstance(operation, dict):
+                continue
+
+            entry: dict[str, Any] = {
+                "request_params": set(),
+                "responses": {},
+            }
+
+            # Request parameters (query/path)
+            for param in operation.get("parameters", []):
+                if isinstance(param, dict) and "name" in param:
+                    entry["request_params"].add(param["name"])
+
+            # Request body fields
+            req_body = operation.get("requestBody", {})
+            if req_body:
+                for media_type in req_body.get("content", {}).values():
+                    schema = media_type.get("schema", {})
+                    entry["request_body_fields"] = _collect_properties(spec, schema)
+                    entry["request_body_required"] = _required_fields(spec, schema)
+                    break
+
+            # Response fields per status code
+            for status_str, resp in operation.get("responses", {}).items():
+                if not isinstance(resp, dict):
+                    continue
+                for media_type in resp.get("content", {}).values():
+                    schema = media_type.get("schema", {})
+                    entry["responses"][status_str] = {
+                        "fields": _collect_properties(spec, schema),
+                        "required": _required_fields(spec, schema),
+                    }
+                    break
+
+            result[(path_str, method.upper())] = entry
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Coverage checking
+# ---------------------------------------------------------------------------
+
+def _extract_pact_body_fields(body: Any, prefix: str = "$") -> FieldSet:
+    """Recursively extract field paths from a pact body object."""
+    fields: FieldSet = set()
+    if isinstance(body, dict):
+        for key, value in body.items():
+            field_path = f"{prefix}.{key}"
+            fields.add(field_path)
+            fields |= _extract_pact_body_fields(value, field_path)
+    elif isinstance(body, list):
+        for item in body:
+            fields |= _extract_pact_body_fields(item, f"{prefix}[*]")
+    return fields
+
+
+def check_coverage(
+    pacts: list[Pact],
+    openapi_map: dict[tuple[str, str], dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """
+    For each pact interaction, cross-check field coverage against OpenAPI spec.
+
+    Returns a list of gap records:
+    {
+        consumer, provider, description,
+        path, method, status,
+        gap_type: 'pact_has_unknown_field' | 'openapi_required_field_missing_in_pact',
+        field,
+        severity: 'WARNING' | 'ERROR'
+    }
+    """
+    gaps: list[dict[str, Any]] = []
+
+    for pact in pacts:
+        consumer = pact.get("consumer", {}).get("name", "unknown")
+        provider = pact.get("provider", {}).get("name", "unknown")
+
+        for interaction in pact.get("interactions", []):
+            description = interaction.get("description", "")
+            request = interaction.get("request", {})
+            response = interaction.get("response", {})
+
+            req_path: str = request.get("path", "")
+            req_method: str = request.get("method", "GET").upper()
+            resp_status: int = response.get("status", 200)
+            resp_body: Any = response.get("body")
+
+            # Find matching OpenAPI entry (exact match first, then template match)
+            oas_entry = openapi_map.get((req_path, req_method))
+            if oas_entry is None:
+                # Try to match path templates: /v1/namespace/ns_existing/list → /v1/namespace/{id}/list
+                for (oas_path, oas_method), entry in openapi_map.items():
+                    if oas_method != req_method:
+                        continue
+                    oas_parts = oas_path.split("/")
+                    req_parts = req_path.split("/")
+                    if len(oas_parts) != len(req_parts):
+                        continue
+                    matched = all(
+                        op == rp or (op.startswith("{") and op.endswith("}"))
+                        for op, rp in zip(oas_parts, req_parts)
+                    )
+                    if matched:
+                        oas_entry = entry
+                        break
+
+            if oas_entry is None:
+                gaps.append({
+                    "consumer": consumer,
+                    "provider": provider,
+                    "description": description,
+                    "path": req_path,
+                    "method": req_method,
+                    "status": resp_status,
+                    "gap_type": "path_not_in_openapi",
+                    "field": req_path,
+                    "severity": "WARNING",
+                })
+                continue
+
+            # Check response field coverage
+            status_key = str(resp_status)
+            oas_resp = oas_entry.get("responses", {}).get(status_key, {})
+            oas_fields: FieldSet = oas_resp.get("fields", set())
+            oas_required: FieldSet = oas_resp.get("required", set())
+
+            pact_body_fields = _extract_pact_body_fields(resp_body)
+            pact_top_fields = {f[2:] for f in pact_body_fields if f.count(".") == 1 and "[" not in f}
+
+            # Pact has field not in OpenAPI
+            for field in pact_top_fields:
+                if oas_fields and field not in oas_fields:
+                    gaps.append({
+                        "consumer": consumer,
+                        "provider": provider,
+                        "description": description,
+                        "path": req_path,
+                        "method": req_method,
+                        "status": resp_status,
+                        "gap_type": "pact_has_unknown_field",
+                        "field": field,
+                        "severity": "WARNING",
+                    })
+
+            # OpenAPI required field missing from pact body
+            for field in oas_required:
+                if field not in pact_top_fields:
+                    gaps.append({
+                        "consumer": consumer,
+                        "provider": provider,
+                        "description": description,
+                        "path": req_path,
+                        "method": req_method,
+                        "status": resp_status,
+                        "gap_type": "openapi_required_field_missing_in_pact",
+                        "field": field,
+                        "severity": "ERROR",
+                    })
+
+    return gaps
+
+
+# ---------------------------------------------------------------------------
+# Report generation
+# ---------------------------------------------------------------------------
+
+def generate_report(
+    pacts: list[Pact],
+    gaps: list[dict[str, Any]],
+    openapi_path: Path,
+) -> str:
+    """Generate a Markdown coverage report."""
+    lines: list[str] = [
+        "# OpenAPI ↔ Pact Field Coverage Report",
+        "",
+        f"**OpenAPI spec**: `{openapi_path}`",
+        f"**Pacts analysed**: {len(pacts)}",
+        "",
+    ]
+
+    if not pacts:
+        lines += [
+            "> **No pacts available** — broker unreachable or no pacts published.",
+            "> Run consumer tests first and publish pacts to the broker.",
+            "",
+        ]
+        return "\n".join(lines)
+
+    errors = [g for g in gaps if g["severity"] == "ERROR"]
+    warnings = [g for g in gaps if g["severity"] == "WARNING"]
+
+    status = "PASS" if not errors else "FAIL"
+    lines += [
+        f"**Status**: {status}",
+        f"**Errors**: {len(errors)}  |  **Warnings**: {len(warnings)}",
+        "",
+    ]
+
+    if not gaps:
+        lines += [
+            "No field coverage gaps detected.",
+            "",
+        ]
+        return "\n".join(lines)
+
+    lines += ["## Coverage Gaps", ""]
+    lines += [
+        "| Severity | Consumer | Path | Method | Status | Gap Type | Field |",
+        "|---|---|---|---|---|---|---|",
+    ]
+    for gap in sorted(gaps, key=lambda g: (g["severity"], g["path"])):
+        sev_icon = "🔴" if gap["severity"] == "ERROR" else "🟡"
+        lines.append(
+            f"| {sev_icon} {gap['severity']} "
+            f"| {gap['consumer']} "
+            f"| `{gap['path']}` "
+            f"| {gap['method']} "
+            f"| {gap['status']} "
+            f"| {gap['gap_type']} "
+            f"| `{gap['field']}` |"
+        )
+
+    lines += ["", "## Details", ""]
+    for i, gap in enumerate(gaps, 1):
+        lines += [
+            f"### Gap #{i}: {gap['gap_type']}",
+            "",
+            f"- **Consumer**: {gap['consumer']}",
+            f"- **Provider**: {gap['provider']}",
+            f"- **Interaction**: {gap['description']}",
+            f"- **Path**: `{gap['method']} {gap['path']}` → HTTP {gap['status']}",
+            f"- **Field**: `{gap['field']}`",
+            f"- **Severity**: {gap['severity']}",
+            "",
+        ]
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Check field coverage between OpenAPI spec and published Pact contracts.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--broker-url",
+        default=os.environ.get("PACT_BROKER_URL", ""),
+        help="Pact Broker base URL (default: $PACT_BROKER_URL)",
+    )
+    parser.add_argument(
+        "--openapi-spec",
+        default="docs/src/rest.yaml",
+        help="Path to OpenAPI spec file (default: docs/src/rest.yaml)",
+    )
+    parser.add_argument(
+        "--output",
+        default="-",
+        help="Output file path (default: stdout)",
+    )
+    args = parser.parse_args()
+
+    spec_path = Path(args.openapi_spec)
+    if not spec_path.exists():
+        print(f"[ERROR] OpenAPI spec not found: {spec_path}", file=sys.stderr)
+        return 1
+
+    # Fetch pacts
+    pacts: list[Pact] = []
+    if args.broker_url:
+        pacts = fetch_pacts(args.broker_url)
+    else:
+        print("[WARN] No --broker-url provided and $PACT_BROKER_URL not set. Skipping broker fetch.", file=sys.stderr)
+
+    # Parse OpenAPI
+    openapi_map = parse_openapi(spec_path)
+
+    # Check coverage
+    gaps = check_coverage(pacts, openapi_map) if pacts else []
+
+    # Generate report
+    report = generate_report(pacts, gaps, spec_path)
+
+    # Write output
+    if args.output == "-":
+        print(report)
+    else:
+        Path(args.output).write_text(report, encoding="utf-8")
+        print(f"[OK] Report written to {args.output}", file=sys.stderr)
+
+    has_errors = any(g["severity"] == "ERROR" for g in gaps)
+    if not pacts:
+        return 2
+    return 1 if has_errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/pact_consistency_check.py
+++ b/ci/pact_consistency_check.py
@@ -1,0 +1,469 @@
+#!/usr/bin/env python3
+"""
+pact_consistency_check.py — Cross-consumer matcher consistency checker.
+
+Compares matcher semantics across multiple consumer pact files against the
+canonical contract-pack/interactions.json, and outputs a difference matrix.
+
+Usage:
+    # Check all 3 language consumers (default multi-dir mode):
+    python ci/pact_consistency_check.py
+
+    # Check a single directory:
+    python ci/pact_consistency_check.py \\
+        --pacts-dir java/lance-namespace-apache-client/target/pacts
+
+    # Check multiple directories (comma-separated):
+    python ci/pact_consistency_check.py \\
+        --pacts-dirs java/lance-namespace-apache-client/target/pacts,\\
+                     python/lance_namespace_urllib3_client/tests/pact/pacts,\\
+                     rust/lance-namespace-reqwest-client/target/pacts
+
+    # Filter to specific consumers:
+    python ci/pact_consistency_check.py \\
+        --consumers lance-namespace-java-apache,lance-namespace-python-urllib3
+
+Known consumer names (from contract-pack/naming.lock.yaml):
+    lance-namespace-java-apache      (Java / Apache HTTP)
+    lance-namespace-python-urllib3   (Python / urllib3)
+    lance-namespace-rust-reqwest     (Rust / reqwest)
+
+Exit codes:
+    0 — all matchers consistent with contract pack
+    1 — matcher drift detected
+    2 — contract pack file not found
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Default pact directories — one per language consumer
+# ---------------------------------------------------------------------------
+
+DEFAULT_PACTS_DIRS: list[str] = [
+    "java/lance-namespace-apache-client/target/pacts",
+    "python/lance_namespace_urllib3_client/tests/pact_tests/pacts",
+    "rust/lance-namespace-reqwest-client/target/pacts",
+]
+
+# ---------------------------------------------------------------------------
+# Types
+# ---------------------------------------------------------------------------
+
+Pact = dict[str, Any]
+MatcherMap = dict[str, str]  # jsonpath → matcher_type
+# interaction_id → consumer_name → MatcherMap
+ConsistencyMatrix = dict[str, dict[str, MatcherMap]]
+
+
+# ---------------------------------------------------------------------------
+# Load contract pack
+# ---------------------------------------------------------------------------
+
+def load_contract_pack(contract_pack_dir: Path) -> dict[str, Any]:
+    """
+    Load the canonical interactions.json from the contract pack directory.
+
+    Returns a dict with:
+        interactions: list of canonical interaction defs
+        canonical_matchers: interaction_id → MatcherMap
+    """
+    interactions_path = contract_pack_dir / "interactions.json"
+    if not interactions_path.exists():
+        print(f"[ERROR] Contract pack interactions.json not found: {interactions_path}", file=sys.stderr)
+        sys.exit(2)
+
+    data: dict[str, Any] = json.loads(interactions_path.read_text(encoding="utf-8"))
+    interactions = data.get("interactions", [])
+
+    canonical_matchers: dict[str, MatcherMap] = {}
+    for interaction in interactions:
+        iid = interaction.get("id", interaction.get("description", "?"))
+        matchers: MatcherMap = {}
+        body_rules = interaction.get("response", {}).get("matchingRules", {}).get("body", {})
+        for path, rule in body_rules.items():
+            matcher_list = rule.get("matchers", [])
+            for m in matcher_list:
+                match_type = m.get("match", "unknown")
+                if "min" in m:
+                    match_type = f"{match_type}(min={m['min']})"
+                matchers[path] = match_type
+        canonical_matchers[iid] = matchers
+
+    return {
+        "interactions": interactions,
+        "canonical_matchers": canonical_matchers,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Load pact files
+# ---------------------------------------------------------------------------
+
+def load_pacts_from_dir(pacts_dir: Path, consumers_filter: list[str] | None = None) -> list[Pact]:
+    """
+    Load all pact JSON files from a single directory (and subdirectories).
+
+    Optionally filter to specific consumer names.
+    Returns empty list (with a warning) if directory does not exist.
+    """
+    if not pacts_dir.exists():
+        print(f"[WARN] Pacts directory not found: {pacts_dir}", file=sys.stderr)
+        print("[WARN] Run consumer tests first to generate pact files.", file=sys.stderr)
+        return []
+
+    pattern = str(pacts_dir / "**" / "*.json")
+    pacts: list[Pact] = []
+
+    for filepath in glob.glob(pattern, recursive=True):
+        try:
+            pact: Pact = json.loads(Path(filepath).read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            print(f"[WARN] Cannot load pact file {filepath!r}: {exc}", file=sys.stderr)
+            continue
+
+        consumer_name = pact.get("consumer", {}).get("name", "")
+        if consumers_filter and consumer_name not in consumers_filter:
+            continue
+        pact["_source_file"] = filepath
+        pacts.append(pact)
+
+    return pacts
+
+
+def load_pacts(
+    pacts_dirs: list[Path],
+    consumers_filter: list[str] | None = None,
+) -> list[Pact]:
+    """
+    Load pact JSON files from multiple directories.
+
+    Deduplicates by (consumer, provider, description) so that the same pact
+    file present in multiple directories is only counted once.
+    """
+    seen: set[tuple[str, str, str]] = set()
+    all_pacts: list[Pact] = []
+    total_dirs_found = 0
+
+    for pacts_dir in pacts_dirs:
+        dir_pacts = load_pacts_from_dir(pacts_dir, consumers_filter)
+        if dir_pacts:
+            total_dirs_found += 1
+        print(
+            f"[INFO] Loaded {len(dir_pacts)} pact file(s) from {pacts_dir}",
+            file=sys.stderr,
+        )
+        for pact in dir_pacts:
+            consumer = pact.get("consumer", {}).get("name", "")
+            provider = pact.get("provider", {}).get("name", "")
+            # Use a set of descriptions as the dedup key
+            descriptions = frozenset(
+                i.get("description", "") for i in pact.get("interactions", [])
+            )
+            key = (consumer, provider, str(sorted(descriptions)))
+            if key not in seen:
+                seen.add(key)
+                all_pacts.append(pact)
+
+    print(
+        f"[INFO] Total: {len(all_pacts)} unique pact file(s) across {len(pacts_dirs)} director(ies)",
+        file=sys.stderr,
+    )
+    return all_pacts
+
+
+# ---------------------------------------------------------------------------
+# Matcher extraction
+# ---------------------------------------------------------------------------
+
+def extract_matchers(interaction: dict[str, Any]) -> MatcherMap:
+    """
+    Extract matcher rules from a single pact interaction's response.
+
+    Returns a MatcherMap: {jsonpath: matcher_type_string}.
+    """
+    matchers: MatcherMap = {}
+    response = interaction.get("response", {})
+    body_rules = response.get("matchingRules", {}).get("body", {})
+
+    for path, rule in body_rules.items():
+        if isinstance(rule, dict):
+            matcher_list = rule.get("matchers", [])
+            for m in matcher_list:
+                if isinstance(m, dict):
+                    match_type = m.get("match", "unknown")
+                    if "min" in m:
+                        match_type = f"{match_type}(min={m['min']})"
+                    matchers[path] = match_type
+
+    return matchers
+
+
+def _description_to_id(description: str, canonical_interactions: list[dict[str, Any]]) -> str | None:
+    """Find the canonical interaction ID matching a description string."""
+    for interaction in canonical_interactions:
+        if interaction.get("description") == description:
+            return interaction.get("id", description)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Comparison
+# ---------------------------------------------------------------------------
+
+def compare_matchers(
+    pacts: list[Pact],
+    contract_pack: dict[str, Any],
+) -> tuple[ConsistencyMatrix, list[dict[str, Any]]]:
+    """
+    Compare matchers in pact files against the canonical contract pack.
+
+    Returns:
+        matrix   — ConsistencyMatrix for report generation
+        drifts   — list of drift records (deviations from canonical)
+    """
+    canonical_matchers: dict[str, MatcherMap] = contract_pack["canonical_matchers"]
+    canonical_interactions: list[dict[str, Any]] = contract_pack["interactions"]
+    matrix: ConsistencyMatrix = {}
+    drifts: list[dict[str, Any]] = []
+
+    for pact in pacts:
+        consumer = pact.get("consumer", {}).get("name", "unknown")
+
+        for interaction in pact.get("interactions", []):
+            description = interaction.get("description", "")
+            iid = _description_to_id(description, canonical_interactions)
+            if iid is None:
+                iid = description  # unknown interaction — still record it
+
+            if iid not in matrix:
+                matrix[iid] = {}
+
+            pact_matchers = extract_matchers(interaction)
+            matrix[iid][consumer] = pact_matchers
+
+            # Compare against canonical
+            canonical = canonical_matchers.get(iid, {})
+            for path, canonical_matcher in canonical.items():
+                pact_matcher = pact_matchers.get(path)
+                if pact_matcher is None:
+                    drifts.append({
+                        "interaction_id": iid,
+                        "consumer": consumer,
+                        "path": path,
+                        "drift_type": "MISSING_IN_PACT",
+                        "canonical": canonical_matcher,
+                        "actual": None,
+                        "severity": "ERROR",
+                    })
+                elif pact_matcher != canonical_matcher:
+                    drifts.append({
+                        "interaction_id": iid,
+                        "consumer": consumer,
+                        "path": path,
+                        "drift_type": "MATCHER_MISMATCH",
+                        "canonical": canonical_matcher,
+                        "actual": pact_matcher,
+                        "severity": "WARNING",
+                    })
+
+            # Check for extra matchers not in canonical (permissive — just warn)
+            for path, pact_matcher in pact_matchers.items():
+                if path not in canonical:
+                    drifts.append({
+                        "interaction_id": iid,
+                        "consumer": consumer,
+                        "path": path,
+                        "drift_type": "EXTRA_IN_PACT",
+                        "canonical": None,
+                        "actual": pact_matcher,
+                        "severity": "WARNING",
+                    })
+
+    return matrix, drifts
+
+
+# ---------------------------------------------------------------------------
+# Report generation
+# ---------------------------------------------------------------------------
+
+def _short_consumer(name: str) -> str:
+    """Shorten consumer names for compact column headers."""
+    return (
+        name.replace("lance-namespace-", "")
+            .replace("-apache", "/apache")
+            .replace("-urllib3", "/urllib3")
+            .replace("-reqwest", "/reqwest")
+    )
+
+
+def generate_matrix(
+    matrix: ConsistencyMatrix,
+    drifts: list[dict[str, Any]],
+    contract_pack: dict[str, Any],
+) -> str:
+    """Generate a Markdown consistency matrix report."""
+    canonical_matchers: dict[str, MatcherMap] = contract_pack["canonical_matchers"]
+    lines: list[str] = [
+        "# Pact Matcher Consistency Matrix",
+        "",
+        "Compares matcher rules across consumer pact files against `contract-pack/interactions.json`.",
+        "",
+        "| Symbol | Meaning |",
+        "|--------|---------|",
+        "| ✅ | Matches canonical |",
+        "| ❌ | Differs from canonical |",
+        "| ⬜ | Not present in this consumer pact |",
+        "",
+    ]
+
+    has_errors = any(d["severity"] == "ERROR" for d in drifts)
+    status = "FAIL" if has_errors else ("WARN" if drifts else "PASS")
+    lines += [
+        f"**Status**: {status}",
+        f"**Drifts detected**: {len(drifts)} ({sum(1 for d in drifts if d['severity'] == 'ERROR')} errors, "
+        f"{sum(1 for d in drifts if d['severity'] == 'WARNING')} warnings)",
+        "",
+    ]
+
+    # Per-interaction matrix tables
+    for iid, consumers in matrix.items():
+        canonical = canonical_matchers.get(iid, {})
+        all_paths = sorted(set(canonical.keys()) | {p for m in consumers.values() for p in m.keys()})
+        consumer_names = sorted(consumers.keys())
+        short_names = [_short_consumer(c) for c in consumer_names]
+
+        lines += [f"## Interaction: `{iid}`", ""]
+        if not all_paths:
+            lines += ["*No body matching rules defined.*", ""]
+            continue
+
+        # Header row
+        header = "| JSON Path | Canonical |" + "".join(f" {s} |" for s in short_names)
+        sep = "|---|---|" + "---|" * len(consumer_names)
+        lines += [header, sep]
+
+        for path in all_paths:
+            canonical_val = canonical.get(path, "—")
+            row = f"| `{path}` | `{canonical_val}` |"
+            for consumer in consumer_names:
+                consumer_val = consumers.get(consumer, {}).get(path, "—")
+                match_icon = "✅" if consumer_val == canonical_val else ("❌" if consumer_val != "—" else "⬜")
+                row += f" {match_icon} `{consumer_val}` |"
+            lines.append(row)
+
+        lines.append("")
+
+    # Drift details
+    if drifts:
+        lines += ["## Drift Details", ""]
+        lines += [
+            "| Severity | Interaction | Consumer | Path | Canonical | Actual | Type |",
+            "|---|---|---|---|---|---|---|",
+        ]
+        for d in sorted(drifts, key=lambda x: (x["severity"], x["interaction_id"])):
+            sev_icon = "🔴" if d["severity"] == "ERROR" else "🟡"
+            lines.append(
+                f"| {sev_icon} {d['severity']} "
+                f"| `{d['interaction_id']}` "
+                f"| {d['consumer']} "
+                f"| `{d['path']}` "
+                f"| `{d['canonical']}` "
+                f"| `{d['actual']}` "
+                f"| {d['drift_type']} |"
+            )
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Check matcher consistency across consumer pact files vs contract pack.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--contract-pack",
+        default="contract-pack",
+        help="Path to contract-pack directory (default: contract-pack/)",
+    )
+
+    dirs_group = parser.add_mutually_exclusive_group()
+    dirs_group.add_argument(
+        "--pacts-dirs",
+        default="",
+        help=(
+            "Comma-separated list of directories to search for pact JSON files. "
+            "Defaults to all 3 language consumer directories: "
+            + ", ".join(DEFAULT_PACTS_DIRS)
+        ),
+    )
+    dirs_group.add_argument(
+        "--pacts-dir",
+        default="",
+        help="Single directory to search for pact JSON files (shorthand for --pacts-dirs with one value).",
+    )
+
+    parser.add_argument(
+        "--consumers",
+        default="",
+        help="Comma-separated list of consumer names to filter (default: all consumers)",
+    )
+    parser.add_argument(
+        "--output",
+        default="-",
+        help="Output file path (default: stdout)",
+    )
+    args = parser.parse_args()
+
+    consumers_filter = [c.strip() for c in args.consumers.split(",") if c.strip()] or None
+
+    # Resolve pact directories
+    if args.pacts_dir:
+        # Single-dir shorthand (backward-compatible with old --pacts-dir flag)
+        raw_dirs = [args.pacts_dir.strip()]
+    elif args.pacts_dirs:
+        raw_dirs = [d.strip() for d in args.pacts_dirs.split(",") if d.strip()]
+    else:
+        raw_dirs = DEFAULT_PACTS_DIRS
+
+    pacts_dirs = [Path(d) for d in raw_dirs]
+
+    contract_pack_dir = Path(args.contract_pack)
+    contract_pack = load_contract_pack(contract_pack_dir)
+
+    pacts = load_pacts(pacts_dirs, consumers_filter)
+
+    if not pacts:
+        print("[WARN] No pact files found. Report will show only canonical matchers.", file=sys.stderr)
+        matrix: ConsistencyMatrix = {}
+        drifts: list[dict[str, Any]] = []
+    else:
+        matrix, drifts = compare_matchers(pacts, contract_pack)
+
+    report = generate_matrix(matrix, drifts, contract_pack)
+
+    if args.output == "-":
+        print(report)
+    else:
+        Path(args.output).write_text(report, encoding="utf-8")
+        print(f"[OK] Report written to {args.output}", file=sys.stderr)
+
+    has_errors = any(d["severity"] == "ERROR" for d in drifts)
+    return 1 if has_errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ci/pact_state_guard.sh
+++ b/ci/pact_state_guard.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# pact_state_guard.sh — Pre-commit hook: guard against unauthorized Pact provider states.
+#
+# Checks every passed *.java file for @State( annotations, extracts the state string(s),
+# and verifies each is present in the whitelist defined by
+# contract-pack/provider-states.lock.json.
+#
+# Usage (called by pre-commit framework):
+#   ci/pact_state_guard.sh [file1.java file2.java ...]
+#
+# Exit codes:
+#   0 — all @State strings are whitelisted (or no @State found)
+#   1 — one or more unauthorized @State strings detected
+#
+# Requirements:
+#   - bash 4+
+#   - python3 (for JSON parsing of provider-states.lock.json)
+#     If python3 is unavailable, falls back to a grep-based approach (less precise).
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+LOCK_FILE="${REPO_ROOT}/contract-pack/provider-states.lock.json"
+
+# ────────────────────────────────────────────────────────────────────────────
+# Validate environment
+# ────────────────────────────────────────────────────────────────────────────
+if [[ ! -f "${LOCK_FILE}" ]]; then
+    echo "[ERROR] pact_state_guard: lock file not found: ${LOCK_FILE}" >&2
+    echo "        Create contract-pack/provider-states.lock.json before committing." >&2
+    exit 1
+fi
+
+if [[ $# -eq 0 ]]; then
+    # No files passed — nothing to check
+    exit 0
+fi
+
+# ────────────────────────────────────────────────────────────────────────────
+# Load whitelist from provider-states.lock.json
+# ────────────────────────────────────────────────────────────────────────────
+if command -v python3 &>/dev/null; then
+    # Use python3 for reliable JSON parsing
+    WHITELIST=$(python3 - "${LOCK_FILE}" <<'PYEOF'
+import json, sys
+lock = json.loads(open(sys.argv[1], encoding="utf-8").read())
+for s in lock.get("states", []):
+    print(s["state"])
+PYEOF
+)
+else
+    # Fallback: grep-based extraction (works for well-formatted JSON)
+    WHITELIST=$(grep -oP '(?<="state": ")[^"]+' "${LOCK_FILE}" || true)
+fi
+
+if [[ -z "${WHITELIST}" ]]; then
+    echo "[WARN] pact_state_guard: no states found in ${LOCK_FILE}. Allowing all." >&2
+    exit 0
+fi
+
+# ────────────────────────────────────────────────────────────────────────────
+# Check each Java file
+# ────────────────────────────────────────────────────────────────────────────
+ERRORS=0
+
+for java_file in "$@"; do
+    [[ -f "${java_file}" ]] || continue
+
+    # Extract @State("...") and @State({"...", "..."}) patterns
+    # Handles:
+    #   @State("state string here")
+    #   @State(value = "state string here")
+    #   @State({"state 1", "state 2"})
+    while IFS= read -r line; do
+        # Strip leading/trailing whitespace
+        line="${line#"${line%%[![:space:]]*}"}"
+        line="${line%"${line##*[![:space:]]}"}"
+
+        [[ -z "${line}" ]] && continue
+
+        # Check if this state string is in the whitelist
+        found=0
+        while IFS= read -r allowed; do
+            if [[ "${line}" == "${allowed}" ]]; then
+                found=1
+                break
+            fi
+        done <<< "${WHITELIST}"
+
+        if [[ "${found}" -eq 0 ]]; then
+            echo "[ERROR] pact_state_guard: unauthorized @State string in ${java_file}:" >&2
+            echo "        '${line}'" >&2
+            echo "" >&2
+            echo "        Allowed states (from contract-pack/provider-states.lock.json):" >&2
+            while IFS= read -r allowed_state; do
+                echo "          - '${allowed_state}'" >&2
+            done <<< "${WHITELIST}"
+            echo "" >&2
+            echo "        To add a new state, update provider-states.lock.json first." >&2
+            ERRORS=$((ERRORS + 1))
+        fi
+    done < <(
+        # Extract state strings from @State annotations using Python for accuracy
+        if command -v python3 &>/dev/null; then
+            python3 - "${java_file}" <<'PYEOF'
+import re, sys
+
+content = open(sys.argv[1], encoding="utf-8", errors="replace").read()
+
+# Match @State("...") or @State(value = "...") or @State({"...", ...})
+pattern = re.compile(
+    r'@State\s*\('
+    r'(?:'
+        r'\s*\{([^}]+)\}'         # array form: @State({"a", "b"})
+        r'|'
+        r'(?:value\s*=\s*)?'      # optional `value =`
+        r'"((?:[^"\\]|\\.)*)"'    # single string form
+    r')',
+    re.MULTILINE,
+)
+
+for m in pattern.finditer(content):
+    array_part = m.group(1)
+    single_part = m.group(2)
+    if array_part:
+        # Extract each quoted string in the array
+        for s in re.findall(r'"((?:[^"\\]|\\.)*)"', array_part):
+            print(s)
+    elif single_part is not None:
+        print(single_part)
+PYEOF
+        else
+            # Fallback: grep for @State("...") single-string form only
+            grep -oP '(?<=@State\(")[^"]+' "${java_file}" 2>/dev/null || true
+        fi
+    )
+done
+
+# ────────────────────────────────────────────────────────────────────────────
+# Result
+# ────────────────────────────────────────────────────────────────────────────
+if [[ "${ERRORS}" -gt 0 ]]; then
+    echo "[FAIL] pact_state_guard: ${ERRORS} unauthorized @State string(s) found." >&2
+    exit 1
+fi
+
+exit 0

--- a/contract-pack/README.md
+++ b/contract-pack/README.md
@@ -1,0 +1,59 @@
+# contract-pack/
+
+This directory holds the **shared contract artifacts** that bridge the
+three Pact consumers (Java/Python/Rust) and the Spring Boot provider
+verification.
+
+## Layout
+
+```
+contract-pack/
+├── README.md                  ← you are here
+└── sample-pacts/              ← consumer-generated pact JSON drops here
+    ├── README.md
+    └── .gitkeep
+```
+
+### `sample-pacts/`
+
+The provider verification test
+[`PactProviderTest`](../java/lance-namespace-pact-tests/src/test/java/org/lance/namespace/pact/provider/PactProviderTest.java)
+is annotated with:
+
+```java
+@PactFolder("../../contract-pack/sample-pacts")
+```
+
+resolved relative to its module root (`java/lance-namespace-pact-tests/`).
+
+In CI the [pact.yml](../.github/workflows/pact.yml) workflow:
+
+1. Runs each consumer job (`consumer-java`, `consumer-python`,
+   `consumer-rust`) to **produce** their pact JSON.
+2. Uploads each pact as a build artifact (`pact-files-java`, …).
+3. The `provider-verify` job downloads all three artifacts back into
+   `contract-pack/sample-pacts/` before invoking `mvn ... -Dtest=PactProviderTest`.
+
+### Local reproduction
+
+```bash
+# 1. Generate consumer pacts (any subset)
+( cd java   && mvn -pl lance-namespace-pact-tests -Dspotless.skip=true -Dtest=NamespaceApiPactTest test )
+( cd python/lance_namespace_pact_tests && uv sync --group dev && uv run pytest tests/pact_tests -v )
+( cd rust   && cargo test -p lance-namespace-pact-tests --tests )
+
+# 2. Stage them where the provider expects to find them
+cp java/lance-namespace-pact-tests/target/pacts/*.json                                contract-pack/sample-pacts/
+cp python/lance_namespace_pact_tests/tests/pact_tests/pacts/*.json                    contract-pack/sample-pacts/
+cp rust/lance-namespace-pact-tests/target/pacts/*.json                                contract-pack/sample-pacts/
+
+# 3. Run provider verification
+( cd java && mvn -pl lance-namespace-pact-tests -am -Dspotless.skip=true \
+                 -Dtest=PactProviderTest -Dspring.profiles.active=pact test )
+```
+
+### Git tracking
+
+The directory is kept in version control via `.gitkeep`, but the
+`*.json` pact files inside `sample-pacts/` are **gitignored** — they
+are build outputs regenerated on every CI run.

--- a/contract-pack/sample-pacts/.gitignore
+++ b/contract-pack/sample-pacts/.gitignore
@@ -1,0 +1,3 @@
+# Pact JSON files in this directory are build artifacts.
+# They are regenerated on every CI run; only .gitkeep + README.md are tracked.
+*.json

--- a/contract-pack/sample-pacts/README.md
+++ b/contract-pack/sample-pacts/README.md
@@ -1,0 +1,22 @@
+# sample-pacts/
+
+Drop zone for **consumer-generated Pact JSON** files. The Spring Boot
+provider verification test
+([`PactProviderTest`](../../java/lance-namespace-pact-tests/src/test/java/org/lance/namespace/pact/provider/PactProviderTest.java))
+loads every `*.json` under this directory via
+`@PactFolder("../../contract-pack/sample-pacts")`.
+
+Expected files (one per consumer):
+
+| File | Producer |
+| --- | --- |
+| `lance-namespace-java-apache-lance-namespace-server.json`     | `mvn -pl lance-namespace-pact-tests -Dtest=NamespaceApiPactTest test` |
+| `lance-namespace-python-urllib3-lance-namespace-server.json`  | `uv run pytest python/lance_namespace_pact_tests/tests/pact_tests` |
+| `lance-namespace-rust-reqwest-lance-namespace-server.json`    | `cargo test -p lance-namespace-pact-tests --tests`                    |
+
+These JSON files are **build artifacts**: they are regenerated on every
+CI run and are intentionally **gitignored**. Only `.gitkeep` and this
+README are tracked.
+
+See [../README.md](../README.md) for the full local reproduction
+workflow.

--- a/java/Makefile
+++ b/java/Makefile
@@ -119,6 +119,31 @@ build-core-async: build-async-client lint-core-async
 check-core-async:
 	./mvnw checkstyle:check spotless:check -pl lance-namespace-core-async -am
 
+# lance-namespace-pact-tests module (hand-written contract tests, no codegen).
+# Depends on apache-client (consumer side) + springboot-server (provider side).
+.PHONY: lint-pact-tests
+lint-pact-tests: gen-apache-client gen-springboot-server
+	./mvnw spotless:apply -pl lance-namespace-pact-tests -am
+
+.PHONY: build-pact-tests
+build-pact-tests: build-apache-client build-springboot-server lint-pact-tests
+	./mvnw install -pl lance-namespace-pact-tests -am -DskipTests
+
+.PHONY: test-pact-consumer
+test-pact-consumer: lint-pact-tests
+	./mvnw -pl lance-namespace-pact-tests -am -Dspotless.skip=true \
+		-Dtest='org.lance.namespace.pact.consumer.*' test
+
+.PHONY: test-pact-provider
+test-pact-provider: lint-pact-tests
+	./mvnw -pl lance-namespace-pact-tests -am -Dspotless.skip=true \
+		-Dtest='org.lance.namespace.pact.provider.PactProviderTest' \
+		-Dspring.profiles.active=pact test
+
+.PHONY: check-pact-tests
+check-pact-tests:
+	./mvnw checkstyle:check spotless:check -pl lance-namespace-pact-tests -am
+
 .PHONY: clean
 clean: clean-apache-client clean-async-client clean-springboot-server
 
@@ -134,10 +159,10 @@ check-springboot-server:
 	./mvnw checkstyle:check spotless:check -pl lance-namespace-springboot-server -am
 
 .PHONY: check
-check: check-apache-client check-async-client check-springboot-server check-core check-core-async
+check: check-apache-client check-async-client check-springboot-server check-core check-core-async check-pact-tests
 
 .PHONY: lint
-lint: lint-apache-client lint-async-client lint-springboot-server lint-core lint-core-async
+lint: lint-apache-client lint-async-client lint-springboot-server lint-core lint-core-async lint-pact-tests
 
 .PHONY: build
-build: build-apache-client build-async-client build-springboot-server build-core build-core-async
+build: build-apache-client build-async-client build-springboot-server build-core build-core-async build-pact-tests

--- a/java/lance-namespace-pact-tests/pom.xml
+++ b/java/lance-namespace-pact-tests/pom.xml
@@ -1,0 +1,194 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.lance</groupId>
+        <artifactId>lance-namespace-root</artifactId>
+        <version>0.7.6</version>
+    </parent>
+
+    <artifactId>lance-namespace-pact-tests</artifactId>
+    <packaging>jar</packaging>
+    <name>${project.artifactId}</name>
+    <description>
+        Hand-written Pact contract tests for Lance Namespace.
+        Houses both consumer (Java Apache HTTP client) tests and provider
+        (Spring Boot server) verification tests. This module is intentionally
+        kept outside any code-generated module so that running clean+gen
+        cannot wipe these tests.
+    </description>
+
+    <properties>
+        <maven.compiler.release>17</maven.compiler.release>
+        <!-- pact-jvm 4.6.14 requires JUnit Platform 1.12+ (ReflectionUtils.returnsVoid),
+             which in turn requires junit-jupiter 5.12+. Override the parent's 5.8.2. -->
+        <junit-version>5.12.2</junit-version>
+        <pact-jvm-version>4.6.14</pact-jvm-version>
+        <assertj.version>3.25.3</assertj.version>
+        <maven-surefire-plugin.pact.version>3.5.5</maven-surefire-plugin.pact.version>
+        <!-- This is a test-only module: nothing to publish to Maven Central. -->
+        <maven.deploy.skip>true</maven.deploy.skip>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- Re-import junit-bom at 5.12.2 so transitive junit-platform-* is aligned with
+                 pact-jvm 4.6.14 instead of inheriting the parent's 5.8.2. -->
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit-version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <!-- ─────────────── Consumer side: Java Apache HTTP client ─────────────── -->
+        <dependency>
+            <groupId>org.lance</groupId>
+            <artifactId>lance-namespace-apache-client</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- ─────────────── Provider side: Spring Boot generated API + models ──── -->
+        <dependency>
+            <groupId>org.lance</groupId>
+            <artifactId>lance-namespace-springboot-server</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Spring Boot runtime needed by PactTestApplication / PactProviderTest -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- ─────────────── Pact: consumer DSL + JUnit5 extension ──────────────── -->
+        <dependency>
+            <groupId>au.com.dius.pact.consumer</groupId>
+            <artifactId>junit5</artifactId>
+            <version>${pact-jvm-version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- ─────────────── Pact: provider verification with Spring MockMvc ────── -->
+        <dependency>
+            <groupId>au.com.dius.pact.provider</groupId>
+            <artifactId>junit5spring</artifactId>
+            <version>${pact-jvm-version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- ─────────────── Test support ───────────────────────────────────────── -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <!-- 3.5.5 supports JUnit Platform 1.12 (required by pact-jvm 4.6.14) -->
+                <version>${maven-surefire-plugin.pact.version}</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <!-- Overwrite pact files on each test run to avoid stale interaction merging -->
+                        <pact.writer.overwrite>true</pact.writer.overwrite>
+                        <!-- Consumer tests write generated pacts into target/pacts; the
+                             pact-publish profile and CI's upload-artifact step both pick them up
+                             from there. -->
+                        <pact.rootDir>${project.build.directory}/pacts</pact.rootDir>
+                    </systemPropertyVariables>
+                </configuration>
+                <dependencies>
+                    <!-- Align platform launcher/commons with junit 5.12.2.
+                         pact-jvm 4.6.14 requires platform 1.12+ APIs. -->
+                    <dependency>
+                        <groupId>org.junit.platform</groupId>
+                        <artifactId>junit-platform-launcher</artifactId>
+                        <version>1.12.2</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.junit.platform</groupId>
+                        <artifactId>junit-platform-commons</artifactId>
+                        <version>1.12.2</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <!-- ── pact-publish: upload pact files to a Pact Broker (CI only) ───── -->
+        <profile>
+            <id>pact-publish</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>au.com.dius.pact.provider</groupId>
+                        <artifactId>maven</artifactId>
+                        <version>${pact-jvm-version}</version>
+                        <configuration>
+                            <pactDirectory>${project.build.directory}/pacts</pactDirectory>
+                            <pactBrokerUrl>${env.PACT_BROKER_URL}</pactBrokerUrl>
+                            <pactBrokerToken>${env.PACT_BROKER_TOKEN}</pactBrokerToken>
+                            <projectVersion>${project.version}+${env.GIT_SHORT_SHA}</projectVersion>
+                            <tags>
+                                <tag>${env.PACT_CONSUMER_BRANCH}</tag>
+                                <tag>${env.GIT_SHORT_SHA}</tag>
+                            </tags>
+                            <trimSnapshot>true</trimSnapshot>
+                            <skipPactPublish>false</skipPactPublish>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/java/lance-namespace-pact-tests/src/test/java/org/lance/namespace/pact/consumer/ErrorResponseDsl.java
+++ b/java/lance-namespace-pact-tests/src/test/java/org/lance/namespace/pact/consumer/ErrorResponseDsl.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.namespace.pact.consumer;
+
+import au.com.dius.pact.consumer.dsl.DslPart;
+import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
+
+/**
+ * Shared DSL helper for building ErrorResponse pact body matchers.
+ *
+ * <p>Schema (from contract-pack/interactions.json):
+ *
+ * <ul>
+ *   <li>{@code error} — String matched as stringType
+ *   <li>{@code code} — Integer matched as integerType
+ *   <li>{@code type} — String matched as stringType
+ *   <li>{@code detail} — String matched as stringType
+ * </ul>
+ */
+public final class ErrorResponseDsl {
+
+  private ErrorResponseDsl() {}
+
+  public static DslPart body(String error, int code, String type, String detail) {
+    return new PactDslJsonBody()
+        .stringType("error", error)
+        .integerType("code", code)
+        .stringType("type", type)
+        .stringType("detail", detail);
+  }
+}

--- a/java/lance-namespace-pact-tests/src/test/java/org/lance/namespace/pact/consumer/NamespaceApiPactTest.java
+++ b/java/lance-namespace-pact-tests/src/test/java/org/lance/namespace/pact/consumer/NamespaceApiPactTest.java
@@ -1,0 +1,919 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.namespace.pact.consumer;
+
+import org.lance.namespace.client.apache.ApiClient;
+import org.lance.namespace.client.apache.ApiException;
+import org.lance.namespace.client.apache.api.NamespaceApi;
+import org.lance.namespace.client.apache.api.TableApi;
+import org.lance.namespace.model.CreateNamespaceRequest;
+import org.lance.namespace.model.CreateNamespaceResponse;
+import org.lance.namespace.model.DeregisterTableRequest;
+import org.lance.namespace.model.DeregisterTableResponse;
+import org.lance.namespace.model.DescribeNamespaceRequest;
+import org.lance.namespace.model.DescribeNamespaceResponse;
+import org.lance.namespace.model.DescribeTableRequest;
+import org.lance.namespace.model.DescribeTableResponse;
+import org.lance.namespace.model.DropNamespaceRequest;
+import org.lance.namespace.model.DropNamespaceResponse;
+import org.lance.namespace.model.DropTableResponse;
+import org.lance.namespace.model.ListNamespacesResponse;
+import org.lance.namespace.model.ListTablesResponse;
+import org.lance.namespace.model.NamespaceExistsRequest;
+import org.lance.namespace.model.RegisterTableRequest;
+import org.lance.namespace.model.RegisterTableResponse;
+import org.lance.namespace.model.TableExistsRequest;
+
+import au.com.dius.pact.consumer.MockServer;
+import au.com.dius.pact.consumer.dsl.PactBuilder;
+import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
+import au.com.dius.pact.consumer.dsl.PactDslJsonRootValue;
+import au.com.dius.pact.consumer.junit5.PactConsumerTestExt;
+import au.com.dius.pact.consumer.junit5.PactTestFor;
+import au.com.dius.pact.core.model.PactSpecVersion;
+import au.com.dius.pact.core.model.V4Pact;
+import au.com.dius.pact.core.model.annotations.Pact;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Pact consumer tests for the Lance Namespace Apache HTTP client.
+ *
+ * <p>Covers all 22 interactions from contract-pack/interactions.json (schema v1.1). Consumer:
+ * lance-namespace-java-apache Provider: lance-namespace-server
+ *
+ * <p>Note: Request body is omitted from pact definitions so the mock server accepts any body. The
+ * generated client serializes default fields (context, id, properties) which is normal — pact is
+ * used to verify the server contract, not the exact request wire format.
+ */
+@ExtendWith(PactConsumerTestExt.class)
+@PactTestFor(providerName = "lance-namespace-server", pactVersion = PactSpecVersion.V4)
+public class NamespaceApiPactTest {
+
+  private static Map<String, Object> acceptJson() {
+    Map<String, Object> h = new HashMap<String, Object>();
+    h.put("Accept", "application/json");
+    return h;
+  }
+
+  private static Map<String, Object> jsonHeaders() {
+    Map<String, Object> h = new HashMap<String, Object>();
+    h.put("Accept", "application/json");
+    h.put("Content-Type", "application/json");
+    return h;
+  }
+
+  private static Map<String, Object> contentTypeJson() {
+    Map<String, Object> h = new HashMap<String, Object>();
+    h.put("Content-Type", "application/json");
+    return h;
+  }
+
+  // =========================================================================
+  // 1. listNamespaces – 200
+  // =========================================================================
+
+  @Pact(consumer = "lance-namespace-java-apache")
+  public V4Pact listNamespaces_returns_3_items(PactBuilder builder) {
+    return builder
+        .given("namespace 'ns_existing' has 3 tables")
+        .expectsToReceiveHttpInteraction(
+            "List child namespaces under ns_existing returns 3 items",
+            i ->
+                i.withRequest(
+                        req ->
+                            req.method("GET")
+                                .path("/v1/namespace/ns_existing/list")
+                                .headers(acceptJson()))
+                    .willRespondWith(
+                        resp ->
+                            resp.status(200)
+                                .headers(contentTypeJson())
+                                .body(
+                                    new PactDslJsonBody()
+                                        .minArrayLike(
+                                            "namespaces",
+                                            1,
+                                            PactDslJsonRootValue.stringType("child_a"),
+                                            3))))
+        .toPact();
+  }
+
+  @Test
+  @PactTestFor(pactMethod = "listNamespaces_returns_3_items")
+  void test_listNamespaces_returns_3_items(MockServer mockServer) throws Exception {
+    NamespaceApi api = new NamespaceApi(new ApiClient().setBasePath(mockServer.getUrl()));
+    ListNamespacesResponse response = api.listNamespaces("ns_existing", null, null, null);
+    assertNotNull(response);
+    assertFalse(response.getNamespaces().isEmpty());
+  }
+
+  // =========================================================================
+  // 2. listNamespaces – 404
+  // =========================================================================
+
+  @Pact(consumer = "lance-namespace-java-apache")
+  public V4Pact listNamespaces_returns_404(PactBuilder builder) {
+    return builder
+        .given("namespace 'ns_missing' does not exist")
+        .expectsToReceiveHttpInteraction(
+            "List child namespaces under non-existent namespace returns 404",
+            i ->
+                i.withRequest(
+                        req ->
+                            req.method("GET")
+                                .path("/v1/namespace/ns_missing/list")
+                                .headers(acceptJson()))
+                    .willRespondWith(
+                        resp ->
+                            resp.status(404)
+                                .headers(contentTypeJson())
+                                .body(
+                                    ErrorResponseDsl.body(
+                                        "NAMESPACE_NOT_FOUND",
+                                        404,
+                                        "org.lance.namespace.NamespaceNotFoundException",
+                                        "Namespace ns_missing does not exist"))))
+        .toPact();
+  }
+
+  @Test
+  @PactTestFor(pactMethod = "listNamespaces_returns_404")
+  void test_listNamespaces_returns_404(MockServer mockServer) {
+    NamespaceApi api = new NamespaceApi(new ApiClient().setBasePath(mockServer.getUrl()));
+    ApiException ex =
+        assertThrows(ApiException.class, () -> api.listNamespaces("ns_missing", null, null, null));
+    assertEquals(404, ex.getCode());
+  }
+
+  // =========================================================================
+  // 3. describeNamespace – 200
+  // =========================================================================
+
+  @Pact(consumer = "lance-namespace-java-apache")
+  public V4Pact describeNamespace_returns_properties(PactBuilder builder) {
+    return builder
+        .given("namespace 'ns_existing' has 3 tables")
+        .expectsToReceiveHttpInteraction(
+            "Describe namespace ns_existing returns properties",
+            i ->
+                i.withRequest(
+                        req ->
+                            req.method("POST")
+                                .path("/v1/namespace/ns_existing/describe")
+                                .headers(jsonHeaders()))
+                    .willRespondWith(
+                        resp ->
+                            resp.status(200)
+                                .headers(contentTypeJson())
+                                .body(
+                                    new PactDslJsonBody()
+                                        .like("properties", new HashMap<String, Object>()))))
+        .toPact();
+  }
+
+  @Test
+  @PactTestFor(pactMethod = "describeNamespace_returns_properties")
+  void test_describeNamespace_returns_properties(MockServer mockServer) throws Exception {
+    NamespaceApi api = new NamespaceApi(new ApiClient().setBasePath(mockServer.getUrl()));
+    DescribeNamespaceResponse response =
+        api.describeNamespace("ns_existing", new DescribeNamespaceRequest(), null);
+    assertNotNull(response);
+  }
+
+  // =========================================================================
+  // 4. describeNamespace – 404
+  // =========================================================================
+
+  @Pact(consumer = "lance-namespace-java-apache")
+  public V4Pact describeNamespace_returns_404(PactBuilder builder) {
+    return builder
+        .given("namespace 'ns_missing' does not exist")
+        .expectsToReceiveHttpInteraction(
+            "Describe non-existent namespace returns 404",
+            i ->
+                i.withRequest(
+                        req ->
+                            req.method("POST")
+                                .path("/v1/namespace/ns_missing/describe")
+                                .headers(jsonHeaders()))
+                    .willRespondWith(
+                        resp ->
+                            resp.status(404)
+                                .headers(contentTypeJson())
+                                .body(
+                                    ErrorResponseDsl.body(
+                                        "NAMESPACE_NOT_FOUND",
+                                        404,
+                                        "org.lance.namespace.NamespaceNotFoundException",
+                                        "Namespace ns_missing does not exist"))))
+        .toPact();
+  }
+
+  @Test
+  @PactTestFor(pactMethod = "describeNamespace_returns_404")
+  void test_describeNamespace_returns_404(MockServer mockServer) {
+    NamespaceApi api = new NamespaceApi(new ApiClient().setBasePath(mockServer.getUrl()));
+    ApiException ex =
+        assertThrows(
+            ApiException.class,
+            () -> api.describeNamespace("ns_missing", new DescribeNamespaceRequest(), null));
+    assertEquals(404, ex.getCode());
+  }
+
+  // =========================================================================
+  // 5. createNamespace – 200
+  // =========================================================================
+
+  @Pact(consumer = "lance-namespace-java-apache")
+  public V4Pact createNamespace_returns_200(PactBuilder builder) {
+    return builder
+        .given("namespace 'ns_new' does not exist")
+        .expectsToReceiveHttpInteraction(
+            "Create namespace ns_new returns created namespace",
+            i ->
+                i.withRequest(
+                        req ->
+                            req.method("POST")
+                                .path("/v1/namespace/ns_new/create")
+                                .headers(jsonHeaders()))
+                    .willRespondWith(
+                        resp ->
+                            resp.status(200)
+                                .headers(contentTypeJson())
+                                .body(
+                                    new PactDslJsonBody()
+                                        .like("properties", new HashMap<String, Object>()))))
+        .toPact();
+  }
+
+  @Test
+  @PactTestFor(pactMethod = "createNamespace_returns_200")
+  void test_createNamespace_returns_200(MockServer mockServer) throws Exception {
+    NamespaceApi api = new NamespaceApi(new ApiClient().setBasePath(mockServer.getUrl()));
+    CreateNamespaceResponse response =
+        api.createNamespace("ns_new", new CreateNamespaceRequest().mode("Create"), null);
+    assertNotNull(response);
+  }
+
+  // =========================================================================
+  // 6. createNamespace – 409
+  // =========================================================================
+
+  @Pact(consumer = "lance-namespace-java-apache")
+  public V4Pact createNamespace_returns_409(PactBuilder builder) {
+    return builder
+        .given("namespace 'ns_existing' has 3 tables")
+        .expectsToReceiveHttpInteraction(
+            "Create already-existing namespace returns 409 conflict",
+            i ->
+                i.withRequest(
+                        req ->
+                            req.method("POST")
+                                .path("/v1/namespace/ns_existing/create")
+                                .headers(jsonHeaders()))
+                    .willRespondWith(
+                        resp ->
+                            resp.status(409)
+                                .headers(contentTypeJson())
+                                .body(
+                                    ErrorResponseDsl.body(
+                                        "NAMESPACE_ALREADY_EXISTS",
+                                        409,
+                                        "org.lance.namespace.NamespaceAlreadyExistsException",
+                                        "Namespace ns_existing already exists"))))
+        .toPact();
+  }
+
+  @Test
+  @PactTestFor(pactMethod = "createNamespace_returns_409")
+  void test_createNamespace_returns_409(MockServer mockServer) {
+    NamespaceApi api = new NamespaceApi(new ApiClient().setBasePath(mockServer.getUrl()));
+    ApiException ex =
+        assertThrows(
+            ApiException.class,
+            () ->
+                api.createNamespace(
+                    "ns_existing", new CreateNamespaceRequest().mode("Create"), null));
+    assertEquals(409, ex.getCode());
+  }
+
+  // =========================================================================
+  // 7. dropNamespace – 200
+  // =========================================================================
+
+  @Pact(consumer = "lance-namespace-java-apache")
+  public V4Pact dropNamespace_returns_200(PactBuilder builder) {
+    return builder
+        .given("namespace 'ns_empty' exists and is empty")
+        .expectsToReceiveHttpInteraction(
+            "Drop empty namespace ns_empty returns 200",
+            i ->
+                i.withRequest(
+                        req ->
+                            req.method("POST")
+                                .path("/v1/namespace/ns_empty/drop")
+                                .headers(jsonHeaders()))
+                    .willRespondWith(
+                        resp ->
+                            resp.status(200)
+                                .headers(contentTypeJson())
+                                .body(new PactDslJsonBody().nullValue("properties"))))
+        .toPact();
+  }
+
+  @Test
+  @PactTestFor(pactMethod = "dropNamespace_returns_200")
+  void test_dropNamespace_returns_200(MockServer mockServer) throws Exception {
+    NamespaceApi api = new NamespaceApi(new ApiClient().setBasePath(mockServer.getUrl()));
+    DropNamespaceResponse response =
+        api.dropNamespace(
+            "ns_empty", new DropNamespaceRequest().mode("Fail").behavior("Restrict"), null);
+    assertNotNull(response);
+  }
+
+  // =========================================================================
+  // 8. dropNamespace – 404
+  // =========================================================================
+
+  @Pact(consumer = "lance-namespace-java-apache")
+  public V4Pact dropNamespace_returns_404(PactBuilder builder) {
+    return builder
+        .given("namespace 'ns_missing' does not exist")
+        .expectsToReceiveHttpInteraction(
+            "Drop non-existent namespace returns 404",
+            i ->
+                i.withRequest(
+                        req ->
+                            req.method("POST")
+                                .path("/v1/namespace/ns_missing/drop")
+                                .headers(jsonHeaders()))
+                    .willRespondWith(
+                        resp ->
+                            resp.status(404)
+                                .headers(contentTypeJson())
+                                .body(
+                                    ErrorResponseDsl.body(
+                                        "NAMESPACE_NOT_FOUND",
+                                        404,
+                                        "org.lance.namespace.NamespaceNotFoundException",
+                                        "Namespace ns_missing does not exist"))))
+        .toPact();
+  }
+
+  @Test
+  @PactTestFor(pactMethod = "dropNamespace_returns_404")
+  void test_dropNamespace_returns_404(MockServer mockServer) {
+    NamespaceApi api = new NamespaceApi(new ApiClient().setBasePath(mockServer.getUrl()));
+    ApiException ex =
+        assertThrows(
+            ApiException.class,
+            () ->
+                api.dropNamespace(
+                    "ns_missing",
+                    new DropNamespaceRequest().mode("Fail").behavior("Restrict"),
+                    null));
+    assertEquals(404, ex.getCode());
+  }
+
+  // =========================================================================
+  // 9. namespaceExists – 200
+  // =========================================================================
+
+  @Pact(consumer = "lance-namespace-java-apache")
+  public V4Pact namespaceExists_returns_200(PactBuilder builder) {
+    return builder
+        .given("namespace 'ns_existing' has 3 tables")
+        .expectsToReceiveHttpInteraction(
+            "Check existence of ns_existing returns 200 no content",
+            i ->
+                i.withRequest(
+                        req ->
+                            req.method("POST")
+                                .path("/v1/namespace/ns_existing/exists")
+                                .headers(jsonHeaders()))
+                    .willRespondWith(resp -> resp.status(200)))
+        .toPact();
+  }
+
+  @Test
+  @PactTestFor(pactMethod = "namespaceExists_returns_200")
+  void test_namespaceExists_returns_200(MockServer mockServer) throws Exception {
+    NamespaceApi api = new NamespaceApi(new ApiClient().setBasePath(mockServer.getUrl()));
+    api.namespaceExists("ns_existing", new NamespaceExistsRequest(), null);
+  }
+
+  // =========================================================================
+  // 10. namespaceExists – 404
+  // =========================================================================
+
+  @Pact(consumer = "lance-namespace-java-apache")
+  public V4Pact namespaceExists_returns_404(PactBuilder builder) {
+    return builder
+        .given("namespace 'ns_missing' does not exist")
+        .expectsToReceiveHttpInteraction(
+            "Check existence of ns_missing returns 404",
+            i ->
+                i.withRequest(
+                        req ->
+                            req.method("POST")
+                                .path("/v1/namespace/ns_missing/exists")
+                                .headers(jsonHeaders()))
+                    .willRespondWith(
+                        resp ->
+                            resp.status(404)
+                                .headers(contentTypeJson())
+                                .body(
+                                    ErrorResponseDsl.body(
+                                        "NAMESPACE_NOT_FOUND",
+                                        404,
+                                        "org.lance.namespace.NamespaceNotFoundException",
+                                        "Namespace ns_missing does not exist"))))
+        .toPact();
+  }
+
+  @Test
+  @PactTestFor(pactMethod = "namespaceExists_returns_404")
+  void test_namespaceExists_returns_404(MockServer mockServer) {
+    NamespaceApi api = new NamespaceApi(new ApiClient().setBasePath(mockServer.getUrl()));
+    ApiException ex =
+        assertThrows(
+            ApiException.class,
+            () -> api.namespaceExists("ns_missing", new NamespaceExistsRequest(), null));
+    assertEquals(404, ex.getCode());
+  }
+
+  // =========================================================================
+  // 11. listTables – 200
+  // =========================================================================
+
+  @Pact(consumer = "lance-namespace-java-apache")
+  public V4Pact listTables_returns_2_items(PactBuilder builder) {
+    return builder
+        .given("namespace 'ns_with_tables' has 2 tables")
+        .expectsToReceiveHttpInteraction(
+            "List tables in ns_with_tables returns 2 tables",
+            i ->
+                i.withRequest(
+                        req ->
+                            req.method("GET")
+                                .path("/v1/namespace/ns_with_tables/table/list")
+                                .headers(acceptJson()))
+                    .willRespondWith(
+                        resp ->
+                            resp.status(200)
+                                .headers(contentTypeJson())
+                                .body(
+                                    new PactDslJsonBody()
+                                        .minArrayLike(
+                                            "tables",
+                                            1,
+                                            PactDslJsonRootValue.stringType("table_alpha"),
+                                            2))))
+        .toPact();
+  }
+
+  @Test
+  @PactTestFor(pactMethod = "listTables_returns_2_items")
+  void test_listTables_returns_2_items(MockServer mockServer) throws Exception {
+    NamespaceApi api = new NamespaceApi(new ApiClient().setBasePath(mockServer.getUrl()));
+    ListTablesResponse response = api.listTables("ns_with_tables", null, null, null, null);
+    assertNotNull(response);
+    assertFalse(response.getTables().isEmpty());
+  }
+
+  // =========================================================================
+  // 12. listTables – 404
+  // =========================================================================
+
+  @Pact(consumer = "lance-namespace-java-apache")
+  public V4Pact listTables_returns_404(PactBuilder builder) {
+    return builder
+        .given("namespace 'ns_missing' does not exist")
+        .expectsToReceiveHttpInteraction(
+            "List tables in non-existent namespace returns 404",
+            i ->
+                i.withRequest(
+                        req ->
+                            req.method("GET")
+                                .path("/v1/namespace/ns_missing/table/list")
+                                .headers(acceptJson()))
+                    .willRespondWith(
+                        resp ->
+                            resp.status(404)
+                                .headers(contentTypeJson())
+                                .body(
+                                    ErrorResponseDsl.body(
+                                        "NAMESPACE_NOT_FOUND",
+                                        404,
+                                        "org.lance.namespace.NamespaceNotFoundException",
+                                        "Namespace ns_missing does not exist"))))
+        .toPact();
+  }
+
+  @Test
+  @PactTestFor(pactMethod = "listTables_returns_404")
+  void test_listTables_returns_404(MockServer mockServer) {
+    NamespaceApi api = new NamespaceApi(new ApiClient().setBasePath(mockServer.getUrl()));
+    ApiException ex =
+        assertThrows(
+            ApiException.class, () -> api.listTables("ns_missing", null, null, null, null));
+    assertEquals(404, ex.getCode());
+  }
+
+  // =========================================================================
+  // 13. describeTable – 200
+  // =========================================================================
+
+  @Pact(consumer = "lance-namespace-java-apache")
+  public V4Pact describeTable_returns_200(PactBuilder builder) {
+    return builder
+        .given("table 'ns_with_tables.table_alpha' exists")
+        .expectsToReceiveHttpInteraction(
+            "Describe table_alpha in ns_with_tables returns table info",
+            i ->
+                i.withRequest(
+                        req ->
+                            req.method("POST")
+                                .path("/v1/table/ns_with_tables.table_alpha/describe")
+                                .headers(jsonHeaders()))
+                    .willRespondWith(
+                        resp ->
+                            resp.status(200)
+                                .headers(contentTypeJson())
+                                .body(
+                                    new PactDslJsonBody()
+                                        .stringType(
+                                            "location",
+                                            "s3://example/ns_with_tables/table_alpha"))))
+        .toPact();
+  }
+
+  @Test
+  @PactTestFor(pactMethod = "describeTable_returns_200")
+  void test_describeTable_returns_200(MockServer mockServer) throws Exception {
+    TableApi api = new TableApi(new ApiClient().setBasePath(mockServer.getUrl()));
+    DescribeTableResponse response =
+        api.describeTable(
+            "ns_with_tables.table_alpha", new DescribeTableRequest(), null, null, null, null);
+    assertNotNull(response);
+    assertNotNull(response.getLocation());
+  }
+
+  // =========================================================================
+  // 14. describeTable – 404
+  // =========================================================================
+
+  @Pact(consumer = "lance-namespace-java-apache")
+  public V4Pact describeTable_returns_404(PactBuilder builder) {
+    return builder
+        .given("table 'ns_existing.table_missing' does not exist")
+        .expectsToReceiveHttpInteraction(
+            "Describe non-existent table returns 404",
+            i ->
+                i.withRequest(
+                        req ->
+                            req.method("POST")
+                                .path("/v1/table/ns_existing.table_missing/describe")
+                                .headers(jsonHeaders()))
+                    .willRespondWith(
+                        resp ->
+                            resp.status(404)
+                                .headers(contentTypeJson())
+                                .body(
+                                    ErrorResponseDsl.body(
+                                        "TABLE_NOT_FOUND",
+                                        404,
+                                        "org.lance.namespace.TableNotFoundException",
+                                        "Table ns_existing.table_missing does not exist"))))
+        .toPact();
+  }
+
+  @Test
+  @PactTestFor(pactMethod = "describeTable_returns_404")
+  void test_describeTable_returns_404(MockServer mockServer) {
+    TableApi api = new TableApi(new ApiClient().setBasePath(mockServer.getUrl()));
+    ApiException ex =
+        assertThrows(
+            ApiException.class,
+            () ->
+                api.describeTable(
+                    "ns_existing.table_missing",
+                    new DescribeTableRequest(),
+                    null,
+                    null,
+                    null,
+                    null));
+    assertEquals(404, ex.getCode());
+  }
+
+  // =========================================================================
+  // 15. tableExists – 200
+  // =========================================================================
+
+  @Pact(consumer = "lance-namespace-java-apache")
+  public V4Pact tableExists_returns_200(PactBuilder builder) {
+    return builder
+        .given("table 'ns_with_tables.table_alpha' exists")
+        .expectsToReceiveHttpInteraction(
+            "Check existence of table_alpha in ns_with_tables returns 200",
+            i ->
+                i.withRequest(
+                        req ->
+                            req.method("POST")
+                                .path("/v1/table/ns_with_tables.table_alpha/exists")
+                                .headers(jsonHeaders()))
+                    .willRespondWith(resp -> resp.status(200)))
+        .toPact();
+  }
+
+  @Test
+  @PactTestFor(pactMethod = "tableExists_returns_200")
+  void test_tableExists_returns_200(MockServer mockServer) throws Exception {
+    TableApi api = new TableApi(new ApiClient().setBasePath(mockServer.getUrl()));
+    api.tableExists("ns_with_tables.table_alpha", new TableExistsRequest(), null);
+  }
+
+  // =========================================================================
+  // 16. tableExists – 404
+  // =========================================================================
+
+  @Pact(consumer = "lance-namespace-java-apache")
+  public V4Pact tableExists_returns_404(PactBuilder builder) {
+    return builder
+        .given("table 'ns_existing.table_missing' does not exist")
+        .expectsToReceiveHttpInteraction(
+            "Check existence of non-existent table returns 404",
+            i ->
+                i.withRequest(
+                        req ->
+                            req.method("POST")
+                                .path("/v1/table/ns_existing.table_missing/exists")
+                                .headers(jsonHeaders()))
+                    .willRespondWith(
+                        resp ->
+                            resp.status(404)
+                                .headers(contentTypeJson())
+                                .body(
+                                    ErrorResponseDsl.body(
+                                        "TABLE_NOT_FOUND",
+                                        404,
+                                        "org.lance.namespace.TableNotFoundException",
+                                        "Table ns_existing.table_missing does not exist"))))
+        .toPact();
+  }
+
+  @Test
+  @PactTestFor(pactMethod = "tableExists_returns_404")
+  void test_tableExists_returns_404(MockServer mockServer) {
+    TableApi api = new TableApi(new ApiClient().setBasePath(mockServer.getUrl()));
+    ApiException ex =
+        assertThrows(
+            ApiException.class,
+            () -> api.tableExists("ns_existing.table_missing", new TableExistsRequest(), null));
+    assertEquals(404, ex.getCode());
+  }
+
+  // =========================================================================
+  // 17. dropTable – 200
+  // =========================================================================
+
+  @Pact(consumer = "lance-namespace-java-apache")
+  public V4Pact dropTable_returns_200(PactBuilder builder) {
+    return builder
+        .given("table 'ns_with_tables.table_alpha' exists")
+        .expectsToReceiveHttpInteraction(
+            "Drop table_alpha in ns_with_tables returns 200",
+            i ->
+                i.withRequest(
+                        req ->
+                            req.method("POST")
+                                .path("/v1/table/ns_with_tables.table_alpha/drop")
+                                .headers(acceptJson()))
+                    .willRespondWith(
+                        resp -> resp.status(200).headers(contentTypeJson()).body("{}")))
+        .toPact();
+  }
+
+  @Test
+  @PactTestFor(pactMethod = "dropTable_returns_200")
+  void test_dropTable_returns_200(MockServer mockServer) throws Exception {
+    TableApi api = new TableApi(new ApiClient().setBasePath(mockServer.getUrl()));
+    DropTableResponse response = api.dropTable("ns_with_tables.table_alpha", null);
+    assertNotNull(response);
+  }
+
+  // =========================================================================
+  // 18. dropTable – 404
+  // =========================================================================
+
+  @Pact(consumer = "lance-namespace-java-apache")
+  public V4Pact dropTable_returns_404(PactBuilder builder) {
+    return builder
+        .given("table 'ns_existing.table_missing' does not exist")
+        .expectsToReceiveHttpInteraction(
+            "Drop non-existent table returns 404",
+            i ->
+                i.withRequest(
+                        req ->
+                            req.method("POST")
+                                .path("/v1/table/ns_existing.table_missing/drop")
+                                .headers(acceptJson()))
+                    .willRespondWith(
+                        resp ->
+                            resp.status(404)
+                                .headers(contentTypeJson())
+                                .body(
+                                    ErrorResponseDsl.body(
+                                        "TABLE_NOT_FOUND",
+                                        404,
+                                        "org.lance.namespace.TableNotFoundException",
+                                        "Table ns_existing.table_missing does not exist"))))
+        .toPact();
+  }
+
+  @Test
+  @PactTestFor(pactMethod = "dropTable_returns_404")
+  void test_dropTable_returns_404(MockServer mockServer) {
+    TableApi api = new TableApi(new ApiClient().setBasePath(mockServer.getUrl()));
+    ApiException ex =
+        assertThrows(ApiException.class, () -> api.dropTable("ns_existing.table_missing", null));
+    assertEquals(404, ex.getCode());
+  }
+
+  // =========================================================================
+  // 19. registerTable – 200
+  // =========================================================================
+
+  @Pact(consumer = "lance-namespace-java-apache")
+  public V4Pact registerTable_returns_200(PactBuilder builder) {
+    return builder
+        .given("namespace 'ns_existing' has 3 tables")
+        .expectsToReceiveHttpInteraction(
+            "Register new table in ns_existing returns 200",
+            i ->
+                i.withRequest(
+                        req ->
+                            req.method("POST")
+                                .path("/v1/table/ns_existing.table_new/register")
+                                .headers(jsonHeaders()))
+                    .willRespondWith(
+                        resp ->
+                            resp.status(200)
+                                .headers(contentTypeJson())
+                                .body(
+                                    new PactDslJsonBody()
+                                        .stringType(
+                                            "location", "s3://example/ns_existing/table_new"))))
+        .toPact();
+  }
+
+  @Test
+  @PactTestFor(pactMethod = "registerTable_returns_200")
+  void test_registerTable_returns_200(MockServer mockServer) throws Exception {
+    TableApi api = new TableApi(new ApiClient().setBasePath(mockServer.getUrl()));
+    RegisterTableResponse response =
+        api.registerTable(
+            "ns_existing.table_new",
+            new RegisterTableRequest()
+                .location("s3://example/ns_existing/table_new")
+                .mode("Create"),
+            null);
+    assertNotNull(response);
+    assertNotNull(response.getLocation());
+  }
+
+  // =========================================================================
+  // 20. registerTable – 409
+  // =========================================================================
+
+  @Pact(consumer = "lance-namespace-java-apache")
+  public V4Pact registerTable_returns_409(PactBuilder builder) {
+    return builder
+        .given("table 'ns_with_tables.table_alpha' exists")
+        .expectsToReceiveHttpInteraction(
+            "Register already-registered table returns 409",
+            i ->
+                i.withRequest(
+                        req ->
+                            req.method("POST")
+                                .path("/v1/table/ns_with_tables.table_alpha/register")
+                                .headers(jsonHeaders()))
+                    .willRespondWith(
+                        resp ->
+                            resp.status(409)
+                                .headers(contentTypeJson())
+                                .body(
+                                    ErrorResponseDsl.body(
+                                        "TABLE_ALREADY_EXISTS",
+                                        409,
+                                        "org.lance.namespace.TableAlreadyExistsException",
+                                        "Table ns_with_tables.table_alpha already exists"))))
+        .toPact();
+  }
+
+  @Test
+  @PactTestFor(pactMethod = "registerTable_returns_409")
+  void test_registerTable_returns_409(MockServer mockServer) {
+    TableApi api = new TableApi(new ApiClient().setBasePath(mockServer.getUrl()));
+    ApiException ex =
+        assertThrows(
+            ApiException.class,
+            () ->
+                api.registerTable(
+                    "ns_with_tables.table_alpha",
+                    new RegisterTableRequest()
+                        .location("s3://example/ns_with_tables/table_alpha")
+                        .mode("Create"),
+                    null));
+    assertEquals(409, ex.getCode());
+  }
+
+  // =========================================================================
+  // 21. deregisterTable – 200
+  // =========================================================================
+
+  @Pact(consumer = "lance-namespace-java-apache")
+  public V4Pact deregisterTable_returns_200(PactBuilder builder) {
+    return builder
+        .given("table 'ns_with_tables.table_alpha' exists")
+        .expectsToReceiveHttpInteraction(
+            "Deregister table_alpha from ns_with_tables returns 200",
+            i ->
+                i.withRequest(
+                        req ->
+                            req.method("POST")
+                                .path("/v1/table/ns_with_tables.table_alpha/deregister")
+                                .headers(jsonHeaders()))
+                    .willRespondWith(
+                        resp -> resp.status(200).headers(contentTypeJson()).body("{}")))
+        .toPact();
+  }
+
+  @Test
+  @PactTestFor(pactMethod = "deregisterTable_returns_200")
+  void test_deregisterTable_returns_200(MockServer mockServer) throws Exception {
+    TableApi api = new TableApi(new ApiClient().setBasePath(mockServer.getUrl()));
+    DeregisterTableResponse response =
+        api.deregisterTable("ns_with_tables.table_alpha", new DeregisterTableRequest(), null);
+    assertNotNull(response);
+  }
+
+  // =========================================================================
+  // 22. deregisterTable – 404
+  // =========================================================================
+
+  @Pact(consumer = "lance-namespace-java-apache")
+  public V4Pact deregisterTable_returns_404(PactBuilder builder) {
+    return builder
+        .given("table 'ns_existing.table_missing' does not exist")
+        .expectsToReceiveHttpInteraction(
+            "Deregister non-existent table returns 404",
+            i ->
+                i.withRequest(
+                        req ->
+                            req.method("POST")
+                                .path("/v1/table/ns_existing.table_missing/deregister")
+                                .headers(jsonHeaders()))
+                    .willRespondWith(
+                        resp ->
+                            resp.status(404)
+                                .headers(contentTypeJson())
+                                .body(
+                                    ErrorResponseDsl.body(
+                                        "TABLE_NOT_FOUND",
+                                        404,
+                                        "org.lance.namespace.TableNotFoundException",
+                                        "Table ns_existing.table_missing does not exist"))))
+        .toPact();
+  }
+
+  @Test
+  @PactTestFor(pactMethod = "deregisterTable_returns_404")
+  void test_deregisterTable_returns_404(MockServer mockServer) {
+    TableApi api = new TableApi(new ApiClient().setBasePath(mockServer.getUrl()));
+    ApiException ex =
+        assertThrows(
+            ApiException.class,
+            () ->
+                api.deregisterTable(
+                    "ns_existing.table_missing", new DeregisterTableRequest(), null));
+    assertEquals(404, ex.getCode());
+  }
+}

--- a/java/lance-namespace-pact-tests/src/test/java/org/lance/namespace/pact/provider/EmptyBodyFilter.java
+++ b/java/lance-namespace-pact-tests/src/test/java/org/lance/namespace/pact/provider/EmptyBodyFilter.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.namespace.pact.provider;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Pact-profile-only servlet filter that wraps empty POST request bodies with {@code {}}.
+ *
+ * <p>Pact consumer tests omit request bodies so that the mock server accepts any payload the client
+ * sends. However, the generated Spring server interfaces declare {@code @RequestBody} as required,
+ * causing Spring to throw {@code HttpMessageNotReadableException} (400 Bad Request) when no body is
+ * present. This filter intercepts those requests before Spring's argument resolver runs and
+ * supplies a minimal empty JSON object so Jackson can deserialize a default-constructed request
+ * DTO.
+ */
+@Component
+@Profile("pact")
+public class EmptyBodyFilter extends OncePerRequestFilter {
+
+  private static final byte[] EMPTY_JSON = "{}".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+
+    String contentType = request.getContentType();
+    String method = request.getMethod();
+
+    // Only wrap POST/PUT/PATCH requests with application/json content type and empty body
+    if (isJsonPost(method, contentType) && request.getContentLength() <= 0) {
+      filterChain.doFilter(new EmptyBodyRequestWrapper(request), response);
+    } else {
+      filterChain.doFilter(request, response);
+    }
+  }
+
+  private static boolean isJsonPost(String method, String contentType) {
+    return ("POST".equalsIgnoreCase(method)
+            || "PUT".equalsIgnoreCase(method)
+            || "PATCH".equalsIgnoreCase(method))
+        && contentType != null
+        && contentType.contains("application/json");
+  }
+
+  /** Wraps the original request and returns an empty JSON object for the body stream. */
+  private static final class EmptyBodyRequestWrapper extends HttpServletRequestWrapper {
+
+    EmptyBodyRequestWrapper(HttpServletRequest request) {
+      super(request);
+    }
+
+    @Override
+    public jakarta.servlet.ServletInputStream getInputStream() throws IOException {
+      InputStream source = new ByteArrayInputStream(EMPTY_JSON);
+      return new jakarta.servlet.ServletInputStream() {
+        @Override
+        public int read() throws IOException {
+          return source.read();
+        }
+
+        @Override
+        public boolean isFinished() {
+          try {
+            return source.available() == 0;
+          } catch (IOException e) {
+            return true;
+          }
+        }
+
+        @Override
+        public boolean isReady() {
+          return true;
+        }
+
+        @Override
+        public void setReadListener(jakarta.servlet.ReadListener listener) {
+          // no-op for synchronous testing
+        }
+      };
+    }
+
+    @Override
+    public int getContentLength() {
+      return EMPTY_JSON.length;
+    }
+
+    @Override
+    public long getContentLengthLong() {
+      return EMPTY_JSON.length;
+    }
+  }
+}

--- a/java/lance-namespace-pact-tests/src/test/java/org/lance/namespace/pact/provider/InMemoryNamespaceFixtures.java
+++ b/java/lance-namespace-pact-tests/src/test/java/org/lance/namespace/pact/provider/InMemoryNamespaceFixtures.java
@@ -1,0 +1,221 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.namespace.pact.provider;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * In-memory store that the Pact Provider State hooks use to pre-populate the server with well-known
+ * test data before each interaction is verified.
+ *
+ * <p>Design:
+ *
+ * <ul>
+ *   <li>Thread-safe via {@link ConcurrentHashMap}: each @State hook runs in the test thread.
+ *   <li>Immutable snapshots returned by getters (defensive copies) to prevent test pollution.
+ *   <li>{@link #reset()} clears all state — must be called at the start of every @State hook.
+ *   <li>Table locations stored as {@code namespaceId -> (tableName -> location)}.
+ * </ul>
+ */
+@Component
+public class InMemoryNamespaceFixtures {
+
+  /** namespace-id → set-of-table-names. */
+  private final Map<String, Set<String>> namespaces = new ConcurrentHashMap<>();
+
+  /** parent-namespace-id → set-of-child-namespace-names. */
+  private final Map<String, Set<String>> childNamespaces = new ConcurrentHashMap<>();
+
+  /**
+   * namespace-id → (table-name → location). Location is used by DescribeTable and RegisterTable
+   * responses.
+   */
+  private final Map<String, Map<String, String>> tableLocations = new ConcurrentHashMap<>();
+
+  /** Flag to simulate 401: when true, the security filter should reject all requests. */
+  private volatile boolean authInvalid = false;
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Lifecycle
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /** Wipes all stored namespaces, tables, child namespace mappings, and table locations. */
+  public void reset() {
+    namespaces.clear();
+    childNamespaces.clear();
+    tableLocations.clear();
+    authInvalid = false;
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Namespace operations
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Creates a namespace with no tables.
+   *
+   * @param namespaceId the namespace identifier (e.g. {@code "ns_existing"})
+   */
+  public void createNamespace(String namespaceId) {
+    namespaces.putIfAbsent(namespaceId, new LinkedHashSet<>());
+  }
+
+  /**
+   * Creates a table inside the given namespace (creates namespace too if absent).
+   *
+   * @param namespaceId the parent namespace identifier
+   * @param tableName the table name to add
+   */
+  public void createTable(String namespaceId, String tableName) {
+    namespaces.computeIfAbsent(namespaceId, k -> new LinkedHashSet<>()).add(tableName);
+  }
+
+  /**
+   * Registers a table with a storage location (creates namespace if absent).
+   *
+   * @param namespaceId the parent namespace identifier
+   * @param tableName the table name to add
+   * @param location the storage location (e.g. {@code "s3://example/ns/table"})
+   */
+  public void registerTableLocation(String namespaceId, String tableName, String location) {
+    namespaces.computeIfAbsent(namespaceId, k -> new LinkedHashSet<>()).add(tableName);
+    tableLocations
+        .computeIfAbsent(namespaceId, k -> new ConcurrentHashMap<>())
+        .put(tableName, location);
+  }
+
+  /**
+   * Registers {@code childName} as a child namespace of {@code parentId}.
+   *
+   * @param parentId the parent namespace identifier (e.g. {@code "ns_existing"})
+   * @param childName the child namespace name (e.g. {@code "child_a"})
+   */
+  public void createChildNamespace(String parentId, String childName) {
+    namespaces.putIfAbsent(parentId, new LinkedHashSet<>());
+    childNamespaces.computeIfAbsent(parentId, k -> new LinkedHashSet<>()).add(childName);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Queries — Namespaces
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Returns whether the given namespace exists.
+   *
+   * @param namespaceId the namespace to check
+   * @return {@code true} if the namespace has been created
+   */
+  public boolean namespaceExists(String namespaceId) {
+    return namespaces.containsKey(namespaceId);
+  }
+
+  /**
+   * Returns an immutable snapshot of child namespace names under the given parent.
+   *
+   * @param parentId the parent namespace identifier; use {@code "$"} for root
+   * @return unmodifiable set of child namespace names, empty if none
+   */
+  public Set<String> listChildNamespaces(String parentId) {
+    if ("$".equals(parentId) || parentId == null) {
+      return Collections.unmodifiableSet(new LinkedHashSet<>(namespaces.keySet()));
+    }
+    Set<String> children = childNamespaces.get(parentId);
+    if (children == null) {
+      return Collections.emptySet();
+    }
+    return Collections.unmodifiableSet(new LinkedHashSet<>(children));
+  }
+
+  /**
+   * Returns an immutable snapshot of table names in the given namespace.
+   *
+   * @param namespaceId the namespace to query
+   * @return unmodifiable set of table names; empty if namespace has no tables
+   * @throws IllegalStateException if the namespace does not exist
+   */
+  public Set<String> listTables(String namespaceId) {
+    Set<String> tables = namespaces.get(namespaceId);
+    if (tables == null) {
+      throw new IllegalStateException("Namespace not found in fixtures: " + namespaceId);
+    }
+    return Collections.unmodifiableSet(new LinkedHashSet<>(tables));
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Queries — Tables
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Returns whether the given table exists in the given namespace.
+   *
+   * @param namespaceId the namespace identifier
+   * @param tableName the table name
+   * @return {@code true} if the table has been created or registered
+   */
+  public boolean tableExists(String namespaceId, String tableName) {
+    Set<String> tables = namespaces.get(namespaceId);
+    return tables != null && tables.contains(tableName);
+  }
+
+  /**
+   * Returns the storage location for the given table, if known.
+   *
+   * @param namespaceId the namespace identifier
+   * @param tableName the table name
+   * @return an {@link Optional} containing the location, or empty if not registered
+   */
+  public Optional<String> getTableLocation(String namespaceId, String tableName) {
+    Map<String, String> locations = tableLocations.get(namespaceId);
+    if (locations == null) {
+      return Optional.empty();
+    }
+    return Optional.ofNullable(locations.get(tableName));
+  }
+
+  /**
+   * Returns all namespaces and their table counts (diagnostic / state inspection).
+   *
+   * @return unmodifiable map copy
+   */
+  public Map<String, Integer> namespaceTableCounts() {
+    Map<String, Integer> result = new LinkedHashMap<>();
+    namespaces.forEach((ns, tables) -> result.put(ns, tables.size()));
+    return Collections.unmodifiableMap(result);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Auth helpers
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Marks all subsequent requests as unauthenticated (causes 401 responses). Corresponds to §7
+   * state: {@code auth token is invalid}.
+   */
+  public void invalidateAuth() {
+    authInvalid = true;
+  }
+
+  /** Returns whether auth should be treated as invalid. */
+  public boolean isAuthInvalid() {
+    return authInvalid;
+  }
+}

--- a/java/lance-namespace-pact-tests/src/test/java/org/lance/namespace/pact/provider/PactNamespaceController.java
+++ b/java/lance-namespace-pact-tests/src/test/java/org/lance/namespace/pact/provider/PactNamespaceController.java
@@ -1,0 +1,252 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.namespace.pact.provider;
+
+import org.lance.namespace.server.springboot.api.NamespaceApi;
+import org.lance.namespace.server.springboot.model.CreateNamespaceRequest;
+import org.lance.namespace.server.springboot.model.CreateNamespaceResponse;
+import org.lance.namespace.server.springboot.model.DescribeNamespaceRequest;
+import org.lance.namespace.server.springboot.model.DescribeNamespaceResponse;
+import org.lance.namespace.server.springboot.model.DropNamespaceRequest;
+import org.lance.namespace.server.springboot.model.DropNamespaceResponse;
+import org.lance.namespace.server.springboot.model.ListNamespacesResponse;
+import org.lance.namespace.server.springboot.model.ListTablesResponse;
+import org.lance.namespace.server.springboot.model.NamespaceExistsRequest;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Test-scope implementation of {@link NamespaceApi} backed by {@link InMemoryNamespaceFixtures}.
+ *
+ * <p>Active only when the {@code pact} Spring profile is enabled. Handles all 5 namespace
+ * operations exercised by the Phase 2 Pact interactions.
+ */
+@Profile("pact")
+@RestController
+public class PactNamespaceController implements NamespaceApi {
+
+  private final InMemoryNamespaceFixtures fixtures;
+
+  @Autowired
+  public PactNamespaceController(InMemoryNamespaceFixtures fixtures) {
+    this.fixtures = fixtures;
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // ListNamespaces — GET /v1/namespace/{id}/list
+  // ─────────────────────────────────────────────────────────────────────────
+
+  @Override
+  public ResponseEntity<ListNamespacesResponse> listNamespaces(
+      String id, Optional<String> delimiter, Optional<String> pageToken, Optional<Integer> limit) {
+
+    if (!fixtures.namespaceExists(id)) {
+      throw new NamespaceNotFoundException(id);
+    }
+
+    Set<String> children = new LinkedHashSet<>(fixtures.listChildNamespaces(id));
+    ListNamespacesResponse response = new ListNamespacesResponse(children);
+    return ResponseEntity.ok(response);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // DescribeNamespace — POST /v1/namespace/{id}/describe
+  // ─────────────────────────────────────────────────────────────────────────
+
+  @Override
+  public ResponseEntity<DescribeNamespaceResponse> describeNamespace(
+      String id, DescribeNamespaceRequest req, Optional<String> delimiter) {
+
+    if (!fixtures.namespaceExists(id)) {
+      throw new NamespaceNotFoundException(id);
+    }
+
+    DescribeNamespaceResponse response = new DescribeNamespaceResponse();
+    response.setProperties(new LinkedHashMap<>());
+    return ResponseEntity.ok(response);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // CreateNamespace — POST /v1/namespace/{id}/create
+  // ─────────────────────────────────────────────────────────────────────────
+
+  @Override
+  public ResponseEntity<CreateNamespaceResponse> createNamespace(
+      String id, CreateNamespaceRequest req, Optional<String> delimiter) {
+
+    if (fixtures.namespaceExists(id)) {
+      throw new NamespaceAlreadyExistsException(id);
+    }
+
+    fixtures.createNamespace(id);
+    CreateNamespaceResponse response = new CreateNamespaceResponse();
+    response.setProperties(new LinkedHashMap<>());
+    return ResponseEntity.ok(response);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // DropNamespace — POST /v1/namespace/{id}/drop
+  // ─────────────────────────────────────────────────────────────────────────
+
+  @Override
+  public ResponseEntity<DropNamespaceResponse> dropNamespace(
+      String id, DropNamespaceRequest req, Optional<String> delimiter) {
+
+    if (!fixtures.namespaceExists(id)) {
+      throw new NamespaceNotFoundException(id);
+    }
+
+    DropNamespaceResponse response = new DropNamespaceResponse();
+    response.setProperties(null);
+    return ResponseEntity.ok(response);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // NamespaceExists — POST /v1/namespace/{id}/exists
+  // ─────────────────────────────────────────────────────────────────────────
+
+  @Override
+  public ResponseEntity<Void> namespaceExists(
+      String id, NamespaceExistsRequest req, Optional<String> delimiter) {
+
+    if (!fixtures.namespaceExists(id)) {
+      throw new NamespaceNotFoundException(id);
+    }
+
+    return ResponseEntity.ok().build();
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // ListTables — GET /v1/namespace/{id}/table/list (via NamespaceApi)
+  // ─────────────────────────────────────────────────────────────────────────
+
+  @Override
+  public ResponseEntity<ListTablesResponse> listTables(
+      String id,
+      Optional<String> delimiter,
+      Optional<String> pageToken,
+      Optional<Integer> limit,
+      Optional<Boolean> includeDeclared) {
+
+    if (!fixtures.namespaceExists(id)) {
+      throw new NamespaceNotFoundException(id);
+    }
+
+    Set<String> tableNames = new LinkedHashSet<>(fixtures.listTables(id));
+    ListTablesResponse response = new ListTablesResponse(tableNames);
+    return ResponseEntity.ok(response);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Domain exceptions
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /** Signals that a namespace does not exist in the in-memory fixture store. */
+  static class NamespaceNotFoundException extends RuntimeException {
+    private final String namespaceId;
+
+    NamespaceNotFoundException(String namespaceId) {
+      super("Namespace " + namespaceId + " does not exist");
+      this.namespaceId = namespaceId;
+    }
+
+    String getNamespaceId() {
+      return namespaceId;
+    }
+  }
+
+  /** Signals that a namespace already exists (for CreateNamespace 409). */
+  static class NamespaceAlreadyExistsException extends RuntimeException {
+    private final String namespaceId;
+
+    NamespaceAlreadyExistsException(String namespaceId) {
+      super("Namespace " + namespaceId + " already exists");
+      this.namespaceId = namespaceId;
+    }
+
+    String getNamespaceId() {
+      return namespaceId;
+    }
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Exception handler — maps domain exceptions → pact-compatible bodies
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Maps domain exceptions to HTTP responses whose JSON bodies include all four fields required by
+   * the consumer pact: {@code error}, {@code code}, {@code type}, {@code detail}.
+   *
+   * <p>Pact's body matching rules use type-matchers, so only the field types matter.
+   */
+  @RestControllerAdvice
+  @Profile("pact")
+  static class PactExceptionHandler {
+
+    @ExceptionHandler(NamespaceNotFoundException.class)
+    ResponseEntity<Map<String, Object>> handleNamespaceNotFound(NamespaceNotFoundException ex) {
+      Map<String, Object> body = new LinkedHashMap<>();
+      body.put("error", "NAMESPACE_NOT_FOUND");
+      body.put("code", 404);
+      body.put("type", "org.lance.namespace.NamespaceNotFoundException");
+      body.put("detail", "Namespace " + ex.getNamespaceId() + " does not exist");
+      return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
+    }
+
+    @ExceptionHandler(NamespaceAlreadyExistsException.class)
+    ResponseEntity<Map<String, Object>> handleNamespaceAlreadyExists(
+        NamespaceAlreadyExistsException ex) {
+      Map<String, Object> body = new LinkedHashMap<>();
+      body.put("error", "NAMESPACE_ALREADY_EXISTS");
+      body.put("code", 409);
+      body.put("type", "org.lance.namespace.NamespaceAlreadyExistsException");
+      body.put("detail", "Namespace " + ex.getNamespaceId() + " already exists");
+      return ResponseEntity.status(HttpStatus.CONFLICT).body(body);
+    }
+
+    @ExceptionHandler(PactTableController.TableNotFoundException.class)
+    ResponseEntity<Map<String, Object>> handleTableNotFound(
+        PactTableController.TableNotFoundException ex) {
+      Map<String, Object> body = new LinkedHashMap<>();
+      body.put("error", "TABLE_NOT_FOUND");
+      body.put("code", 404);
+      body.put("type", "org.lance.namespace.TableNotFoundException");
+      body.put("detail", "Table " + ex.getFullTableId() + " does not exist");
+      return ResponseEntity.status(HttpStatus.NOT_FOUND).body(body);
+    }
+
+    @ExceptionHandler(PactTableController.TableAlreadyExistsException.class)
+    ResponseEntity<Map<String, Object>> handleTableAlreadyExists(
+        PactTableController.TableAlreadyExistsException ex) {
+      Map<String, Object> body = new LinkedHashMap<>();
+      body.put("error", "TABLE_ALREADY_EXISTS");
+      body.put("code", 409);
+      body.put("type", "org.lance.namespace.TableAlreadyExistsException");
+      body.put("detail", "Table " + ex.getFullTableId() + " already exists");
+      return ResponseEntity.status(HttpStatus.CONFLICT).body(body);
+    }
+  }
+}

--- a/java/lance-namespace-pact-tests/src/test/java/org/lance/namespace/pact/provider/PactProviderTest.java
+++ b/java/lance-namespace-pact-tests/src/test/java/org/lance/namespace/pact/provider/PactProviderTest.java
@@ -1,0 +1,186 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.namespace.pact.provider;
+
+import au.com.dius.pact.provider.junit5.PactVerificationContext;
+import au.com.dius.pact.provider.junit5.PactVerificationInvocationContextProvider;
+import au.com.dius.pact.provider.junitsupport.Provider;
+import au.com.dius.pact.provider.junitsupport.State;
+import au.com.dius.pact.provider.junitsupport.loader.PactFolder;
+import au.com.dius.pact.provider.spring.junit5.MockMvcTestTarget;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * Pact Provider verification test for {@code lance-namespace-server}.
+ *
+ * <p>Phase 2 mode: loads pacts from the local {@code contract-pack/sample-pacts/} directory via
+ * {@link PactFolder}. The path is relative to the module root ({@code
+ * java/lance-namespace-pact-tests/}), so {@code ../../contract-pack/sample-pacts} resolves to
+ * {@code contract-pack/sample-pacts/} at the repository root.
+ *
+ * <p>No real HTTP port is opened; all requests are dispatched through {@link MockMvc}.
+ *
+ * <p>Covers all 12 MVP API provider states (8 states, 22 interactions). Provider state strings MUST
+ * match contract-pack/provider-states.lock.json verbatim.
+ *
+ * <p>To switch to Pact Broker mode, set the environment variables {@code PACT_BROKER_URL} and
+ * {@code PACT_BROKER_TOKEN}, replace {@code @PactFolder} with {@code @PactBroker} (uncommenting the
+ * block below), and activate the {@code pact-broker} Spring profile.
+ */
+@Provider("lance-namespace-server")
+// ── Phase 2: offline pact folder ──────────────────────────────────────────────────────────────
+// Relative to module root: java/lance-namespace-pact-tests/
+//   → ../../contract-pack/sample-pacts  → {repo-root}/contract-pack/sample-pacts/
+@PactFolder("../../contract-pack/sample-pacts")
+// ── Broker variant (uncomment + supply env vars PACT_BROKER_URL / PACT_BROKER_TOKEN) ─────────
+// @PactBroker(
+//     url = "${PACT_BROKER_URL}",
+//     authentication = @PactBrokerAuth(token = "${PACT_BROKER_TOKEN}"))
+@SpringBootTest(
+    classes = PactTestApplication.class,
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@AutoConfigureMockMvc
+@ActiveProfiles("pact")
+public class PactProviderTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @Autowired private InMemoryNamespaceFixtures fixtures;
+
+  @BeforeEach
+  void configurePactTarget(PactVerificationContext context) {
+    context.setTarget(new MockMvcTestTarget(mockMvc));
+  }
+
+  @TestTemplate
+  @ExtendWith(PactVerificationInvocationContextProvider.class)
+  void verifyPact(PactVerificationContext context) {
+    context.verifyInteraction();
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Provider State hooks — state strings copied verbatim from
+  // contract-pack/provider-states.lock.json (do NOT rename)
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Provider state: {@code "namespace 'ns_existing' has 3 tables"}
+   *
+   * <p>Populates {@code ns_existing} with child namespaces {@code child_a}, {@code child_b}, {@code
+   * child_c} per {@code provider-states.lock.json} fixture section.
+   */
+  @State("namespace 'ns_existing' has 3 tables")
+  public void setupNsExistingWith3Tables() {
+    fixtures.reset();
+    fixtures.createNamespace("ns_existing");
+    fixtures.createChildNamespace("ns_existing", "child_a");
+    fixtures.createChildNamespace("ns_existing", "child_b");
+    fixtures.createChildNamespace("ns_existing", "child_c");
+  }
+
+  /**
+   * Provider state: {@code "namespace 'ns_missing' does not exist"}
+   *
+   * <p>Clears all state so {@code ns_missing} is absent, causing the controller to return 404.
+   */
+  @State("namespace 'ns_missing' does not exist")
+  public void setupNsMissingAbsent() {
+    fixtures.reset();
+    // teardownAction per provider-states.lock.json: no-op — reset() already ensures ns_missing
+    // absent
+  }
+
+  /**
+   * Provider state: {@code "namespace 'ns_empty' exists and is empty"}
+   *
+   * <p>Creates {@code ns_empty} with no children; used for DropNamespace success path.
+   */
+  @State("namespace 'ns_empty' exists and is empty")
+  public void setupNsEmptyExists() {
+    fixtures.reset();
+    fixtures.createNamespace("ns_empty");
+  }
+
+  /**
+   * Provider state: {@code "namespace 'ns_new' does not exist"}
+   *
+   * <p>Ensures {@code ns_new} is absent; used for CreateNamespace success path.
+   */
+  @State("namespace 'ns_new' does not exist")
+  public void setupNsNewAbsent() {
+    fixtures.reset();
+    // ns_new must not exist — reset() ensures this
+  }
+
+  /**
+   * Provider state: {@code "namespace 'ns_with_tables' has 2 tables"}
+   *
+   * <p>Creates {@code ns_with_tables} with tables {@code table_alpha} and {@code table_beta}; used
+   * for ListTables success path.
+   */
+  @State("namespace 'ns_with_tables' has 2 tables")
+  public void setupNsWithTables() {
+    fixtures.reset();
+    fixtures.createNamespace("ns_with_tables");
+    fixtures.createTable("ns_with_tables", "table_alpha");
+    fixtures.createTable("ns_with_tables", "table_beta");
+  }
+
+  /**
+   * Provider state: {@code "table 'ns_with_tables.table_alpha' exists"}
+   *
+   * <p>Creates namespace {@code ns_with_tables} and registers table {@code table_alpha} at a known
+   * location; used for table read/write operations.
+   */
+  @State("table 'ns_with_tables.table_alpha' exists")
+  public void setupTableAlphaExists() {
+    fixtures.reset();
+    fixtures.createNamespace("ns_with_tables");
+    fixtures.createTable("ns_with_tables", "table_alpha");
+    fixtures.registerTableLocation(
+        "ns_with_tables", "table_alpha", "s3://example/ns_with_tables/table_alpha");
+  }
+
+  /**
+   * Provider state: {@code "table 'ns_existing.table_missing' does not exist"}
+   *
+   * <p>Creates namespace {@code ns_existing} but does NOT register table {@code table_missing};
+   * used for table 404 error paths.
+   */
+  @State("table 'ns_existing.table_missing' does not exist")
+  public void setupTableMissingAbsent() {
+    fixtures.reset();
+    fixtures.createNamespace("ns_existing");
+    // table_missing must not exist in ns_existing
+  }
+
+  /**
+   * Provider state: {@code "table 'ns_existing.table_new' does not exist"}
+   *
+   * <p>Creates namespace {@code ns_existing} with no tables; used for RegisterTable success path.
+   */
+  @State("table 'ns_existing.table_new' does not exist")
+  public void setupTableNewAbsent() {
+    fixtures.reset();
+    fixtures.createNamespace("ns_existing");
+    // table_new must not be registered yet
+  }
+}

--- a/java/lance-namespace-pact-tests/src/test/java/org/lance/namespace/pact/provider/PactStateController.java
+++ b/java/lance-namespace-pact-tests/src/test/java/org/lance/namespace/pact/provider/PactStateController.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.namespace.pact.provider;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Pact Provider State controller — exposes fixture-setup helpers as named methods.
+ *
+ * <p>For the MockMvc-based PoC, the actual {@link au.com.dius.pact.provider.junitsupport.State}
+ * annotations live in {@link PactProviderTest} (which can {@code @Autowired} {@link
+ * InMemoryNamespaceFixtures} directly). This class centralises the state-setup logic so that a
+ * future HTTP-target variant can call these methods from a provider-state endpoint.
+ *
+ * <p>State strings are copied verbatim from {@code contract-pack/provider-states.lock.json} — do
+ * NOT rename them.
+ *
+ * <p>Active only when the {@code pact} Spring profile is enabled.
+ */
+@Profile("pact")
+@RestController
+public class PactStateController {
+
+  private final InMemoryNamespaceFixtures fixtures;
+
+  @Autowired
+  public PactStateController(InMemoryNamespaceFixtures fixtures) {
+    this.fixtures = fixtures;
+  }
+
+  /**
+   * Sets up provider state: {@code "namespace 'ns_existing' has 3 tables"}.
+   *
+   * <p>Creates namespace {@code ns_existing} and populates it with three child namespaces {@code
+   * child_a}, {@code child_b}, {@code child_c} as specified in {@code provider-states.lock.json}
+   * fixture.
+   */
+  public void setupNsExistingWith3Tables() {
+    fixtures.reset();
+    fixtures.createNamespace("ns_existing");
+    fixtures.createChildNamespace("ns_existing", "child_a");
+    fixtures.createChildNamespace("ns_existing", "child_b");
+    fixtures.createChildNamespace("ns_existing", "child_c");
+  }
+
+  /**
+   * Sets up provider state: {@code "namespace 'ns_missing' does not exist"}.
+   *
+   * <p>Clears all state to ensure {@code ns_missing} is absent from the in-memory store. Per {@code
+   * provider-states.lock.json}: teardownAction is "no-op".
+   */
+  public void setupNsMissingAbsent() {
+    fixtures.reset();
+  }
+}

--- a/java/lance-namespace-pact-tests/src/test/java/org/lance/namespace/pact/provider/PactTableController.java
+++ b/java/lance-namespace-pact-tests/src/test/java/org/lance/namespace/pact/provider/PactTableController.java
@@ -1,0 +1,258 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.namespace.pact.provider;
+
+import org.lance.namespace.server.springboot.api.TableApi;
+import org.lance.namespace.server.springboot.model.CreateTableResponse;
+import org.lance.namespace.server.springboot.model.DeregisterTableRequest;
+import org.lance.namespace.server.springboot.model.DeregisterTableResponse;
+import org.lance.namespace.server.springboot.model.DescribeTableRequest;
+import org.lance.namespace.server.springboot.model.DescribeTableResponse;
+import org.lance.namespace.server.springboot.model.DropTableResponse;
+import org.lance.namespace.server.springboot.model.ListTablesResponse;
+import org.lance.namespace.server.springboot.model.RegisterTableRequest;
+import org.lance.namespace.server.springboot.model.RegisterTableResponse;
+import org.lance.namespace.server.springboot.model.TableExistsRequest;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Optional;
+
+/**
+ * Test-scope implementation of {@link TableApi} backed by {@link InMemoryNamespaceFixtures}.
+ *
+ * <p>Active only when the {@code pact} Spring profile is enabled. Handles the 7 Table API
+ * operations covered by Phase 2 Pact interactions:
+ *
+ * <ul>
+ *   <li>ListTables ({@code GET /v1/namespace/{id}/table/list})
+ *   <li>DescribeTable ({@code POST /v1/table/{id}/describe})
+ *   <li>TableExists ({@code POST /v1/table/{id}/exists})
+ *   <li>DropTable ({@code POST /v1/table/{id}/drop})
+ *   <li>RegisterTable ({@code POST /v1/table/{id}/register})
+ *   <li>DeregisterTable ({@code POST /v1/table/{id}/deregister})
+ * </ul>
+ *
+ * <p>The table {@code id} path parameter uses dot-separated format: {@code namespace.tableName}.
+ * Example: {@code ns_with_tables.table_alpha} → namespace={@code ns_with_tables}, table={@code
+ * table_alpha}.
+ */
+@Profile("pact")
+@RestController
+public class PactTableController implements TableApi {
+
+  private final InMemoryNamespaceFixtures fixtures;
+
+  @Autowired
+  public PactTableController(InMemoryNamespaceFixtures fixtures) {
+    this.fixtures = fixtures;
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // DescribeTable — POST /v1/table/{id}/describe
+  // ─────────────────────────────────────────────────────────────────────────
+
+  @Override
+  public ResponseEntity<DescribeTableResponse> describeTable(
+      String id,
+      DescribeTableRequest req,
+      Optional<String> delimiter,
+      Optional<Boolean> withTableUri,
+      Optional<Boolean> loadDetailedMetadata,
+      Optional<Boolean> checkDeclared) {
+
+    TableRef ref = TableRef.parse(id);
+    if (!fixtures.tableExists(ref.namespaceId(), ref.tableName())) {
+      throw new TableNotFoundException(id);
+    }
+
+    String location =
+        fixtures
+            .getTableLocation(ref.namespaceId(), ref.tableName())
+            .orElse("s3://example/" + ref.namespaceId() + "/" + ref.tableName());
+
+    DescribeTableResponse response = new DescribeTableResponse();
+    response.setLocation(location);
+    return ResponseEntity.ok(response);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // TableExists — POST /v1/table/{id}/exists
+  // ─────────────────────────────────────────────────────────────────────────
+
+  @Override
+  public ResponseEntity<Void> tableExists(
+      String id, TableExistsRequest req, Optional<String> delimiter) {
+
+    TableRef ref = TableRef.parse(id);
+    if (!fixtures.tableExists(ref.namespaceId(), ref.tableName())) {
+      throw new TableNotFoundException(id);
+    }
+    return ResponseEntity.ok().build();
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // DropTable — POST /v1/table/{id}/drop
+  // ─────────────────────────────────────────────────────────────────────────
+
+  @Override
+  public ResponseEntity<DropTableResponse> dropTable(String id, Optional<String> delimiter) {
+
+    TableRef ref = TableRef.parse(id);
+    if (!fixtures.tableExists(ref.namespaceId(), ref.tableName())) {
+      throw new TableNotFoundException(id);
+    }
+    return ResponseEntity.ok(new DropTableResponse());
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // RegisterTable — POST /v1/table/{id}/register
+  // ─────────────────────────────────────────────────────────────────────────
+
+  @Override
+  public ResponseEntity<RegisterTableResponse> registerTable(
+      String id, RegisterTableRequest req, Optional<String> delimiter) {
+
+    TableRef ref = TableRef.parse(id);
+    if (fixtures.tableExists(ref.namespaceId(), ref.tableName())) {
+      throw new TableAlreadyExistsException(id);
+    }
+
+    String location =
+        req.getLocation() != null
+            ? req.getLocation()
+            : "s3://example/" + ref.namespaceId() + "/" + ref.tableName();
+
+    fixtures.registerTableLocation(ref.namespaceId(), ref.tableName(), location);
+
+    RegisterTableResponse response = new RegisterTableResponse();
+    response.setLocation(location);
+    return ResponseEntity.ok(response);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // DeregisterTable — POST /v1/table/{id}/deregister
+  // ─────────────────────────────────────────────────────────────────────────
+
+  @Override
+  public ResponseEntity<DeregisterTableResponse> deregisterTable(
+      String id, DeregisterTableRequest req, Optional<String> delimiter) {
+
+    TableRef ref = TableRef.parse(id);
+    if (!fixtures.tableExists(ref.namespaceId(), ref.tableName())) {
+      throw new TableNotFoundException(id);
+    }
+    return ResponseEntity.ok(new DeregisterTableResponse());
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Stub implementations for unsupported endpoints (return 501)
+  // ─────────────────────────────────────────────────────────────────────────
+
+  @Override
+  public ResponseEntity<ListTablesResponse> listAllTables(
+      Optional<String> delimiter,
+      Optional<String> pageToken,
+      Optional<Integer> limit,
+      Optional<Boolean> includeDeclared) {
+    return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
+  }
+
+  @Override
+  public ResponseEntity<CreateTableResponse> createTable(
+      String id,
+      org.springframework.core.io.Resource body,
+      Optional<String> delimiter,
+      Optional<String> mode,
+      Optional<String> properties,
+      Optional<String> storageOptions) {
+    return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Helpers
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Parses a dot-separated table id into namespace and table parts.
+   *
+   * <p>Format: {@code {namespaceId}.{tableName}} Example: {@code ns_with_tables.table_alpha} →
+   * namespace={@code ns_with_tables}, table={@code table_alpha}
+   *
+   * <p>If no dot separator is found, the entire id is treated as the table name in the root
+   * namespace.
+   */
+  private static final class TableRef {
+    private final String namespaceId;
+    private final String tableName;
+
+    private TableRef(String namespaceId, String tableName) {
+      this.namespaceId = namespaceId;
+      this.tableName = tableName;
+    }
+
+    static TableRef parse(String id) {
+      int dot = id.lastIndexOf('.');
+      if (dot > 0 && dot < id.length() - 1) {
+        return new TableRef(id.substring(0, dot), id.substring(dot + 1));
+      }
+      // Fallback: treat whole id as table name with no namespace
+      return new TableRef("", id);
+    }
+
+    String namespaceId() {
+      return namespaceId;
+    }
+
+    String tableName() {
+      return tableName;
+    }
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // Domain exceptions
+  // ─────────────────────────────────────────────────────────────────────────
+
+  /** Signals that a table does not exist. */
+  static class TableNotFoundException extends RuntimeException {
+    private final String fullTableId;
+
+    TableNotFoundException(String fullTableId) {
+      super("Table " + fullTableId + " does not exist");
+      this.fullTableId = fullTableId;
+    }
+
+    String getFullTableId() {
+      return fullTableId;
+    }
+  }
+
+  /** Signals that a table already exists (for RegisterTable 409). */
+  static class TableAlreadyExistsException extends RuntimeException {
+    private final String fullTableId;
+
+    TableAlreadyExistsException(String fullTableId) {
+      super("Table " + fullTableId + " already exists");
+      this.fullTableId = fullTableId;
+    }
+
+    String getFullTableId() {
+      return fullTableId;
+    }
+  }
+}

--- a/java/lance-namespace-pact-tests/src/test/java/org/lance/namespace/pact/provider/PactTestApplication.java
+++ b/java/lance-namespace-pact-tests/src/test/java/org/lance/namespace/pact/provider/PactTestApplication.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.namespace.pact.provider;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Minimal Spring Boot application entry point for Pact provider verification tests.
+ *
+ * <p>This class exists solely to satisfy {@code @SpringBootTest}'s requirement for a
+ * {@code @SpringBootApplication} class on the classpath. It is test-scoped and not published as
+ * part of the library artifact.
+ */
+@SpringBootApplication(
+    scanBasePackages = {
+      "org.lance.namespace.server.springboot",
+      "org.lance.namespace.pact.provider"
+    })
+public class PactTestApplication {
+
+  public static void main(String[] args) {
+    SpringApplication.run(PactTestApplication.class, args);
+  }
+}

--- a/java/lance-namespace-pact-tests/src/test/java/org/lance/namespace/pact/provider/PactValidationConfig.java
+++ b/java/lance-namespace-pact-tests/src/test/java/org/lance/namespace/pact/provider/PactValidationConfig.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.lance.namespace.pact.provider;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
+import jakarta.validation.executable.ExecutableValidator;
+import jakarta.validation.metadata.BeanDescriptor;
+import jakarta.validation.metadata.ConstructorDescriptor;
+import jakarta.validation.metadata.MethodDescriptor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.Set;
+
+/**
+ * Pact-profile-only configuration that disables Bean Validation.
+ *
+ * <p>Pact consumer tests omit required request body fields (e.g., {@code location} in {@code
+ * RegisterTableRequest}) because pact is used to verify server response contracts, not to test
+ * input validation. The generated Spring server interfaces apply {@code @Valid} and
+ * {@code @NotNull} constraints. This configuration replaces the default JSR-303 validator with a
+ * no-op implementation so that pact verification can proceed without triggering Bean Validation
+ * failures for missing fields.
+ */
+@Configuration
+@Profile("pact")
+public class PactValidationConfig {
+
+  /** No-op {@link Validator} that accepts all inputs without running constraints. */
+  @Bean
+  public Validator validator() {
+    return new NoOpValidator();
+  }
+
+  private static final class NoOpValidator implements Validator {
+
+    private static final ExecutableValidator NO_OP_EXECUTABLE = new NoOpExecutableValidator();
+
+    @Override
+    public <T> Set<ConstraintViolation<T>> validate(T object, Class<?>... groups) {
+      return Set.of();
+    }
+
+    @Override
+    public <T> Set<ConstraintViolation<T>> validateProperty(
+        T object, String propertyName, Class<?>... groups) {
+      return Set.of();
+    }
+
+    @Override
+    public <T> Set<ConstraintViolation<T>> validateValue(
+        Class<T> beanType, String propertyName, Object value, Class<?>... groups) {
+      return Set.of();
+    }
+
+    @Override
+    public BeanDescriptor getConstraintsForClass(Class<?> clazz) {
+      return new NoOpBeanDescriptor();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T unwrap(Class<T> type) {
+      if (type.isInstance(this)) {
+        return (T) this;
+      }
+      return null;
+    }
+
+    @Override
+    public ExecutableValidator forExecutables() {
+      return NO_OP_EXECUTABLE;
+    }
+  }
+
+  private static final class NoOpExecutableValidator implements ExecutableValidator {
+
+    @Override
+    public <T> Set<ConstraintViolation<T>> validateParameters(
+        T object, Method method, Object[] parameterValues, Class<?>... groups) {
+      return Set.of();
+    }
+
+    @Override
+    public <T> Set<ConstraintViolation<T>> validateReturnValue(
+        T object, Method method, Object returnValue, Class<?>... groups) {
+      return Set.of();
+    }
+
+    @Override
+    public <T> Set<ConstraintViolation<T>> validateConstructorParameters(
+        Constructor<? extends T> constructor, Object[] parameterValues, Class<?>... groups) {
+      return Set.of();
+    }
+
+    @Override
+    public <T> Set<ConstraintViolation<T>> validateConstructorReturnValue(
+        Constructor<? extends T> constructor, T createdObject, Class<?>... groups) {
+      return Set.of();
+    }
+  }
+
+  private static final class NoOpBeanDescriptor implements BeanDescriptor {
+
+    @Override
+    public boolean isBeanConstrained() {
+      return false;
+    }
+
+    @Override
+    public jakarta.validation.metadata.PropertyDescriptor getConstraintsForProperty(
+        String propertyName) {
+      return null;
+    }
+
+    @Override
+    public Set<jakarta.validation.metadata.PropertyDescriptor> getConstrainedProperties() {
+      return Set.of();
+    }
+
+    @Override
+    public MethodDescriptor getConstraintsForMethod(String methodName, Class<?>... parameterTypes) {
+      return null;
+    }
+
+    @Override
+    public Set<MethodDescriptor> getConstrainedMethods(
+        jakarta.validation.metadata.MethodType methodType,
+        jakarta.validation.metadata.MethodType... methodTypes) {
+      return Set.of();
+    }
+
+    @Override
+    public ConstructorDescriptor getConstraintsForConstructor(Class<?>... parameterTypes) {
+      return null;
+    }
+
+    @Override
+    public Set<ConstructorDescriptor> getConstrainedConstructors() {
+      return Set.of();
+    }
+
+    @Override
+    public boolean hasConstraints() {
+      return false;
+    }
+
+    @Override
+    public Class<?> getElementClass() {
+      return Object.class;
+    }
+
+    @Override
+    public Set<jakarta.validation.metadata.ConstraintDescriptor<?>> getConstraintDescriptors() {
+      return Set.of();
+    }
+
+    @Override
+    public jakarta.validation.metadata.ElementDescriptor.ConstraintFinder findConstraints() {
+      return null;
+    }
+  }
+}

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -84,6 +84,7 @@
 
         <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
         <maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
+        <pact-jvm-version>4.6.14</pact-jvm-version>
     </properties>
 
     <modules>
@@ -92,6 +93,7 @@
         <module>lance-namespace-springboot-server</module>
         <module>lance-namespace-core</module>
         <module>lance-namespace-core-async</module>
+        <module>lance-namespace-pact-tests</module>
     </modules>
 
     <dependencyManagement>
@@ -357,6 +359,30 @@
                                 </goals>
                             </execution>
                         </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>pact-publish</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>au.com.dius.pact.provider</groupId>
+                        <artifactId>maven</artifactId>
+                        <version>${pact-jvm-version}</version>
+                        <configuration>
+                            <pactDirectory>target/pacts</pactDirectory>
+                            <pactBrokerUrl>${env.PACT_BROKER_URL}</pactBrokerUrl>
+                            <pactBrokerToken>${env.PACT_BROKER_TOKEN}</pactBrokerToken>
+                            <projectVersion>${project.version}+${env.GIT_SHORT_SHA}</projectVersion>
+                            <tags>
+                                <tag>${env.PACT_CONSUMER_BRANCH}</tag>
+                                <tag>${env.GIT_SHORT_SHA}</tag>
+                            </tags>
+                            <trimSnapshot>true</trimSnapshot>
+                            <skipPactPublish>false</skipPactPublish>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/python/Makefile
+++ b/python/Makefile
@@ -52,6 +52,20 @@ publish-ns:
 	cd lance_namespace; \
 		uv build
 
+# lance_namespace_pact_tests package (hand-written contract tests, no codegen).
+# Lives outside lance_namespace_urllib3_client/ so `make clean-urllib3-client`
+# cannot wipe these tests. Depends on the urllib3 client for HTTP plumbing.
+.PHONY: test-pact-tests
+test-pact-tests: build-urllib3-client
+	cd lance_namespace_pact_tests; \
+		uv sync --group dev; \
+		uv run pytest tests/pact_tests -v
+
+.PHONY: build-pact-tests
+build-pact-tests: build-urllib3-client
+	cd lance_namespace_pact_tests; \
+		uv sync --group dev
+
 .PHONY: clean
 clean: clean-urllib3-client
 
@@ -59,7 +73,7 @@ clean: clean-urllib3-client
 gen: gen-urllib3-client
 
 .PHONY: build
-build: build-urllib3-client build-ns
+build: build-urllib3-client build-ns build-pact-tests
 
 .PHONY: publish
 publish: publish-urllib3-client publish-ns

--- a/python/lance_namespace_pact_tests/README.md
+++ b/python/lance_namespace_pact_tests/README.md
@@ -1,0 +1,37 @@
+# lance-namespace-pact-tests (Python)
+
+Hand-written Pact **consumer** contract tests for the Lance Namespace
+Python (urllib3) client.
+
+This package is intentionally placed *outside* the code-generated
+[`lance_namespace_urllib3_client/`](../lance_namespace_urllib3_client/) so
+that running `make clean` / `make gen-urllib3-client` can never wipe these
+tests.
+
+## Layout
+
+```
+lance_namespace_pact_tests/
+├── pyproject.toml          # uv-managed, depends on the urllib3 client + pact-python v3
+├── README.md
+└── tests/
+    ├── __init__.py
+    └── pact_tests/
+        ├── __init__.py
+        ├── conftest.py            # CONSUMER_NAME / PROVIDER_NAME / PACT_DIR
+        ├── error_response_dsl.py  # shared ErrorResponse matcher helper
+        ├── test_namespace_api_pact.py
+        └── test_table_api_pact.py
+```
+
+## Running locally
+
+```bash
+cd python/lance_namespace_pact_tests
+uv sync --group dev
+uv run pytest tests/pact_tests -v
+```
+
+Generated pact JSON files land in `tests/pact_tests/pacts/` (see
+`PACT_DIR` in `conftest.py`). The CI workflow uploads them as artifacts
+and (when `PACT_BROKER_URL` is configured) publishes them to a broker.

--- a/python/lance_namespace_pact_tests/pyproject.toml
+++ b/python/lance_namespace_pact_tests/pyproject.toml
@@ -1,0 +1,44 @@
+[project]
+name = "lance-namespace-pact-tests"
+version = "0.7.6"
+description = "Hand-written Pact consumer contract tests for Lance Namespace (Python urllib3 client). Lives outside the code-generated lance_namespace_urllib3_client/ package so that `make clean` can never wipe these tests."
+readme = "README.md"
+authors = [{ name = "Lance Devs", email = "dev@lance.org" }]
+license = { text = "Apache-2.0" }
+requires-python = ">=3.10"
+# This package is test-only; it is never published to PyPI.
+# It depends on the urllib3 client for the consumer-side HTTP plumbing.
+dependencies = [
+    "lance-namespace-urllib3-client",
+    "urllib3>=1.25.3,<3.0.0",
+]
+
+[dependency-groups]
+dev = [
+    "pytest>=7.2.1",
+    "pytest-cov>=2.8.1",
+    # pact-python v3 (matches the API used in tests/pact_tests/*).
+    "pact-python>=3.0.0",
+]
+
+[tool.uv.sources]
+# Pull the freshly-built urllib3 client from the sibling directory.
+lance-namespace-urllib3-client = { path = "../lance_namespace_urllib3_client" }
+
+[tool.pytest.ini_options]
+# Tests live under tests/pact_tests/ and import each other via
+# `from tests.pact_tests.<module>`. Setting rootdir at the package root
+# makes that import path resolve naturally.
+testpaths = ["tests/pact_tests"]
+addopts = "-ra"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+# This is a tests-only package — produce an empty wheel just to satisfy
+# the build backend if someone runs `uv build`. The actual tests are not
+# packaged.
+packages = []
+bypass-selection = true

--- a/python/lance_namespace_pact_tests/tests/pact_tests/__init__.py
+++ b/python/lance_namespace_pact_tests/tests/pact_tests/__init__.py
@@ -1,0 +1,11 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/python/lance_namespace_pact_tests/tests/pact_tests/conftest.py
+++ b/python/lance_namespace_pact_tests/tests/pact_tests/conftest.py
@@ -1,0 +1,31 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Shared Pact constants for lance-namespace-python-urllib3 consumer tests.
+
+Consumer name: lance-namespace-python-urllib3
+Provider name: lance-namespace-server
+
+Uses pact-python v3 API: each test creates its own Pact and uses
+``pact.serve()`` as a context manager.  No session-scoped mock server.
+"""
+import os
+from pathlib import Path
+
+CONSUMER_NAME = "lance-namespace-python-urllib3"
+PROVIDER_NAME = "lance-namespace-server"
+
+# Directory where generated pact JSON files are written
+PACT_DIR: Path = Path(os.path.dirname(__file__)) / "pacts"
+
+# Ensure the output directory exists at import time
+PACT_DIR.mkdir(parents=True, exist_ok=True)

--- a/python/lance_namespace_pact_tests/tests/pact_tests/error_response_dsl.py
+++ b/python/lance_namespace_pact_tests/tests/pact_tests/error_response_dsl.py
@@ -1,0 +1,44 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+ErrorResponse DSL helper for Python Pact consumer tests (pact-python v3).
+
+Mirrors Java ErrorResponseDsl.java — all four fields (error, code, type, detail)
+use type-matchers so only field types matter, not the exact values.
+Per plan §8, the ErrorResponse has exactly these 4 fields.
+"""
+from pact import match
+
+
+def error_response_body(
+    error: str,
+    code: int,
+    error_type: str,
+    detail: str = "An error occurred",
+) -> dict:
+    """Build a type-matched ErrorResponse body for Pact v3 interactions.
+
+    Args:
+        error: Error code string (e.g. ``"NAMESPACE_NOT_FOUND"``).
+        code: HTTP status integer (e.g. ``404``).
+        error_type: Exception class FQCN (e.g. ``"org.lance.namespace.NamespaceNotFoundException"``).
+        detail: Human-readable detail message (used as example value only).
+
+    Returns:
+        Dictionary of pact-python v3 matchers representing the ErrorResponse shape.
+    """
+    return {
+        "error": match.like(error),
+        "code": match.integer(code),
+        "type": match.like(error_type),
+        "detail": match.like(detail),
+    }

--- a/python/lance_namespace_pact_tests/tests/pact_tests/test_namespace_api_pact.py
+++ b/python/lance_namespace_pact_tests/tests/pact_tests/test_namespace_api_pact.py
@@ -1,0 +1,364 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Pact consumer tests for the Namespace API — consumer lance-namespace-python-urllib3.
+
+Covers all 5 MVP Namespace operations:
+  - ListNamespaces   (GET  /v1/namespace/{id}/list)
+  - DescribeNamespace (POST /v1/namespace/{id}/describe)
+  - CreateNamespace  (POST /v1/namespace/{id}/create)
+  - DropNamespace    (POST /v1/namespace/{id}/drop)
+  - NamespaceExists  (POST /v1/namespace/{id}/exists)
+
+Each operation has a success (2xx) and error (4xx) interaction.
+Provider state strings MUST match contract-pack/provider-states.lock.json verbatim.
+
+Uses pact-python v3 API: each test builds its own Pact and starts the mock
+server with ``pact.serve()`` as a context manager.
+"""
+import json
+from typing import Any
+
+import urllib3  # type: ignore[import-untyped]
+from pact import Pact, match
+
+from tests.pact_tests.conftest import CONSUMER_NAME, PACT_DIR, PROVIDER_NAME
+from tests.pact_tests.error_response_dsl import error_response_body
+
+
+JSON_CONTENT_TYPE = "application/json"
+
+
+def _get(base_url: str, path: str) -> tuple[int, Any]:
+    """Issue a GET request and return (status, parsed_body)."""
+    http = urllib3.PoolManager()
+    resp = http.request("GET", f"{base_url}{path}", headers={"Accept": JSON_CONTENT_TYPE})
+    return resp.status, json.loads(resp.data.decode("utf-8"))
+
+
+def _post(base_url: str, path: str, body: dict | None = None) -> tuple[int, Any]:
+    """Issue a POST request and return (status, parsed_body_or_None)."""
+    http = urllib3.PoolManager()
+    encoded = json.dumps(body or {}).encode("utf-8")
+    resp = http.request(
+        "POST",
+        f"{base_url}{path}",
+        body=encoded,
+        headers={"Content-Type": JSON_CONTENT_TYPE, "Accept": JSON_CONTENT_TYPE},
+    )
+    if resp.data:
+        try:
+            return resp.status, json.loads(resp.data.decode("utf-8"))
+        except ValueError:
+            return resp.status, None
+    return resp.status, None
+
+
+def _new_pact() -> Pact:
+    """Return a fresh Pact for each test."""
+    return Pact(CONSUMER_NAME, PROVIDER_NAME)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ListNamespaces
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestListNamespaces:
+    """GET /v1/namespace/{id}/list"""
+
+    def test_list_namespaces_returns_items(self) -> None:
+        """200: ns_existing has child namespaces → returns array of string names."""
+        pact = _new_pact()
+        (
+            pact
+            .upon_receiving("List child namespaces under ns_existing returns 3 items")
+            .given("namespace 'ns_existing' has 3 tables")
+            .with_request(method="GET", path="/v1/namespace/ns_existing/list")
+            .with_header("Accept", JSON_CONTENT_TYPE)
+            .will_respond_with(200)
+            .with_header("Content-Type", JSON_CONTENT_TYPE)
+            .with_body({"namespaces": match.each_like("child_a", min=1)})
+        )
+
+        with pact.serve() as srv:
+            status, body = _get(srv.url, "/v1/namespace/ns_existing/list")
+
+        pact.write_file(PACT_DIR, overwrite=True)
+
+        assert status == 200
+        assert isinstance(body.get("namespaces"), list)
+        assert len(body["namespaces"]) >= 1
+        for ns in body["namespaces"]:
+            assert isinstance(ns, str)
+
+    def test_list_namespaces_returns_404(self) -> None:
+        """404: ns_missing does not exist → returns ErrorResponse."""
+        pact = _new_pact()
+        (
+            pact
+            .upon_receiving("List child namespaces under non-existent namespace returns 404")
+            .given("namespace 'ns_missing' does not exist")
+            .with_request(method="GET", path="/v1/namespace/ns_missing/list")
+            .with_header("Accept", JSON_CONTENT_TYPE)
+            .will_respond_with(404)
+            .with_header("Content-Type", JSON_CONTENT_TYPE)
+            .with_body(error_response_body(
+                "NAMESPACE_NOT_FOUND",
+                404,
+                "org.lance.namespace.NamespaceNotFoundException",
+                "Namespace ns_missing does not exist",
+            ))
+        )
+
+        with pact.serve() as srv:
+            status, body = _get(srv.url, "/v1/namespace/ns_missing/list")
+
+        pact.write_file(PACT_DIR, overwrite=True)
+
+        assert status == 404
+        assert isinstance(body.get("error"), str)
+        assert isinstance(body.get("code"), int)
+        assert isinstance(body.get("type"), str)
+        assert isinstance(body.get("detail"), str)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# DescribeNamespace
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestDescribeNamespace:
+    """POST /v1/namespace/{id}/describe"""
+
+    def test_describe_namespace_returns_properties(self) -> None:
+        """200: ns_existing exists → returns properties object."""
+        pact = _new_pact()
+        (
+            pact
+            .upon_receiving("Describe namespace ns_existing returns properties")
+            .given("namespace 'ns_existing' has 3 tables")
+            .with_request(method="POST", path="/v1/namespace/ns_existing/describe")
+            .with_body("{}", JSON_CONTENT_TYPE, part="Request")
+            .will_respond_with(200)
+            .with_header("Content-Type", JSON_CONTENT_TYPE)
+            .with_body({"properties": match.like({})})
+        )
+
+        with pact.serve() as srv:
+            status, body = _post(srv.url, "/v1/namespace/ns_existing/describe")
+
+        pact.write_file(PACT_DIR, overwrite=True)
+
+        assert status == 200
+        assert "properties" in body
+
+    def test_describe_namespace_returns_404(self) -> None:
+        """404: ns_missing does not exist → returns ErrorResponse."""
+        pact = _new_pact()
+        (
+            pact
+            .upon_receiving("Describe non-existent namespace returns 404")
+            .given("namespace 'ns_missing' does not exist")
+            .with_request(method="POST", path="/v1/namespace/ns_missing/describe")
+            .with_body("{}", JSON_CONTENT_TYPE, part="Request")
+            .will_respond_with(404)
+            .with_header("Content-Type", JSON_CONTENT_TYPE)
+            .with_body(error_response_body(
+                "NAMESPACE_NOT_FOUND",
+                404,
+                "org.lance.namespace.NamespaceNotFoundException",
+                "Namespace ns_missing does not exist",
+            ))
+        )
+
+        with pact.serve() as srv:
+            status, body = _post(srv.url, "/v1/namespace/ns_missing/describe")
+
+        pact.write_file(PACT_DIR, overwrite=True)
+
+        assert status == 404
+        assert isinstance(body.get("error"), str)
+        assert isinstance(body.get("code"), int)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CreateNamespace
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestCreateNamespace:
+    """POST /v1/namespace/{id}/create"""
+
+    def test_create_namespace_returns_200(self) -> None:
+        """200: ns_new does not exist → namespace is created, returns properties."""
+        pact = _new_pact()
+        (
+            pact
+            .upon_receiving("Create namespace ns_new returns created namespace")
+            .given("namespace 'ns_new' does not exist")
+            .with_request(method="POST", path="/v1/namespace/ns_new/create")
+            .with_body('{"mode":"Create"}', JSON_CONTENT_TYPE, part="Request")
+            .will_respond_with(200)
+            .with_header("Content-Type", JSON_CONTENT_TYPE)
+            .with_body({"properties": match.like({})})
+        )
+
+        with pact.serve() as srv:
+            status, body = _post(srv.url, "/v1/namespace/ns_new/create", {"mode": "Create"})
+
+        pact.write_file(PACT_DIR, overwrite=True)
+
+        assert status == 200
+        assert "properties" in body
+
+    def test_create_namespace_returns_409(self) -> None:
+        """409: ns_existing already exists → returns ErrorResponse."""
+        pact = _new_pact()
+        (
+            pact
+            .upon_receiving("Create already-existing namespace returns 409 conflict")
+            .given("namespace 'ns_existing' has 3 tables")
+            .with_request(method="POST", path="/v1/namespace/ns_existing/create")
+            .with_body('{"mode":"Create"}', JSON_CONTENT_TYPE, part="Request")
+            .will_respond_with(409)
+            .with_header("Content-Type", JSON_CONTENT_TYPE)
+            .with_body(error_response_body(
+                "NAMESPACE_ALREADY_EXISTS",
+                409,
+                "org.lance.namespace.NamespaceAlreadyExistsException",
+                "Namespace ns_existing already exists",
+            ))
+        )
+
+        with pact.serve() as srv:
+            status, body = _post(srv.url, "/v1/namespace/ns_existing/create", {"mode": "Create"})
+
+        pact.write_file(PACT_DIR, overwrite=True)
+
+        assert status == 409
+        assert isinstance(body.get("error"), str)
+        assert isinstance(body.get("code"), int)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# DropNamespace
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestDropNamespace:
+    """POST /v1/namespace/{id}/drop"""
+
+    def test_drop_namespace_returns_200(self) -> None:
+        """200: ns_empty is empty → namespace is dropped."""
+        pact = _new_pact()
+        (
+            pact
+            .upon_receiving("Drop empty namespace ns_empty returns 200")
+            .given("namespace 'ns_empty' exists and is empty")
+            .with_request(method="POST", path="/v1/namespace/ns_empty/drop")
+            .with_body('{"mode":"Fail","behavior":"Restrict"}', JSON_CONTENT_TYPE, part="Request")
+            .will_respond_with(200)
+        )
+
+        with pact.serve() as srv:
+            status, _body = _post(
+                srv.url, "/v1/namespace/ns_empty/drop", {"mode": "Fail", "behavior": "Restrict"}
+            )
+
+        pact.write_file(PACT_DIR, overwrite=True)
+
+        assert status == 200
+
+    def test_drop_namespace_returns_404(self) -> None:
+        """404: ns_missing does not exist → returns ErrorResponse."""
+        pact = _new_pact()
+        (
+            pact
+            .upon_receiving("Drop non-existent namespace returns 404")
+            .given("namespace 'ns_missing' does not exist")
+            .with_request(method="POST", path="/v1/namespace/ns_missing/drop")
+            .with_body('{"mode":"Fail","behavior":"Restrict"}', JSON_CONTENT_TYPE, part="Request")
+            .will_respond_with(404)
+            .with_header("Content-Type", JSON_CONTENT_TYPE)
+            .with_body(error_response_body(
+                "NAMESPACE_NOT_FOUND",
+                404,
+                "org.lance.namespace.NamespaceNotFoundException",
+                "Namespace ns_missing does not exist",
+            ))
+        )
+
+        with pact.serve() as srv:
+            status, body = _post(
+                srv.url, "/v1/namespace/ns_missing/drop", {"mode": "Fail", "behavior": "Restrict"}
+            )
+
+        pact.write_file(PACT_DIR, overwrite=True)
+
+        assert status == 404
+        assert isinstance(body.get("error"), str)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# NamespaceExists
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestNamespaceExists:
+    """POST /v1/namespace/{id}/exists"""
+
+    def test_namespace_exists_returns_200(self) -> None:
+        """200: ns_existing exists → 200 no-content response."""
+        pact = _new_pact()
+        (
+            pact
+            .upon_receiving("Check existence of ns_existing returns 200 no content")
+            .given("namespace 'ns_existing' has 3 tables")
+            .with_request(method="POST", path="/v1/namespace/ns_existing/exists")
+            .with_body("{}", JSON_CONTENT_TYPE, part="Request")
+            .will_respond_with(200)
+        )
+
+        with pact.serve() as srv:
+            status, _body = _post(srv.url, "/v1/namespace/ns_existing/exists")
+
+        pact.write_file(PACT_DIR, overwrite=True)
+
+        assert status == 200
+
+    def test_namespace_exists_returns_404(self) -> None:
+        """404: ns_missing does not exist → returns ErrorResponse."""
+        pact = _new_pact()
+        (
+            pact
+            .upon_receiving("Check existence of ns_missing returns 404")
+            .given("namespace 'ns_missing' does not exist")
+            .with_request(method="POST", path="/v1/namespace/ns_missing/exists")
+            .with_body("{}", JSON_CONTENT_TYPE, part="Request")
+            .will_respond_with(404)
+            .with_header("Content-Type", JSON_CONTENT_TYPE)
+            .with_body(error_response_body(
+                "NAMESPACE_NOT_FOUND",
+                404,
+                "org.lance.namespace.NamespaceNotFoundException",
+                "Namespace ns_missing does not exist",
+            ))
+        )
+
+        with pact.serve() as srv:
+            status, body = _post(srv.url, "/v1/namespace/ns_missing/exists")
+
+        pact.write_file(PACT_DIR, overwrite=True)
+
+        assert status == 404
+        assert isinstance(body.get("error"), str)

--- a/python/lance_namespace_pact_tests/tests/pact_tests/test_table_api_pact.py
+++ b/python/lance_namespace_pact_tests/tests/pact_tests/test_table_api_pact.py
@@ -1,0 +1,428 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Pact consumer tests for the Table API — consumer lance-namespace-python-urllib3.
+
+Covers all 7 MVP Table operations:
+  - ListTables      (GET  /v1/namespace/{id}/table/list)
+  - DescribeTable   (POST /v1/table/{id}/describe)
+  - TableExists     (POST /v1/table/{id}/exists)
+  - DropTable       (POST /v1/table/{id}/drop)
+  - RegisterTable   (POST /v1/table/{id}/register)
+  - DeregisterTable (POST /v1/table/{id}/deregister)
+
+Each operation has a success (2xx) and error (4xx) interaction.
+Provider state strings MUST match contract-pack/provider-states.lock.json verbatim.
+
+Uses pact-python v3 API: each test builds its own Pact and starts the mock
+server with ``pact.serve()`` as a context manager.
+"""
+import json
+from typing import Any
+
+import urllib3  # type: ignore[import-untyped]
+from pact import Pact, match
+
+from tests.pact_tests.conftest import CONSUMER_NAME, PACT_DIR, PROVIDER_NAME
+from tests.pact_tests.error_response_dsl import error_response_body
+
+
+JSON_CONTENT_TYPE = "application/json"
+
+
+def _get(base_url: str, path: str) -> tuple[int, Any]:
+    """Issue a GET request and return (status, parsed_body)."""
+    http = urllib3.PoolManager()
+    resp = http.request("GET", f"{base_url}{path}", headers={"Accept": JSON_CONTENT_TYPE})
+    return resp.status, json.loads(resp.data.decode("utf-8"))
+
+
+def _post(base_url: str, path: str, body: dict | None = None) -> tuple[int, Any]:
+    """Issue a POST request and return (status, parsed_body_or_None)."""
+    http = urllib3.PoolManager()
+    encoded = json.dumps(body or {}).encode("utf-8")
+    resp = http.request(
+        "POST",
+        f"{base_url}{path}",
+        body=encoded,
+        headers={"Content-Type": JSON_CONTENT_TYPE, "Accept": JSON_CONTENT_TYPE},
+    )
+    if resp.data:
+        try:
+            return resp.status, json.loads(resp.data.decode("utf-8"))
+        except ValueError:
+            return resp.status, None
+    return resp.status, None
+
+
+def _new_pact() -> Pact:
+    """Return a fresh Pact for each test."""
+    return Pact(CONSUMER_NAME, PROVIDER_NAME)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ListTables
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestListTables:
+    """GET /v1/namespace/{id}/table/list"""
+
+    def test_list_tables_returns_items(self) -> None:
+        """200: ns_with_tables has 2 tables → returns array of string names."""
+        pact = _new_pact()
+        (
+            pact
+            .upon_receiving("List tables in ns_with_tables returns 2 tables")
+            .given("namespace 'ns_with_tables' has 2 tables")
+            .with_request(method="GET", path="/v1/namespace/ns_with_tables/table/list")
+            .with_header("Accept", JSON_CONTENT_TYPE)
+            .will_respond_with(200)
+            .with_header("Content-Type", JSON_CONTENT_TYPE)
+            .with_body({"tables": match.each_like("table_alpha", min=1)})
+        )
+
+        with pact.serve() as srv:
+            status, body = _get(srv.url, "/v1/namespace/ns_with_tables/table/list")
+
+        pact.write_file(PACT_DIR, overwrite=True)
+
+        assert status == 200
+        assert isinstance(body.get("tables"), list)
+        assert len(body["tables"]) >= 1
+        for tbl in body["tables"]:
+            assert isinstance(tbl, str)
+
+    def test_list_tables_returns_404(self) -> None:
+        """404: ns_missing does not exist → returns ErrorResponse."""
+        pact = _new_pact()
+        (
+            pact
+            .upon_receiving("List tables in non-existent namespace returns 404")
+            .given("namespace 'ns_missing' does not exist")
+            .with_request(method="GET", path="/v1/namespace/ns_missing/table/list")
+            .with_header("Accept", JSON_CONTENT_TYPE)
+            .will_respond_with(404)
+            .with_header("Content-Type", JSON_CONTENT_TYPE)
+            .with_body(error_response_body(
+                "NAMESPACE_NOT_FOUND",
+                404,
+                "org.lance.namespace.NamespaceNotFoundException",
+                "Namespace ns_missing does not exist",
+            ))
+        )
+
+        with pact.serve() as srv:
+            status, body = _get(srv.url, "/v1/namespace/ns_missing/table/list")
+
+        pact.write_file(PACT_DIR, overwrite=True)
+
+        assert status == 404
+        assert isinstance(body.get("error"), str)
+        assert isinstance(body.get("code"), int)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# DescribeTable
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestDescribeTable:
+    """POST /v1/table/{id}/describe"""
+
+    def test_describe_table_returns_200(self) -> None:
+        """200: table_alpha exists → returns location field."""
+        pact = _new_pact()
+        (
+            pact
+            .upon_receiving("Describe table_alpha in ns_with_tables returns table info")
+            .given("table 'ns_with_tables.table_alpha' exists")
+            .with_request(method="POST", path="/v1/table/ns_with_tables.table_alpha/describe")
+            .with_body("{}", JSON_CONTENT_TYPE, part="Request")
+            .will_respond_with(200)
+            .with_header("Content-Type", JSON_CONTENT_TYPE)
+            .with_body({"location": match.like("s3://example/ns_with_tables/table_alpha")})
+        )
+
+        with pact.serve() as srv:
+            status, body = _post(srv.url, "/v1/table/ns_with_tables.table_alpha/describe")
+
+        pact.write_file(PACT_DIR, overwrite=True)
+
+        assert status == 200
+        assert isinstance(body.get("location"), str)
+
+    def test_describe_table_returns_404(self) -> None:
+        """404: table_missing does not exist → returns ErrorResponse."""
+        pact = _new_pact()
+        (
+            pact
+            .upon_receiving("Describe non-existent table returns 404")
+            .given("table 'ns_existing.table_missing' does not exist")
+            .with_request(method="POST", path="/v1/table/ns_existing.table_missing/describe")
+            .with_body("{}", JSON_CONTENT_TYPE, part="Request")
+            .will_respond_with(404)
+            .with_header("Content-Type", JSON_CONTENT_TYPE)
+            .with_body(error_response_body(
+                "TABLE_NOT_FOUND",
+                404,
+                "org.lance.namespace.TableNotFoundException",
+                "Table ns_existing.table_missing does not exist",
+            ))
+        )
+
+        with pact.serve() as srv:
+            status, body = _post(srv.url, "/v1/table/ns_existing.table_missing/describe")
+
+        pact.write_file(PACT_DIR, overwrite=True)
+
+        assert status == 404
+        assert isinstance(body.get("error"), str)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# TableExists
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestTableExists:
+    """POST /v1/table/{id}/exists"""
+
+    def test_table_exists_returns_200(self) -> None:
+        """200: table_alpha exists → 200 no-content."""
+        pact = _new_pact()
+        (
+            pact
+            .upon_receiving("Check existence of table_alpha in ns_with_tables returns 200")
+            .given("table 'ns_with_tables.table_alpha' exists")
+            .with_request(method="POST", path="/v1/table/ns_with_tables.table_alpha/exists")
+            .with_body("{}", JSON_CONTENT_TYPE, part="Request")
+            .will_respond_with(200)
+        )
+
+        with pact.serve() as srv:
+            status, _body = _post(srv.url, "/v1/table/ns_with_tables.table_alpha/exists")
+
+        pact.write_file(PACT_DIR, overwrite=True)
+
+        assert status == 200
+
+    def test_table_exists_returns_404(self) -> None:
+        """404: table_missing does not exist → returns ErrorResponse."""
+        pact = _new_pact()
+        (
+            pact
+            .upon_receiving("Check existence of non-existent table returns 404")
+            .given("table 'ns_existing.table_missing' does not exist")
+            .with_request(method="POST", path="/v1/table/ns_existing.table_missing/exists")
+            .with_body("{}", JSON_CONTENT_TYPE, part="Request")
+            .will_respond_with(404)
+            .with_header("Content-Type", JSON_CONTENT_TYPE)
+            .with_body(error_response_body(
+                "TABLE_NOT_FOUND",
+                404,
+                "org.lance.namespace.TableNotFoundException",
+                "Table ns_existing.table_missing does not exist",
+            ))
+        )
+
+        with pact.serve() as srv:
+            status, body = _post(srv.url, "/v1/table/ns_existing.table_missing/exists")
+
+        pact.write_file(PACT_DIR, overwrite=True)
+
+        assert status == 404
+        assert isinstance(body.get("error"), str)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# DropTable
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestDropTable:
+    """POST /v1/table/{id}/drop"""
+
+    def test_drop_table_returns_200(self) -> None:
+        """200: table_alpha exists → dropped successfully."""
+        pact = _new_pact()
+        (
+            pact
+            .upon_receiving("Drop table_alpha in ns_with_tables returns 200")
+            .given("table 'ns_with_tables.table_alpha' exists")
+            .with_request(method="POST", path="/v1/table/ns_with_tables.table_alpha/drop")
+            .with_body("{}", JSON_CONTENT_TYPE, part="Request")
+            .will_respond_with(200)
+        )
+
+        with pact.serve() as srv:
+            status, _body = _post(srv.url, "/v1/table/ns_with_tables.table_alpha/drop")
+
+        pact.write_file(PACT_DIR, overwrite=True)
+
+        assert status == 200
+
+    def test_drop_table_returns_404(self) -> None:
+        """404: table_missing does not exist → returns ErrorResponse."""
+        pact = _new_pact()
+        (
+            pact
+            .upon_receiving("Drop non-existent table returns 404")
+            .given("table 'ns_existing.table_missing' does not exist")
+            .with_request(method="POST", path="/v1/table/ns_existing.table_missing/drop")
+            .with_body("{}", JSON_CONTENT_TYPE, part="Request")
+            .will_respond_with(404)
+            .with_header("Content-Type", JSON_CONTENT_TYPE)
+            .with_body(error_response_body(
+                "TABLE_NOT_FOUND",
+                404,
+                "org.lance.namespace.TableNotFoundException",
+                "Table ns_existing.table_missing does not exist",
+            ))
+        )
+
+        with pact.serve() as srv:
+            status, body = _post(srv.url, "/v1/table/ns_existing.table_missing/drop")
+
+        pact.write_file(PACT_DIR, overwrite=True)
+
+        assert status == 404
+        assert isinstance(body.get("error"), str)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# RegisterTable
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestRegisterTable:
+    """POST /v1/table/{id}/register"""
+
+    def test_register_table_returns_200(self) -> None:
+        """200: table_new does not exist → registered, returns location."""
+        pact = _new_pact()
+        (
+            pact
+            .upon_receiving("Register new table in ns_existing returns 200")
+            .given("namespace 'ns_existing' has 3 tables")
+            .with_request(method="POST", path="/v1/table/ns_existing.table_new/register")
+            .with_body(
+                '{"location":"s3://example/ns_existing/table_new","mode":"Create"}',
+                JSON_CONTENT_TYPE,
+                part="Request",
+            )
+            .will_respond_with(200)
+            .with_header("Content-Type", JSON_CONTENT_TYPE)
+            .with_body({"location": match.like("s3://example/ns_existing/table_new")})
+        )
+
+        with pact.serve() as srv:
+            status, body = _post(
+                srv.url,
+                "/v1/table/ns_existing.table_new/register",
+                {"location": "s3://example/ns_existing/table_new", "mode": "Create"},
+            )
+
+        pact.write_file(PACT_DIR, overwrite=True)
+
+        assert status == 200
+        assert isinstance(body.get("location"), str)
+
+    def test_register_table_returns_409(self) -> None:
+        """409: table_alpha already exists → returns ErrorResponse."""
+        pact = _new_pact()
+        (
+            pact
+            .upon_receiving("Register already-registered table returns 409")
+            .given("table 'ns_with_tables.table_alpha' exists")
+            .with_request(method="POST", path="/v1/table/ns_with_tables.table_alpha/register")
+            .with_body(
+                '{"location":"s3://example/ns_with_tables/table_alpha","mode":"Create"}',
+                JSON_CONTENT_TYPE,
+                part="Request",
+            )
+            .will_respond_with(409)
+            .with_header("Content-Type", JSON_CONTENT_TYPE)
+            .with_body(error_response_body(
+                "TABLE_ALREADY_EXISTS",
+                409,
+                "org.lance.namespace.TableAlreadyExistsException",
+                "Table ns_with_tables.table_alpha already exists",
+            ))
+        )
+
+        with pact.serve() as srv:
+            status, body = _post(
+                srv.url,
+                "/v1/table/ns_with_tables.table_alpha/register",
+                {"location": "s3://example/ns_with_tables/table_alpha", "mode": "Create"},
+            )
+
+        pact.write_file(PACT_DIR, overwrite=True)
+
+        assert status == 409
+        assert isinstance(body.get("error"), str)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# DeregisterTable
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestDeregisterTable:
+    """POST /v1/table/{id}/deregister"""
+
+    def test_deregister_table_returns_200(self) -> None:
+        """200: table_alpha exists → deregistered successfully."""
+        pact = _new_pact()
+        (
+            pact
+            .upon_receiving("Deregister table_alpha from ns_with_tables returns 200")
+            .given("table 'ns_with_tables.table_alpha' exists")
+            .with_request(method="POST", path="/v1/table/ns_with_tables.table_alpha/deregister")
+            .with_body("{}", JSON_CONTENT_TYPE, part="Request")
+            .will_respond_with(200)
+        )
+
+        with pact.serve() as srv:
+            status, _body = _post(srv.url, "/v1/table/ns_with_tables.table_alpha/deregister")
+
+        pact.write_file(PACT_DIR, overwrite=True)
+
+        assert status == 200
+
+    def test_deregister_table_returns_404(self) -> None:
+        """404: table_missing does not exist → returns ErrorResponse."""
+        pact = _new_pact()
+        (
+            pact
+            .upon_receiving("Deregister non-existent table returns 404")
+            .given("table 'ns_existing.table_missing' does not exist")
+            .with_request(method="POST", path="/v1/table/ns_existing.table_missing/deregister")
+            .with_body("{}", JSON_CONTENT_TYPE, part="Request")
+            .will_respond_with(404)
+            .with_header("Content-Type", JSON_CONTENT_TYPE)
+            .with_body(error_response_body(
+                "TABLE_NOT_FOUND",
+                404,
+                "org.lance.namespace.TableNotFoundException",
+                "Table ns_existing.table_missing does not exist",
+            ))
+        )
+
+        with pact.serve() as srv:
+            status, body = _post(srv.url, "/v1/table/ns_existing.table_missing/deregister")
+
+        pact.write_file(PACT_DIR, overwrite=True)
+
+        assert status == 404
+        assert isinstance(body.get("error"), str)

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -18,12 +18,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
+name = "ariadne"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8454c8a44ce2cb9cc7e7fae67fc6128465b343b92c6631e94beca3c8d1524ea5"
+dependencies = [
+ "unicode-width",
+ "yansi",
 ]
 
 [[package]]
@@ -40,6 +94,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -50,6 +115,49 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "sync_wrapper",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
 
 [[package]]
 name = "backtrace"
@@ -79,16 +187,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
-name = "bytes"
-version = "1.10.1"
+name = "byteorder"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "bzip2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+dependencies = [
+ "bzip2-sys",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "cc"
@@ -97,7 +251,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80f41ae168f955c12fb8960b057d70d0ca153fb83182b57d86380443527be7e9"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
+]
+
+[[package]]
+name = "cfb"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38f2da7a0a2c4ccf0065be06397cc26a81f4e528be095826eee9d4adbb8c60f"
+dependencies = [
+ "byteorder",
+ "fnv",
+ "uuid",
 ]
 
 [[package]]
@@ -125,6 +292,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "compression-codecs"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,6 +327,35 @@ name = "compression-core"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e47641d3deaf41fb1538ac1f54735925e275eaf3bf4d55c81b137fba797e5cbb"
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation"
@@ -158,12 +374,71 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
 ]
 
 [[package]]
@@ -201,6 +476,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deflate64"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -208,6 +489,44 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "difference"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "objc2",
 ]
 
 [[package]]
@@ -228,6 +547,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -243,10 +574,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.0",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "filetime"
+version = "0.2.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5b2eef6fafbf69f877e55509ce5b11a760690ac9700a2921be067aa6afaef6"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -265,6 +628,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,31 +643,68 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-channel"
-version = "0.3.31"
+name = "fs2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -307,22 +713,23 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -330,8 +737,26 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -356,9 +781,22 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasi 0.14.7+wasi-0.2.4",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -366,6 +804,15 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "gregorian"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18888aec42cda8438d991d59b05e5ffa1a9799b1df634346672b1fac7eb02354"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "h2"
@@ -394,15 +841,57 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+
+[[package]]
+name = "hashers"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2bca93b15ea5a746f220e56587f71e73c6165eab783df9e26590069953e3c30"
+dependencies = [
+ "fxhash",
+]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.0",
+]
 
 [[package]]
 name = "http"
@@ -445,6 +934,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,6 +953,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -475,11 +971,26 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
+ "log",
  "rustls",
  "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
  "tower-service",
 ]
 
@@ -501,10 +1012,12 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.0",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -519,7 +1032,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.1",
 ]
 
 [[package]]
@@ -618,6 +1131,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -668,6 +1187,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "indextree"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cee462cd93b03891663339b59a21246cc5fc2cc95060d0bb5059e25cd50edc4"
+dependencies = [
+ "indextree-macros",
+]
+
+[[package]]
+name = "indextree-macros"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f85dac6c239acc85fd61934c572292d93adfd2de459d9c032aa22b553506e915"
+dependencies = [
+ "either",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "strum",
+ "syn",
+ "thiserror",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.17.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+dependencies = [
+ "console",
+ "number_prefix",
+ "portable-atomic",
+ "unicode-width",
+ "web-time",
+]
+
+[[package]]
+name = "infer"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7"
+dependencies = [
+ "cfb",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "io-uring"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -685,13 +1259,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
-name = "iri-string"
-version = "0.7.8"
+name = "itertools"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
- "memchr",
- "serde",
+ "either",
 ]
 
 [[package]]
@@ -701,6 +1274,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.3",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -708,6 +1291,27 @@ checksum = "852f13bec5eba4ba9afbeb93fd7c13fe56147f055939ae21c43a29a0ecb2702e"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kiss_xml"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3476adc74b5dbc6c88dcbf30fcdc5f2336cd43d7ff9cfcffdc5c475013c9b27c"
+dependencies = [
+ "dyn-clone",
+ "regex",
+]
+
+[[package]]
+name = "lance-namespace-pact-tests"
+version = "0.7.6"
+dependencies = [
+ "pact_consumer",
+ "pact_models",
+ "reqwest",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]
@@ -723,10 +1327,57 @@ dependencies = [
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.176"
+name = "lazy_static"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "lenient_semver"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de8de3f4f3754c280ce1c8c42ed8dd26a9c8385c2e5ad4ec5a77e774cea9c1ec"
+dependencies = [
+ "lenient_semver_parser",
+ "semver",
+]
+
+[[package]]
+name = "lenient_semver_parser"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f650c1d024ddc26b4bb79c3076b30030f2cf2b18292af698c81f7337a64d7d6"
+dependencies = [
+ "lenient_semver_version_builder",
+ "semver",
+]
+
+[[package]]
+name = "lenient_semver_version_builder"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9049f8ff49f75b946f95557148e70230499c8a642bf2d6528246afc7d0282d17"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -735,16 +1386,102 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
+name = "logos"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2c55a318a87600ea870ff8c2012148b44bf18b74fad48d0f835c38c7d07c5f"
+dependencies = [
+ "logos-derive",
+]
+
+[[package]]
+name = "logos-codegen"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58b3ffaa284e1350d017a57d04ada118c4583cf260c8fb01e0fe28a2e9cf8970"
+dependencies = [
+ "fnv",
+ "proc-macro2",
+ "quote",
+ "regex-automata",
+ "regex-syntax",
+ "syn",
+]
+
+[[package]]
+name = "logos-derive"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d3a9855747c17eaf4383823f135220716ab49bea5fbea7dd42cc9a92f8aa31"
+dependencies = [
+ "logos-codegen",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
+]
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+
+[[package]]
+name = "md5"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
 
 [[package]]
 name = "memchr"
@@ -769,6 +1506,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -789,6 +1532,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "memchr",
+ "mime",
+ "serde",
+ "serde_json",
+ "spin",
+ "version_check",
+]
+
+[[package]]
+name = "multimap"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -801,6 +1609,171 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-cloud-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-location"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-text"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
+dependencies = [
+ "bitflags",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-ui-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
+dependencies = [
+ "bitflags",
+ "block2",
+ "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-location",
+ "objc2-core-text",
+ "objc2-foundation",
+ "objc2-quartz-core",
+ "objc2-user-notifications",
+]
+
+[[package]]
+name = "objc2-user-notifications"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -819,16 +1792,359 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "onig"
+version = "6.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
+dependencies = [
+ "bitflags",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e68317604e77e53b85896388e1a803c1d21b74c899ec9e5e1112db90735edd7"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
+name = "os_info"
+version = "3.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4022a17595a00d6a369236fdae483f0de7f0a339960a53118b818238e132224"
+dependencies = [
+ "android_system_properties",
+ "log",
+ "nix",
+ "objc2",
+ "objc2-foundation",
+ "objc2-ui-kit",
+ "serde",
+ "windows-sys 0.61.0",
+]
+
+[[package]]
+name = "pact-plugin-driver"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4927f5455775dacf0c48623194e6ec3fd0e97ccb5cf501fd6582486028dc0e45"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "backtrace",
+ "bytes",
+ "chrono",
+ "flate2",
+ "futures-util",
+ "home",
+ "indicatif",
+ "itertools",
+ "lazy_static",
+ "log",
+ "maplit",
+ "md5 0.7.0",
+ "os_info",
+ "pact_models",
+ "prost",
+ "prost-types",
+ "regex",
+ "reqwest",
+ "semver",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sysinfo",
+ "tar",
+ "tokio",
+ "toml",
+ "tonic",
+ "tonic-build",
+ "tracing",
+ "tracing-core",
+ "uuid",
+ "zip",
+]
+
+[[package]]
+name = "pact_consumer"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa0db7d966725e70b75df97c718a4b5c071d2d7257c8e6ff70fbde1b499bbdc0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "futures",
+ "itertools",
+ "lazy_static",
+ "maplit",
+ "pact-plugin-driver",
+ "pact_matching",
+ "pact_mock_server",
+ "pact_models",
+ "regex",
+ "serde_json",
+ "termsize",
+ "tokio",
+ "tracing",
+ "tracing-core",
+ "url",
+ "uuid",
+ "yansi",
+]
+
+[[package]]
+name = "pact_matching"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2473329ff8cb3847fbf0b6b54e89488eb901a608cc88b7b70ed41497fc63dd62"
+dependencies = [
+ "ansi_term",
+ "anyhow",
+ "base64",
+ "bytes",
+ "chrono",
+ "difference",
+ "futures",
+ "hex",
+ "http",
+ "infer",
+ "itertools",
+ "kiss_xml",
+ "lazy_static",
+ "lenient_semver",
+ "maplit",
+ "md5 0.8.0",
+ "mime",
+ "multer",
+ "nom 7.1.3",
+ "onig",
+ "pact-plugin-driver",
+ "pact_models",
+ "rand",
+ "regex",
+ "reqwest",
+ "semver",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sxd-document",
+ "tokio",
+ "tracing",
+ "tracing-core",
+ "tree_magic_mini",
+ "uuid",
+]
+
+[[package]]
+name = "pact_mock_server"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7981270f758414078f0f61680313727e6d29bec6ec410e236c0bf0a4ba21e723"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "futures",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "itertools",
+ "lazy_static",
+ "maplit",
+ "pact-plugin-driver",
+ "pact_matching",
+ "pact_models",
+ "rcgen",
+ "rustls",
+ "rustls-pemfile",
+ "rustls-webpki",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-rustls",
+ "tracing",
+ "tracing-core",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "pact_models"
+version = "1.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d29c0f9419f30d7e7f190e83c58e363ec9cd45f22edd8f1101c5213b4528fb"
+dependencies = [
+ "anyhow",
+ "ariadne",
+ "base64",
+ "bytes",
+ "chrono",
+ "chrono-tz",
+ "fs2",
+ "gregorian",
+ "hashers",
+ "hex",
+ "indextree",
+ "itertools",
+ "kiss_xml",
+ "lazy_static",
+ "lenient_semver",
+ "logos",
+ "maplit",
+ "mime",
+ "nom 7.1.3",
+ "onig",
+ "parse-zoneinfo",
+ "rand",
+ "rand_regex",
+ "regex",
+ "regex-syntax",
+ "reqwest",
+ "semver",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sxd-document",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link 0.2.0",
+]
+
+[[package]]
+name = "parse-zoneinfo"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
+dependencies = [
+ "regex",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "peresil"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f658886ed52e196e850cfbbfddab9eaa7f6d90dd0929e264c31e5cec07e09e57"
+
+[[package]]
+name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.11.4",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.11.4",
+]
+
+[[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -841,6 +2157,18 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -867,12 +2195,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+dependencies = [
+ "heck",
+ "itertools",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph 0.7.1",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn",
+ "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -888,7 +2278,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.0",
  "thiserror",
  "tokio",
  "tracing",
@@ -925,7 +2315,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.0",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -944,6 +2334,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -975,6 +2371,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_regex"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04db2e382d13679a1e42400e90e306cdbb79dc5cd41bb035ba4eae72e78cdf37"
+dependencies = [
+ "rand",
+ "regex-syntax",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "ref-cast"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -995,15 +2443,44 @@ dependencies = [
 ]
 
 [[package]]
-name = "reqwest"
-version = "0.12.23"
+name = "regex"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
- "async-compression",
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
  "base64",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
@@ -1067,11 +2544,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.0",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd3c25631629d034ce7cd9940adc9d45762d46de2b0f57193c4443b92c6d4d40"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -1090,6 +2581,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -1159,13 +2659,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "security-framework"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc198e42d9b7510827939c9a15f5062a0c913f3371d765977e586d2fe6c16f4a"
 dependencies = [
  "bitflags",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -1182,10 +2688,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde"
-version = "1.0.226"
+name = "semver"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dca6411025b24b60bfa7ec1fe1f8e710ac09782dca409ee8237ba74b51295fd"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -1193,18 +2705,18 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.226"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba2ba63999edb9dac981fb34b3e5c0d111a69b0924e253ed29d83f7c99e966a4"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.226"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8db53ae22f34573731bafa1db20f04027b2d25e02d8205921b569171699cdb33"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1213,15 +2725,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.145"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
  "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -1233,6 +2745,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1279,10 +2800,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -1298,6 +2863,16 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
@@ -1305,6 +2880,12 @@ dependencies = [
  "libc",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "stable_deref_trait"
@@ -1319,10 +2900,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "sxd-document"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94d82f37be9faf1b10a82c4bd492b74f698e40082f0f40de38ab275f31d42078"
+dependencies = [
+ "peresil",
+ "typed-arena",
+]
 
 [[package]]
 name = "syn"
@@ -1353,6 +2965,76 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.30.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a5b4ddaee55fb2bea2bf0e5000747e5f5c0de765e5a5ff87f4cd106439f4bb3"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "windows",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.0",
+]
+
+[[package]]
+name = "termsize"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f11ff5c25c172608d5b85e2fb43ee9a6d683a7f4ab7f96ae07b3d8b590368fd"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -1442,10 +3124,24 @@ dependencies = [
  "io-uring",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
+ "signal-hook-registry",
  "slab",
- "socket2",
+ "socket2 0.6.0",
+ "tokio-macros",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1455,6 +3151,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f63835928ca123f1bef57abbcd23bb2ba0ac9ae1235f1e65bda0d06e7786bd"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -1472,6 +3179,90 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.11.4",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "tonic"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac6f67be712d12f0b41328db3137e0d0757645d8904b4cb7d51cd9c2279e847"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "prost-types",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1479,29 +3270,38 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap 2.11.4",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
 name = "tower-http"
-version = "0.6.6"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
+ "async-compression",
  "bitflags",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
+ "http-body-util",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -1518,21 +3318,46 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
 ]
 
 [[package]]
-name = "tracing-core"
-version = "0.1.34"
+name = "tracing-attributes"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom 8.0.0",
+ "petgraph 0.8.3",
 ]
 
 [[package]]
@@ -1540,6 +3365,18 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typed-arena"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9b2228007eba4120145f785df0f6c92ea538f5a3635a612ecf4e334c8c1446d"
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicase"
@@ -1552,6 +3389,18 @@ name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -1576,6 +3425,29 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "getrandom 0.4.2",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"
@@ -1607,7 +3479,16 @@ version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.46.0",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -1683,6 +3564,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap 2.11.4",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
 name = "wasm-streams"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1693,6 +3596,18 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap 2.11.4",
+ "semver",
 ]
 
 [[package]]
@@ -1716,6 +3631,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
+dependencies = [
+ "windows-core 0.52.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "windows-core"
 version = "0.62.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1724,8 +3689,8 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link 0.2.0",
- "windows-result",
- "windows-strings",
+ "windows-result 0.4.0",
+ "windows-strings 0.5.0",
 ]
 
 [[package]]
@@ -1763,12 +3728,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 
 [[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
 dependencies = [
  "windows-link 0.2.0",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -1946,16 +3940,147 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap 2.11.4",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap 2.11.4",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap 2.11.4",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "yoke"
@@ -2027,6 +4152,20 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"
@@ -2059,4 +4198,80 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "aes",
+ "arbitrary",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "deflate64",
+ "displaydoc",
+ "flate2",
+ "getrandom 0.3.3",
+ "hmac",
+ "indexmap 2.11.4",
+ "lzma-rs",
+ "memchr",
+ "pbkdf2",
+ "sha1",
+ "thiserror",
+ "time",
+ "xz2",
+ "zeroize",
+ "zopfli",
+ "zstd",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["lance-namespace-reqwest-client"]
+members = ["lance-namespace-reqwest-client", "lance-namespace-pact-tests"]
 
 [workspace.dependencies]
 lance-namespace-reqwest-client = { path = "lance-namespace-reqwest-client", version = "0.7.6" }

--- a/rust/Makefile
+++ b/rust/Makefile
@@ -33,7 +33,18 @@ gen-reqwest-client: clean-reqwest-client
 
 .PHONY: build-reqwest-client
 build-reqwest-client: gen-reqwest-client
-	cargo test --all-features
+	cargo test --all-features -p lance-namespace-reqwest-client
+
+# lance-namespace-pact-tests crate (hand-written, no codegen).
+# Test-only crate that hosts the consumer Pact integration tests.
+# Independent of `make clean-reqwest-client`, which only nukes the reqwest crate.
+.PHONY: test-pact-tests
+test-pact-tests:
+	cargo test -p lance-namespace-pact-tests --tests
+
+.PHONY: build-pact-tests
+build-pact-tests:
+	cargo build -p lance-namespace-pact-tests --tests
 
 .PHONY: clean
 clean: clean-reqwest-client
@@ -42,4 +53,4 @@ clean: clean-reqwest-client
 gen: gen-reqwest-client
 
 .PHONY: build
-build: build-reqwest-client
+build: build-reqwest-client build-pact-tests

--- a/rust/lance-namespace-pact-tests/Cargo.toml
+++ b/rust/lance-namespace-pact-tests/Cargo.toml
@@ -1,0 +1,38 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+[package]
+name = "lance-namespace-pact-tests"
+version = "0.7.6"
+edition = "2021"
+license = "Apache-2.0"
+publish = false
+description = "Hand-written Pact consumer contract tests for Lance Namespace (Rust reqwest client). Lives outside the code-generated `lance-namespace-reqwest-client` crate so that `make clean` cannot wipe these tests."
+
+# This crate exists only to host integration tests under tests/.
+# The empty lib.rs prevents Cargo warnings about a missing crate root.
+[lib]
+path = "src/lib.rs"
+
+# The pact_consumer/pact_models stack is heavy enough that we list it as
+# regular dependencies (this crate is test-only, never published).
+[dependencies]
+
+[dev-dependencies]
+# Pact consumer DSL (matches PR-original PACT_JVM_VERSION-aligned crate version).
+pact_consumer = "1.2"
+pact_models = "1.3"
+tokio = { version = "1", features = ["full"] }
+serde_json = "^1.0"
+# The hand-written tests directly use `reqwest::Client` to drive the
+# pact mock server (independently of the generated reqwest-client crate).
+reqwest = { version = "^0.12", default-features = false, features = ["json", "rustls-tls-native-roots"] }

--- a/rust/lance-namespace-pact-tests/src/lib.rs
+++ b/rust/lance-namespace-pact-tests/src/lib.rs
@@ -1,0 +1,19 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Hand-written Pact consumer contract tests for Lance Namespace (Rust).
+//!
+//! This crate exists *only* to host integration tests under `tests/`.
+//! It must live outside `lance-namespace-reqwest-client/` so that
+//! `rust/Makefile`'s `make clean-reqwest-client` can never wipe these tests.
+//!
+//! See `tests/namespace_api_tests.rs` and `tests/table_api_tests.rs`.

--- a/rust/lance-namespace-pact-tests/tests/namespace_api_tests.rs
+++ b/rust/lance-namespace-pact-tests/tests/namespace_api_tests.rs
@@ -1,0 +1,509 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Pact consumer tests for the Namespace API.
+//!
+//! Consumer: `lance-namespace-rust-reqwest`
+//! Provider: `lance-namespace-server`
+//!
+//! Covers all 5 MVP Namespace operations:
+//! - ListNamespaces  (GET  /v1/namespace/{id}/list)
+//! - DescribeNamespace (POST /v1/namespace/{id}/describe)
+//! - CreateNamespace (POST /v1/namespace/{id}/create)
+//! - DropNamespace   (POST /v1/namespace/{id}/drop)
+//! - NamespaceExists  (POST /v1/namespace/{id}/exists)
+//!
+//! Provider state strings MUST match contract-pack/provider-states.lock.json verbatim.
+
+use pact_consumer::patterns::{JsonPattern, Pattern};
+use pact_consumer::prelude::*;
+use pact_models::matchingrules::{MatchingRule, MatchingRuleCategory, RuleLogic};
+use pact_models::path_exp::DocPath;
+use serde_json::{json, Value};
+
+/// A JsonPattern that emits {"match": "integer"} — canonical `integer` matcher.
+#[derive(Debug)]
+struct IntegerLike(i64);
+impl Pattern for IntegerLike {
+    type Matches = serde_json::Value;
+    fn to_example(&self) -> Self::Matches {
+        json!(self.0)
+    }
+    fn to_example_bytes(&self) -> Vec<u8> {
+        self.0.to_string().into_bytes()
+    }
+    fn extract_matching_rules(&self, path: DocPath, rules_out: &mut MatchingRuleCategory) {
+        rules_out.add_rule(path, MatchingRule::Integer, RuleLogic::And);
+    }
+}
+impl From<IntegerLike> for JsonPattern {
+    fn from(v: IntegerLike) -> Self {
+        JsonPattern::pattern(v)
+    }
+}
+
+const CONSUMER: &str = "lance-namespace-rust-reqwest";
+const PROVIDER: &str = "lance-namespace-server";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Build a type-matched ErrorResponse body matcher.
+/// Fields: error (string), code (integer), type (string), detail (string).
+fn error_response_matcher(
+    error: &str,
+    code: u16,
+    error_type: &str,
+    detail: &str,
+) -> pact_consumer::prelude::JsonPattern {
+    json_pattern!({
+        "error": like!(error),
+        "code": IntegerLike(code as i64),
+        "type": like!(error_type),
+        "detail": like!(detail)
+    })
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ListNamespaces — GET /v1/namespace/{id}/list
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_list_namespaces_returns_items() {
+    let mock_server = PactBuilder::new(CONSUMER, PROVIDER)
+        .interaction(
+            "List child namespaces under ns_existing returns 3 items",
+            "",
+            |mut i| {
+                i.given("namespace 'ns_existing' has 3 tables");
+                i.request.method("GET");
+                i.request.path("/v1/namespace/ns_existing/list");
+                i.request.header("Accept", "application/json");
+                i.response.status(200);
+                i.response.content_type("application/json");
+                i.response.json_body(json_pattern!({
+                    "namespaces": each_like!(like!("child_a"), min = 1)
+                }));
+                i
+            },
+        )
+        .start_mock_server(None, None);
+
+    let base_url_raw = mock_server.url().to_string();
+    let base_url = base_url_raw.trim_end_matches('/');
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("{}/v1/namespace/ns_existing/list", base_url))
+        .header("Accept", "application/json")
+        .send()
+        .await
+        .expect("request failed");
+
+    assert_eq!(resp.status().as_u16(), 200);
+    let body: Value = resp.json().await.expect("body parse failed");
+    let namespaces = body["namespaces"]
+        .as_array()
+        .expect("namespaces must be array");
+    assert!(!namespaces.is_empty());
+    for ns in namespaces {
+        assert!(ns.is_string(), "each namespace must be a string");
+    }
+}
+
+#[tokio::test]
+async fn test_list_namespaces_returns_404() {
+    let error_body = error_response_matcher(
+        "NAMESPACE_NOT_FOUND",
+        404,
+        "org.lance.namespace.NamespaceNotFoundException",
+        "Namespace ns_missing does not exist",
+    );
+
+    let mock_server = PactBuilder::new(CONSUMER, PROVIDER)
+        .interaction(
+            "List child namespaces under non-existent namespace returns 404",
+            "",
+            |mut i| {
+                i.given("namespace 'ns_missing' does not exist");
+                i.request.method("GET");
+                i.request.path("/v1/namespace/ns_missing/list");
+                i.request.header("Accept", "application/json");
+                i.response.status(404);
+                i.response.content_type("application/json");
+                i.response.json_body(error_body);
+                i
+            },
+        )
+        .start_mock_server(None, None);
+
+    let base_url_raw = mock_server.url().to_string();
+    let base_url = base_url_raw.trim_end_matches('/');
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("{}/v1/namespace/ns_missing/list", base_url))
+        .header("Accept", "application/json")
+        .send()
+        .await
+        .expect("request failed");
+
+    assert_eq!(resp.status().as_u16(), 404);
+    let body: Value = resp.json().await.expect("body parse failed");
+    assert!(body["error"].is_string());
+    assert!(body["code"].is_number());
+    assert!(body["type"].is_string());
+    assert!(body["detail"].is_string());
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DescribeNamespace — POST /v1/namespace/{id}/describe
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_describe_namespace_returns_200() {
+    let mock_server = PactBuilder::new(CONSUMER, PROVIDER)
+        .interaction(
+            "Describe namespace ns_existing returns properties",
+            "",
+            |mut i| {
+                i.given("namespace 'ns_existing' has 3 tables");
+                i.request.method("POST");
+                i.request.path("/v1/namespace/ns_existing/describe");
+                i.request.header("Content-Type", "application/json");
+                i.request.header("Accept", "application/json");
+                i.request.json_body(json_pattern!({}));
+                i.response.status(200);
+                i.response.content_type("application/json");
+                i.response.json_body(json_pattern!({
+                    "properties": like!({})
+                }));
+                i
+            },
+        )
+        .start_mock_server(None, None);
+
+    let base_url_raw = mock_server.url().to_string();
+    let base_url = base_url_raw.trim_end_matches('/');
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{}/v1/namespace/ns_existing/describe", base_url))
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json")
+        .json(&json!({}))
+        .send()
+        .await
+        .expect("request failed");
+
+    assert_eq!(resp.status().as_u16(), 200);
+    let body: Value = resp.json().await.expect("body parse failed");
+    assert!(body.get("properties").is_some());
+}
+
+#[tokio::test]
+async fn test_describe_namespace_returns_404() {
+    let error_body = error_response_matcher(
+        "NAMESPACE_NOT_FOUND",
+        404,
+        "org.lance.namespace.NamespaceNotFoundException",
+        "Namespace ns_missing does not exist",
+    );
+
+    let mock_server = PactBuilder::new(CONSUMER, PROVIDER)
+        .interaction(
+            "Describe non-existent namespace returns 404",
+            "",
+            |mut i| {
+                i.given("namespace 'ns_missing' does not exist");
+                i.request.method("POST");
+                i.request.path("/v1/namespace/ns_missing/describe");
+                i.request.header("Content-Type", "application/json");
+                i.request.header("Accept", "application/json");
+                i.request.json_body(json_pattern!({}));
+                i.response.status(404);
+                i.response.content_type("application/json");
+                i.response.json_body(error_body);
+                i
+            },
+        )
+        .start_mock_server(None, None);
+
+    let base_url_raw = mock_server.url().to_string();
+    let base_url = base_url_raw.trim_end_matches('/');
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{}/v1/namespace/ns_missing/describe", base_url))
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json")
+        .json(&json!({}))
+        .send()
+        .await
+        .expect("request failed");
+
+    assert_eq!(resp.status().as_u16(), 404);
+    let body: Value = resp.json().await.expect("body parse failed");
+    assert!(body["error"].is_string());
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// CreateNamespace — POST /v1/namespace/{id}/create
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_create_namespace_returns_200() {
+    let mock_server = PactBuilder::new(CONSUMER, PROVIDER)
+        .interaction(
+            "Create namespace ns_new returns created namespace",
+            "",
+            |mut i| {
+                i.given("namespace 'ns_new' does not exist");
+                i.request.method("POST");
+                i.request.path("/v1/namespace/ns_new/create");
+                i.request.header("Content-Type", "application/json");
+                i.request.header("Accept", "application/json");
+                i.request.json_body(json_pattern!({"mode": "Create"}));
+                i.response.status(200);
+                i.response.content_type("application/json");
+                i.response.json_body(json_pattern!({
+                    "properties": like!({})
+                }));
+                i
+            },
+        )
+        .start_mock_server(None, None);
+
+    let base_url_raw = mock_server.url().to_string();
+    let base_url = base_url_raw.trim_end_matches('/');
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{}/v1/namespace/ns_new/create", base_url))
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json")
+        .json(&json!({"mode": "Create"}))
+        .send()
+        .await
+        .expect("request failed");
+
+    assert_eq!(resp.status().as_u16(), 200);
+}
+
+#[tokio::test]
+async fn test_create_namespace_returns_409() {
+    let error_body = error_response_matcher(
+        "NAMESPACE_ALREADY_EXISTS",
+        409,
+        "org.lance.namespace.NamespaceAlreadyExistsException",
+        "Namespace ns_existing already exists",
+    );
+
+    let mock_server = PactBuilder::new(CONSUMER, PROVIDER)
+        .interaction(
+            "Create already-existing namespace returns 409 conflict",
+            "",
+            |mut i| {
+                i.given("namespace 'ns_existing' has 3 tables");
+                i.request.method("POST");
+                i.request.path("/v1/namespace/ns_existing/create");
+                i.request.header("Content-Type", "application/json");
+                i.request.header("Accept", "application/json");
+                i.request.json_body(json_pattern!({"mode": "Create"}));
+                i.response.status(409);
+                i.response.content_type("application/json");
+                i.response.json_body(error_body);
+                i
+            },
+        )
+        .start_mock_server(None, None);
+
+    let base_url_raw = mock_server.url().to_string();
+    let base_url = base_url_raw.trim_end_matches('/');
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{}/v1/namespace/ns_existing/create", base_url))
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json")
+        .json(&json!({"mode": "Create"}))
+        .send()
+        .await
+        .expect("request failed");
+
+    assert_eq!(resp.status().as_u16(), 409);
+    let body: Value = resp.json().await.expect("body parse failed");
+    assert!(body["error"].is_string());
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DropNamespace — POST /v1/namespace/{id}/drop
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_drop_namespace_returns_200() {
+    let mock_server = PactBuilder::new(CONSUMER, PROVIDER)
+        .interaction("Drop empty namespace ns_empty returns 200", "", |mut i| {
+            i.given("namespace 'ns_empty' exists and is empty");
+            i.request.method("POST");
+            i.request.path("/v1/namespace/ns_empty/drop");
+            i.request.header("Content-Type", "application/json");
+            i.request.header("Accept", "application/json");
+            i.request
+                .json_body(json_pattern!({"mode": "Fail", "behavior": "Restrict"}));
+            i.response.status(200);
+            i.response.content_type("application/json");
+            i.response.json_body(json_pattern!({}));
+            i
+        })
+        .start_mock_server(None, None);
+
+    let base_url_raw = mock_server.url().to_string();
+    let base_url = base_url_raw.trim_end_matches('/');
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{}/v1/namespace/ns_empty/drop", base_url))
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json")
+        .json(&json!({"mode": "Fail", "behavior": "Restrict"}))
+        .send()
+        .await
+        .expect("request failed");
+
+    assert_eq!(resp.status().as_u16(), 200);
+}
+
+#[tokio::test]
+async fn test_drop_namespace_returns_404() {
+    let error_body = error_response_matcher(
+        "NAMESPACE_NOT_FOUND",
+        404,
+        "org.lance.namespace.NamespaceNotFoundException",
+        "Namespace ns_missing does not exist",
+    );
+
+    let mock_server = PactBuilder::new(CONSUMER, PROVIDER)
+        .interaction("Drop non-existent namespace returns 404", "", |mut i| {
+            i.given("namespace 'ns_missing' does not exist");
+            i.request.method("POST");
+            i.request.path("/v1/namespace/ns_missing/drop");
+            i.request.header("Content-Type", "application/json");
+            i.request.header("Accept", "application/json");
+            i.request
+                .json_body(json_pattern!({"mode": "Fail", "behavior": "Restrict"}));
+            i.response.status(404);
+            i.response.content_type("application/json");
+            i.response.json_body(error_body);
+            i
+        })
+        .start_mock_server(None, None);
+
+    let base_url_raw = mock_server.url().to_string();
+    let base_url = base_url_raw.trim_end_matches('/');
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{}/v1/namespace/ns_missing/drop", base_url))
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json")
+        .json(&json!({"mode": "Fail", "behavior": "Restrict"}))
+        .send()
+        .await
+        .expect("request failed");
+
+    assert_eq!(resp.status().as_u16(), 404);
+    let body: Value = resp.json().await.expect("body parse failed");
+    assert!(body["error"].is_string());
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// NamespaceExists — POST /v1/namespace/{id}/exists
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_namespace_exists_returns_200() {
+    let mock_server = PactBuilder::new(CONSUMER, PROVIDER)
+        .interaction(
+            "Check existence of ns_existing returns 200 no content",
+            "",
+            |mut i| {
+                i.given("namespace 'ns_existing' has 3 tables");
+                i.request.method("POST");
+                i.request.path("/v1/namespace/ns_existing/exists");
+                i.request.header("Content-Type", "application/json");
+                i.request.header("Accept", "application/json");
+                i.request.json_body(json_pattern!({}));
+                i.response.status(200);
+                i
+            },
+        )
+        .start_mock_server(None, None);
+
+    let base_url_raw = mock_server.url().to_string();
+    let base_url = base_url_raw.trim_end_matches('/');
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{}/v1/namespace/ns_existing/exists", base_url))
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json")
+        .json(&json!({}))
+        .send()
+        .await
+        .expect("request failed");
+
+    assert_eq!(resp.status().as_u16(), 200);
+}
+
+#[tokio::test]
+async fn test_namespace_exists_returns_404() {
+    let error_body = error_response_matcher(
+        "NAMESPACE_NOT_FOUND",
+        404,
+        "org.lance.namespace.NamespaceNotFoundException",
+        "Namespace ns_missing does not exist",
+    );
+
+    let mock_server = PactBuilder::new(CONSUMER, PROVIDER)
+        .interaction("Check existence of ns_missing returns 404", "", |mut i| {
+            i.given("namespace 'ns_missing' does not exist");
+            i.request.method("POST");
+            i.request.path("/v1/namespace/ns_missing/exists");
+            i.request.header("Content-Type", "application/json");
+            i.request.header("Accept", "application/json");
+            i.request.json_body(json_pattern!({}));
+            i.response.status(404);
+            i.response.content_type("application/json");
+            i.response.json_body(error_body);
+            i
+        })
+        .start_mock_server(None, None);
+
+    let base_url_raw = mock_server.url().to_string();
+    let base_url = base_url_raw.trim_end_matches('/');
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{}/v1/namespace/ns_missing/exists", base_url))
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json")
+        .json(&json!({}))
+        .send()
+        .await
+        .expect("request failed");
+
+    assert_eq!(resp.status().as_u16(), 404);
+    let body: Value = resp.json().await.expect("body parse failed");
+    assert!(body["error"].is_string());
+}

--- a/rust/lance-namespace-pact-tests/tests/table_api_tests.rs
+++ b/rust/lance-namespace-pact-tests/tests/table_api_tests.rs
@@ -1,0 +1,606 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Pact consumer tests for the Table API.
+//!
+//! Consumer: `lance-namespace-rust-reqwest`
+//! Provider: `lance-namespace-server`
+//!
+//! Covers all 7 MVP Table operations:
+//! - ListTables      (GET  /v1/namespace/{id}/table/list)
+//! - DescribeTable   (POST /v1/table/{id}/describe)
+//! - TableExists     (POST /v1/table/{id}/exists)
+//! - DropTable       (POST /v1/table/{id}/drop)
+//! - RegisterTable   (POST /v1/table/{id}/register)
+//! - DeregisterTable (POST /v1/table/{id}/deregister)
+//!
+//! Provider state strings MUST match contract-pack/provider-states.lock.json verbatim.
+
+use pact_consumer::patterns::{JsonPattern, Pattern};
+use pact_consumer::prelude::*;
+use pact_models::matchingrules::{MatchingRule, MatchingRuleCategory, RuleLogic};
+use pact_models::path_exp::DocPath;
+use serde_json::{json, Value};
+
+/// A JsonPattern that emits {"match": "integer"} — canonical `integer` matcher.
+#[derive(Debug)]
+struct IntegerLike(i64);
+impl Pattern for IntegerLike {
+    type Matches = serde_json::Value;
+    fn to_example(&self) -> Self::Matches {
+        json!(self.0)
+    }
+    fn to_example_bytes(&self) -> Vec<u8> {
+        self.0.to_string().into_bytes()
+    }
+    fn extract_matching_rules(&self, path: DocPath, rules_out: &mut MatchingRuleCategory) {
+        rules_out.add_rule(path, MatchingRule::Integer, RuleLogic::And);
+    }
+}
+impl From<IntegerLike> for JsonPattern {
+    fn from(v: IntegerLike) -> Self {
+        JsonPattern::pattern(v)
+    }
+}
+
+const CONSUMER: &str = "lance-namespace-rust-reqwest";
+const PROVIDER: &str = "lance-namespace-server";
+
+/// Build a type-matched ErrorResponse body matcher.
+fn error_response_matcher(
+    error: &str,
+    code: u16,
+    error_type: &str,
+    detail: &str,
+) -> pact_consumer::prelude::JsonPattern {
+    json_pattern!({
+        "error": like!(error),
+        "code": IntegerLike(code as i64),
+        "type": like!(error_type),
+        "detail": like!(detail)
+    })
+}
+
+#[tokio::test]
+async fn test_list_tables_returns_items() {
+    let mock_server = PactBuilder::new(CONSUMER, PROVIDER)
+        .interaction(
+            "List tables in ns_with_tables returns 2 tables",
+            "",
+            |mut i| {
+                i.given("namespace 'ns_with_tables' has 2 tables");
+                i.request.method("GET");
+                i.request.path("/v1/namespace/ns_with_tables/table/list");
+                i.request.header("Accept", "application/json");
+                i.response.status(200);
+                i.response.content_type("application/json");
+                i.response.json_body(json_pattern!({
+                    "tables": each_like!(like!("table_alpha"), min = 1)
+                }));
+                i
+            },
+        )
+        .start_mock_server(None, None);
+
+    let base_url_raw = mock_server.url().to_string();
+    let base_url = base_url_raw.trim_end_matches('/');
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!(
+            "{}/v1/namespace/ns_with_tables/table/list",
+            base_url
+        ))
+        .header("Accept", "application/json")
+        .send()
+        .await
+        .expect("request failed");
+
+    assert_eq!(resp.status().as_u16(), 200);
+    let body: Value = resp.json().await.expect("body parse failed");
+    let tables = body["tables"].as_array().expect("tables must be array");
+    assert!(!tables.is_empty());
+    for tbl in tables {
+        assert!(tbl.is_string(), "each table must be a string");
+    }
+}
+
+#[tokio::test]
+async fn test_list_tables_returns_404() {
+    let error_body = error_response_matcher(
+        "NAMESPACE_NOT_FOUND",
+        404,
+        "org.lance.namespace.NamespaceNotFoundException",
+        "Namespace ns_missing does not exist",
+    );
+
+    let mock_server = PactBuilder::new(CONSUMER, PROVIDER)
+        .interaction(
+            "List tables in non-existent namespace returns 404",
+            "",
+            |mut i| {
+                i.given("namespace 'ns_missing' does not exist");
+                i.request.method("GET");
+                i.request.path("/v1/namespace/ns_missing/table/list");
+                i.request.header("Accept", "application/json");
+                i.response.status(404);
+                i.response.content_type("application/json");
+                i.response.json_body(error_body);
+                i
+            },
+        )
+        .start_mock_server(None, None);
+
+    let base_url_raw = mock_server.url().to_string();
+    let base_url = base_url_raw.trim_end_matches('/');
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .get(format!("{}/v1/namespace/ns_missing/table/list", base_url))
+        .header("Accept", "application/json")
+        .send()
+        .await
+        .expect("request failed");
+
+    assert_eq!(resp.status().as_u16(), 404);
+    let body: Value = resp.json().await.expect("body parse failed");
+    assert!(body["error"].is_string());
+}
+
+#[tokio::test]
+async fn test_describe_table_returns_200() {
+    let mock_server = PactBuilder::new(CONSUMER, PROVIDER)
+        .interaction(
+            "Describe table_alpha in ns_with_tables returns table info",
+            "",
+            |mut i| {
+                i.given("table 'ns_with_tables.table_alpha' exists");
+                i.request.method("POST");
+                i.request
+                    .path("/v1/table/ns_with_tables.table_alpha/describe");
+                i.request.header("Content-Type", "application/json");
+                i.request.header("Accept", "application/json");
+                i.request.json_body(json_pattern!({}));
+                i.response.status(200);
+                i.response.content_type("application/json");
+                i.response.json_body(json_pattern!({
+                    "location": like!("s3://example/ns_with_tables/table_alpha")
+                }));
+                i
+            },
+        )
+        .start_mock_server(None, None);
+
+    let base_url_raw = mock_server.url().to_string();
+    let base_url = base_url_raw.trim_end_matches('/');
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!(
+            "{}/v1/table/ns_with_tables.table_alpha/describe",
+            base_url
+        ))
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json")
+        .json(&json!({}))
+        .send()
+        .await
+        .expect("request failed");
+
+    assert_eq!(resp.status().as_u16(), 200);
+    let body: Value = resp.json().await.expect("body parse failed");
+    assert!(body["location"].is_string());
+}
+
+#[tokio::test]
+async fn test_describe_table_returns_404() {
+    let error_body = error_response_matcher(
+        "TABLE_NOT_FOUND",
+        404,
+        "org.lance.namespace.TableNotFoundException",
+        "Table ns_existing.table_missing does not exist",
+    );
+
+    let mock_server = PactBuilder::new(CONSUMER, PROVIDER)
+        .interaction("Describe non-existent table returns 404", "", |mut i| {
+            i.given("table 'ns_existing.table_missing' does not exist");
+            i.request.method("POST");
+            i.request
+                .path("/v1/table/ns_existing.table_missing/describe");
+            i.request.header("Content-Type", "application/json");
+            i.request.header("Accept", "application/json");
+            i.request.json_body(json_pattern!({}));
+            i.response.status(404);
+            i.response.content_type("application/json");
+            i.response.json_body(error_body);
+            i
+        })
+        .start_mock_server(None, None);
+
+    let base_url_raw = mock_server.url().to_string();
+    let base_url = base_url_raw.trim_end_matches('/');
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!(
+            "{}/v1/table/ns_existing.table_missing/describe",
+            base_url
+        ))
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json")
+        .json(&json!({}))
+        .send()
+        .await
+        .expect("request failed");
+
+    assert_eq!(resp.status().as_u16(), 404);
+    let body: Value = resp.json().await.expect("body parse failed");
+    assert!(body["error"].is_string());
+}
+
+#[tokio::test]
+async fn test_table_exists_returns_200() {
+    let mock_server = PactBuilder::new(CONSUMER, PROVIDER)
+        .interaction(
+            "Check existence of table_alpha in ns_with_tables returns 200",
+            "",
+            |mut i| {
+                i.given("table 'ns_with_tables.table_alpha' exists");
+                i.request.method("POST");
+                i.request
+                    .path("/v1/table/ns_with_tables.table_alpha/exists");
+                i.request.header("Content-Type", "application/json");
+                i.request.header("Accept", "application/json");
+                i.request.json_body(json_pattern!({}));
+                i.response.status(200);
+                i
+            },
+        )
+        .start_mock_server(None, None);
+
+    let base_url_raw = mock_server.url().to_string();
+    let base_url = base_url_raw.trim_end_matches('/');
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!(
+            "{}/v1/table/ns_with_tables.table_alpha/exists",
+            base_url
+        ))
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json")
+        .json(&json!({}))
+        .send()
+        .await
+        .expect("request failed");
+
+    assert_eq!(resp.status().as_u16(), 200);
+}
+
+#[tokio::test]
+async fn test_table_exists_returns_404() {
+    let error_body = error_response_matcher(
+        "TABLE_NOT_FOUND",
+        404,
+        "org.lance.namespace.TableNotFoundException",
+        "Table ns_existing.table_missing does not exist",
+    );
+
+    let mock_server = PactBuilder::new(CONSUMER, PROVIDER)
+        .interaction(
+            "Check existence of non-existent table returns 404",
+            "",
+            |mut i| {
+                i.given("table 'ns_existing.table_missing' does not exist");
+                i.request.method("POST");
+                i.request.path("/v1/table/ns_existing.table_missing/exists");
+                i.request.header("Content-Type", "application/json");
+                i.request.header("Accept", "application/json");
+                i.request.json_body(json_pattern!({}));
+                i.response.status(404);
+                i.response.content_type("application/json");
+                i.response.json_body(error_body);
+                i
+            },
+        )
+        .start_mock_server(None, None);
+
+    let base_url_raw = mock_server.url().to_string();
+    let base_url = base_url_raw.trim_end_matches('/');
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!(
+            "{}/v1/table/ns_existing.table_missing/exists",
+            base_url
+        ))
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json")
+        .json(&json!({}))
+        .send()
+        .await
+        .expect("request failed");
+
+    assert_eq!(resp.status().as_u16(), 404);
+    let body: Value = resp.json().await.expect("body parse failed");
+    assert!(body["error"].is_string());
+}
+
+#[tokio::test]
+async fn test_drop_table_returns_200() {
+    let mock_server = PactBuilder::new(CONSUMER, PROVIDER)
+        .interaction(
+            "Drop table_alpha in ns_with_tables returns 200",
+            "",
+            |mut i| {
+                i.given("table 'ns_with_tables.table_alpha' exists");
+                i.request.method("POST");
+                i.request.path("/v1/table/ns_with_tables.table_alpha/drop");
+                i.request.header("Accept", "application/json");
+                i.response.status(200);
+                i.response.content_type("application/json");
+                i.response.json_body(json_pattern!({}));
+                i
+            },
+        )
+        .start_mock_server(None, None);
+
+    let base_url_raw = mock_server.url().to_string();
+    let base_url = base_url_raw.trim_end_matches('/');
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!(
+            "{}/v1/table/ns_with_tables.table_alpha/drop",
+            base_url
+        ))
+        .header("Accept", "application/json")
+        .send()
+        .await
+        .expect("request failed");
+
+    assert_eq!(resp.status().as_u16(), 200);
+}
+
+#[tokio::test]
+async fn test_drop_table_returns_404() {
+    let error_body = error_response_matcher(
+        "TABLE_NOT_FOUND",
+        404,
+        "org.lance.namespace.TableNotFoundException",
+        "Table ns_existing.table_missing does not exist",
+    );
+
+    let mock_server = PactBuilder::new(CONSUMER, PROVIDER)
+        .interaction("Drop non-existent table returns 404", "", |mut i| {
+            i.given("table 'ns_existing.table_missing' does not exist");
+            i.request.method("POST");
+            i.request.path("/v1/table/ns_existing.table_missing/drop");
+            i.request.header("Accept", "application/json");
+            i.response.status(404);
+            i.response.content_type("application/json");
+            i.response.json_body(error_body);
+            i
+        })
+        .start_mock_server(None, None);
+
+    let base_url_raw = mock_server.url().to_string();
+    let base_url = base_url_raw.trim_end_matches('/');
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!(
+            "{}/v1/table/ns_existing.table_missing/drop",
+            base_url
+        ))
+        .header("Accept", "application/json")
+        .send()
+        .await
+        .expect("request failed");
+
+    assert_eq!(resp.status().as_u16(), 404);
+    let body: Value = resp.json().await.expect("body parse failed");
+    assert!(body["error"].is_string());
+}
+
+#[tokio::test]
+async fn test_register_table_returns_200() {
+    let mock_server = PactBuilder::new(CONSUMER, PROVIDER)
+        .interaction(
+            "Register new table in ns_existing returns 200",
+            "",
+            |mut i| {
+                i.given("namespace 'ns_existing' has 3 tables");
+                i.request.method("POST");
+                i.request.path("/v1/table/ns_existing.table_new/register");
+                i.request.header("Content-Type", "application/json");
+                i.request.header("Accept", "application/json");
+                i.request.json_body(json_pattern!({
+                    "location": "s3://example/ns_existing/table_new",
+                    "mode": "Create"
+                }));
+                i.response.status(200);
+                i.response.content_type("application/json");
+                i.response.json_body(json_pattern!({
+                    "location": like!("s3://example/ns_existing/table_new")
+                }));
+                i
+            },
+        )
+        .start_mock_server(None, None);
+
+    let base_url_raw = mock_server.url().to_string();
+    let base_url = base_url_raw.trim_end_matches('/');
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!(
+            "{}/v1/table/ns_existing.table_new/register",
+            base_url
+        ))
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json")
+        .json(&json!({
+            "location": "s3://example/ns_existing/table_new",
+            "mode": "Create"
+        }))
+        .send()
+        .await
+        .expect("request failed");
+
+    assert_eq!(resp.status().as_u16(), 200);
+    let body: Value = resp.json().await.expect("body parse failed");
+    assert!(body["location"].is_string());
+}
+
+#[tokio::test]
+async fn test_register_table_returns_409() {
+    let error_body = error_response_matcher(
+        "TABLE_ALREADY_EXISTS",
+        409,
+        "org.lance.namespace.TableAlreadyExistsException",
+        "Table ns_with_tables.table_alpha already exists",
+    );
+
+    let mock_server = PactBuilder::new(CONSUMER, PROVIDER)
+        .interaction(
+            "Register already-registered table returns 409",
+            "",
+            |mut i| {
+                i.given("table 'ns_with_tables.table_alpha' exists");
+                i.request.method("POST");
+                i.request
+                    .path("/v1/table/ns_with_tables.table_alpha/register");
+                i.request.header("Content-Type", "application/json");
+                i.request.header("Accept", "application/json");
+                i.request.json_body(json_pattern!({
+                    "location": "s3://example/ns_with_tables/table_alpha",
+                    "mode": "Create"
+                }));
+                i.response.status(409);
+                i.response.content_type("application/json");
+                i.response.json_body(error_body);
+                i
+            },
+        )
+        .start_mock_server(None, None);
+
+    let base_url_raw = mock_server.url().to_string();
+    let base_url = base_url_raw.trim_end_matches('/');
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!(
+            "{}/v1/table/ns_with_tables.table_alpha/register",
+            base_url
+        ))
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json")
+        .json(&json!({
+            "location": "s3://example/ns_with_tables/table_alpha",
+            "mode": "Create"
+        }))
+        .send()
+        .await
+        .expect("request failed");
+
+    assert_eq!(resp.status().as_u16(), 409);
+    let body: Value = resp.json().await.expect("body parse failed");
+    assert!(body["error"].is_string());
+}
+
+#[tokio::test]
+async fn test_deregister_table_returns_200() {
+    let mock_server = PactBuilder::new(CONSUMER, PROVIDER)
+        .interaction(
+            "Deregister table_alpha from ns_with_tables returns 200",
+            "",
+            |mut i| {
+                i.given("table 'ns_with_tables.table_alpha' exists");
+                i.request.method("POST");
+                i.request
+                    .path("/v1/table/ns_with_tables.table_alpha/deregister");
+                i.request.header("Content-Type", "application/json");
+                i.request.header("Accept", "application/json");
+                i.request.json_body(json_pattern!({}));
+                i.response.status(200);
+                i.response.content_type("application/json");
+                i.response.json_body(json_pattern!({}));
+                i
+            },
+        )
+        .start_mock_server(None, None);
+
+    let base_url_raw = mock_server.url().to_string();
+    let base_url = base_url_raw.trim_end_matches('/');
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!(
+            "{}/v1/table/ns_with_tables.table_alpha/deregister",
+            base_url
+        ))
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json")
+        .json(&json!({}))
+        .send()
+        .await
+        .expect("request failed");
+
+    assert_eq!(resp.status().as_u16(), 200);
+}
+
+#[tokio::test]
+async fn test_deregister_table_returns_404() {
+    let error_body = error_response_matcher(
+        "TABLE_NOT_FOUND",
+        404,
+        "org.lance.namespace.TableNotFoundException",
+        "Table ns_existing.table_missing does not exist",
+    );
+
+    let mock_server = PactBuilder::new(CONSUMER, PROVIDER)
+        .interaction("Deregister non-existent table returns 404", "", |mut i| {
+            i.given("table 'ns_existing.table_missing' does not exist");
+            i.request.method("POST");
+            i.request
+                .path("/v1/table/ns_existing.table_missing/deregister");
+            i.request.header("Content-Type", "application/json");
+            i.request.header("Accept", "application/json");
+            i.request.json_body(json_pattern!({}));
+            i.response.status(404);
+            i.response.content_type("application/json");
+            i.response.json_body(error_body);
+            i
+        })
+        .start_mock_server(None, None);
+
+    let base_url_raw = mock_server.url().to_string();
+    let base_url = base_url_raw.trim_end_matches('/');
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!(
+            "{}/v1/table/ns_existing.table_missing/deregister",
+            base_url
+        ))
+        .header("Content-Type", "application/json")
+        .header("Accept", "application/json")
+        .json(&json!({}))
+        .send()
+        .await
+        .expect("request failed");
+
+    assert_eq!(resp.status().as_u16(), 404);
+    let body: Value = resp.json().await.expect("body parse failed");
+    assert!(body["error"].is_string());
+}


### PR DESCRIPTION

## Summary

Introduce a **consumer-driven contract testing** suite for `lance-namespace`
based on the [Pact](https://docs.pact.io/) framework [pact-foundation](https://github.com/pact-foundation). The suite covers both
**Namespace** and **Table** REST APIs (11 operations × success + 4xx error
scenarios) and verifies three language clients (**Java / Python / Rust**)
against the Spring Boot reference provider.

## Problem

`lance-namespace` ships an OpenAPI spec plus auto-generated clients in Java,
Python and Rust, but so far there is **no automated mechanism** to guarantee
that:

1. Every client actually speaks the exact wire protocol the server implements.
2. Error responses (`ErrorResponse`) keep a consistent 4-field shape across
   languages and versions.
3. Breaking changes in request/response schemas are caught **before** they
   reach downstream consumers (pylance, rust callers, Spark/Ray integrations, …).

Typical symptoms without contract tests:

- A field rename on the server silently breaks a Python/Rust client at runtime.
- 4xx error bodies drift between languages (missing `error`, different casing,
  optional `instance`, etc.), making retries / user-facing messages inconsistent.
- Each client re-invents ad-hoc HTTP mocks, so regressions are only caught in
  integration environments.

## Solution

A complete Pact-based contract test suite, plus a small contract-pack folder
that hosts the generated pact files, plus CI wiring that runs all three
consumer suites and the Spring Boot provider verification on every PR.

### APIs under contract (success + 4xx for each)

| Group | Operations |
|---|---|
| **Namespace API** | `ListNamespaces`, `DescribeNamespace`, `CreateNamespace`, `DropNamespace`, `NamespaceExists` |
| **Table API**     | `ListTables`, `DescribeTable`, `TableExists`, `DropTable`, `RegisterTable`, `DeregisterTable` |



### Consumer interaction count

| Client | File | Interactions |
|---|---|---:|
| Java   | `NamespaceApiPactTest.java`   | **22** (`@Pact`) |
| Python | `test_namespace_api_pact.py`  | **10** |
| Python | `test_table_api_pact.py`      | **12** |
| Rust   | `namespace_api_tests.rs`      | **10** |
| Rust   | `table_api_tests.rs`          | **12** |
| **Total** | | **66** |

### Error body DSL

A reusable 4-field `ErrorResponse` shape (`error`, `code`, `type`, `instance`)
is enforced for every 4xx interaction, exposed as:

- Java:   `ErrorResponseDsl.java`
- Python: `error_response_dsl.py`
- Rust:   inline matchers under `tests/`

### Provider verification

`PactProviderTest` boots an isolated `PactTestApplication` (Spring Boot,
`pact` profile, no external deps) and replays consumer pacts via
`MockMvcTestTarget` + `@PactFolder`, with provider states served by
`PactStateController` using `InMemoryNamespaceFixtures`.

### CI pipeline (`.github/workflows/pact.yml`)

5 jobs, triggered on `push` and `pull_request`:

1. `consumer-java`   — Consumer Contract Tests (Java Apache Client)
2. `consumer-python` — Consumer Contract Tests (Python urllib3 Client)
3. `consumer-rust`   — Consumer Contract Tests (Rust reqwest Client)
4. `provider-verify` — Provider Verification Tests (Spring Boot Server),
   downloads `pact-files-java/python/rust` artifacts and replays them
5. `can-i-deploy`    — Can I Deploy Check (main branch gate)

`.pre-commit-config.yaml` wires `ci/pact_state_guard.sh` so any new
`@State("...")` string must be whitelisted before commit.

## Verification

- ✅ Java   Consumer + Provider — 22 consumer pacts generated; provider
  verification replays all interactions, **0 failures**
- ✅ Python Consumer — 22 tests pass locally (`pact-python`)
- ✅ Rust   Consumer — 22 tests pass locally (`pact_consumer` + `tokio`)
- ✅ Sample pacts can be dropped under `contract-pack/sample-pacts/` for
  offline provider verification without a live Pact Broker.

## How to run locally
- Java consumer (generates pacts under java/lance-namespace-pact-tests/target/pacts)
`cd java && make test-pact-consumer`
- Java provider verification (replays pacts via @PactFolder + MockMvcTestTarget)
`cd java && make test-pact-provider`
- Python consumer
`cd python && make test-pact-tests`
- Rust consumer
`cd rust && make test-pact-tests`

close: https://github.com/lance-format/lance-namespace/issues/340 
google doc: https://docs.google.com/document/d/1Wju0Ema10OkuDLs8tYzZ0xXqihX65k-OYabZbnc5NbI/edit?usp=sharing 