### PR TITLE
feat(spec): add source_task_size to RefreshMaterializedViewRequest

### DIFF
--- a/docs/src/namespace/operations/models/RefreshMaterializedViewRequest.md
+++ b/docs/src/namespace/operations/models/RefreshMaterializedViewRequest.md
@@ -13,6 +13,7 @@
 |**maxRowsPerFragment** | **Integer** | Optional maximum rows per fragment |  [optional] |
 |**concurrency** | **Integer** | Optional concurrency override |  [optional] |
 |**intraApplierConcurrency** | **Integer** | Optional intra-applier concurrency override |  [optional] |
+|**sourceTaskSize** | **Integer** | Optional number of source row ids per work item during expansion. Bounds per-actor memory for chunker materialized views.  |  [optional] |
 |**cluster** | **String** | Optional cluster name (operational override) |  [optional] |
 |**outputLimit** | **Integer** | Post-trim cap on view row count after expansion. Valid only for chunker materialized views; returns 400 if set on other kinds.  |  [optional] |
 |**manifest** | **String** | Optional inline JSON-serialized GenevaManifest. Operational override for this refresh only; does not mutate the view&#39;s snapshotted manifest. When omitted, the manifest stored in the view&#39;s metadata is used.  |  [optional] |

--- a/docs/src/spec.yaml
+++ b/docs/src/spec.yaml
@@ -5503,6 +5503,13 @@ components:
             - integer
             - "null"
           description: Optional intra-applier concurrency override
+        source_task_size:
+          type:
+            - integer
+            - "null"
+          description: |
+            Optional number of source row ids per work item during expansion.
+            Bounds per-actor memory for chunker materialized views.
         cluster:
           type:
             - string

--- a/python/lance_namespace_urllib3_client/docs/RefreshMaterializedViewRequest.md
+++ b/python/lance_namespace_urllib3_client/docs/RefreshMaterializedViewRequest.md
@@ -11,6 +11,7 @@ Name | Type | Description | Notes
 **max_rows_per_fragment** | **int** | Optional maximum rows per fragment | [optional] 
 **concurrency** | **int** | Optional concurrency override | [optional] 
 **intra_applier_concurrency** | **int** | Optional intra-applier concurrency override | [optional] 
+**source_task_size** | **int** | Optional number of source row ids per work item during expansion. Bounds per-actor memory for chunker materialized views.  | [optional] 
 **cluster** | **str** | Optional cluster name (operational override) | [optional] 
 **output_limit** | **int** | Post-trim cap on view row count after expansion. Valid only for chunker materialized views; returns 400 if set on other kinds.  | [optional] 
 **manifest** | **str** | Optional inline JSON-serialized GenevaManifest. Operational override for this refresh only; does not mutate the view&#39;s snapshotted manifest. When omitted, the manifest stored in the view&#39;s metadata is used.  | [optional] 

--- a/python/lance_namespace_urllib3_client/lance_namespace_urllib3_client/models/refresh_materialized_view_request.py
+++ b/python/lance_namespace_urllib3_client/lance_namespace_urllib3_client/models/refresh_materialized_view_request.py
@@ -33,10 +33,11 @@ class RefreshMaterializedViewRequest(BaseModel):
     max_rows_per_fragment: Optional[StrictInt] = Field(default=None, description="Optional maximum rows per fragment")
     concurrency: Optional[StrictInt] = Field(default=None, description="Optional concurrency override")
     intra_applier_concurrency: Optional[StrictInt] = Field(default=None, description="Optional intra-applier concurrency override")
+    source_task_size: Optional[StrictInt] = Field(default=None, description="Optional number of source row ids per work item during expansion. Bounds per-actor memory for chunker materialized views. ")
     cluster: Optional[StrictStr] = Field(default=None, description="Optional cluster name (operational override)")
     output_limit: Optional[StrictInt] = Field(default=None, description="Post-trim cap on view row count after expansion. Valid only for chunker materialized views; returns 400 if set on other kinds. ")
     manifest: Optional[StrictStr] = Field(default=None, description="Optional inline JSON-serialized GenevaManifest. Operational override for this refresh only; does not mutate the view's snapshotted manifest. When omitted, the manifest stored in the view's metadata is used. ")
