### PR TITLE
fix: pin central-publishing-maven-plugin to an existing version

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -84,6 +84,7 @@
 
         <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
         <maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
+        <central-publishing-maven-plugin.version>0.8.0</central-publishing-maven-plugin.version>
     </properties>
 
     <modules>
@@ -305,7 +306,7 @@
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.8.5</version>
+                        <version>${central-publishing-maven-plugin.version}</version>
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>ossrh</publishingServerId>


### PR DESCRIPTION
Fixes #353. The deploy-to-ossrh plugin version was being bumped in lockstep with the project version by the .bumpversion.toml `<version>` rule, pointing it at nonexistent plugin releases (0.8.1–0.8.5). Extracted it to a `central-publishing-maven-plugin.version` property pinned to 0.8.0 so the bumpversion matcher can no longer clobber it.