-    __properties: ClassVar[List[str]] = ["identity", "id", "src_version", "max_rows_per_fragment", "concurrency", "intra_applier_concurrency", "cluster", "output_limit", "manifest"]
+    __properties: ClassVar[List[str]] = ["identity", "id", "src_version", "max_rows_per_fragment", "concurrency", "intra_applier_concurrency", "source_task_size", "cluster", "output_limit", "manifest"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -100,6 +101,11 @@ class RefreshMaterializedViewRequest(BaseModel):
         if self.intra_applier_concurrency is None and "intra_applier_concurrency" in self.model_fields_set:
             _dict['intra_applier_concurrency'] = None
 
+        # set to None if source_task_size (nullable) is None
+        # and model_fields_set contains the field
+        if self.source_task_size is None and "source_task_size" in self.model_fields_set:
+            _dict['source_task_size'] = None
+
         # set to None if cluster (nullable) is None
         # and model_fields_set contains the field
         if self.cluster is None and "cluster" in self.model_fields_set:
@@ -133,6 +139,7 @@ class RefreshMaterializedViewRequest(BaseModel):
             "max_rows_per_fragment": obj.get("max_rows_per_fragment"),
             "concurrency": obj.get("concurrency"),
             "intra_applier_concurrency": obj.get("intra_applier_concurrency"),
+            "source_task_size": obj.get("source_task_size"),
             "cluster": obj.get("cluster"),
             "output_limit": obj.get("output_limit"),
             "manifest": obj.get("manifest")

--- a/python/lance_namespace_urllib3_client/test/test_refresh_materialized_view_request.py
+++ b/python/lance_namespace_urllib3_client/test/test_refresh_materialized_view_request.py
@@ -45,6 +45,7 @@ class TestRefreshMaterializedViewRequest(unittest.TestCase):
                 max_rows_per_fragment = 56,
                 concurrency = 56,
                 intra_applier_concurrency = 56,
+                source_task_size = 56,
                 cluster = '',
                 output_limit = 56,
                 manifest = ''

--- a/rust/lance-namespace-reqwest-client/docs/RefreshMaterializedViewRequest.md
+++ b/rust/lance-namespace-reqwest-client/docs/RefreshMaterializedViewRequest.md
@@ -10,6 +10,7 @@ Name | Type | Description | Notes
 **max_rows_per_fragment** | Option<**i32**> | Optional maximum rows per fragment | [optional]
 **concurrency** | Option<**i32**> | Optional concurrency override | [optional]
 **intra_applier_concurrency** | Option<**i32**> | Optional intra-applier concurrency override | [optional]
+**source_task_size** | Option<**i32**> | Optional number of source row ids per work item during expansion. Bounds per-actor memory for chunker materialized views. | [optional]
 **cluster** | Option<**String**> | Optional cluster name (operational override) | [optional]
 **output_limit** | Option<**i32**> | Post-trim cap on view row count after expansion. Valid only for chunker materialized views; returns 400 if set on other kinds.  | [optional]
 **manifest** | Option<**String**> | Optional inline JSON-serialized GenevaManifest. Operational override for this refresh only; does not mutate the view's snapshotted manifest. When omitted, the manifest stored in the view's metadata is used.  | [optional]

--- a/rust/lance-namespace-reqwest-client/src/models/refresh_materialized_view_request.rs
+++ b/rust/lance-namespace-reqwest-client/src/models/refresh_materialized_view_request.rs
@@ -30,6 +30,9 @@ pub struct RefreshMaterializedViewRequest {
     /// Optional intra-applier concurrency override
     #[serde(rename = "intra_applier_concurrency", default, with = "::serde_with::rust::double_option", skip_serializing_if = "Option::is_none")]
     pub intra_applier_concurrency: Option<Option<i32>>,
+    /// Optional number of source row ids per work item during expansion. Bounds per-actor memory for chunker materialized views.
+    #[serde(rename = "source_task_size", default, with = "::serde_with::rust::double_option", skip_serializing_if = "Option::is_none")]
+    pub source_task_size: Option<Option<i32>>,
     /// Optional cluster name (operational override)
     #[serde(rename = "cluster", default, with = "::serde_with::rust::double_option", skip_serializing_if = "Option::is_none")]
     pub cluster: Option<Option<String>>,
@@ -50,6 +53,7 @@ impl RefreshMaterializedViewRequest {
             max_rows_per_fragment: None,
             concurrency: None,
             intra_applier_concurrency: None,
+            source_task_size: None,
             cluster: None,
             output_limit: None,
             manifest: None,


### PR DESCRIPTION
## Context

Chunker-backed materialized-view refresh bounds per-actor memory by controlling how many source row IDs go into one expansion work item. That knob (`source_task_size`) needs to travel over the enterprise `db://` path, but `RefreshMaterializedViewRequest` had no field for it — so it was silently dropped on remote refresh.

## Change

Adds an optional `source_task_size` integer to `RefreshMaterializedViewRequest`, mirroring the existing optional overrides (`max_rows_per_fragment`, `intra_applier_concurrency`, …). Regenerated the Python (urllib3) and Rust (reqwest) client models and their docs; updated the spec model doc and the urllib3 test stub.

Geneva feature-detects the field, so it forwards `source_task_size` once a release carries it and degrades gracefully on older versions.

## Test plan

- `openapi-spec-validator docs/src/spec.yaml` → OK
- urllib3 model round-trips `source_task_size` (set / omitted / from_dict)

## Follow-ups (separate repos)

- lance: bump `lance-namespace-reqwest-client`, rebuild `RestNamespace` bindings, publish a pylance beta.
- geneva + sophon: pin the new versions so the field transits end-to-end at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)