### PR TITLE
feat(java): propagate source_task_size to generated Java clients

### DIFF
--- a/java/lance-namespace-apache-client/api/openapi.yaml
+++ b/java/lance-namespace-apache-client/api/openapi.yaml
@@ -8383,6 +8383,7 @@ components:
     RefreshMaterializedViewRequest:
       example:
         src_version: 0
+        source_task_size: 5
         cluster: cluster
         identity:
           api_key: api_key
@@ -8393,7 +8394,7 @@ components:
         - id
         max_rows_per_fragment: 6
         intra_applier_concurrency: 5
-        output_limit: 5
+        output_limit: 2
         concurrency: 1
       properties:
         identity:
@@ -8417,6 +8418,12 @@ components:
           type: integer
         intra_applier_concurrency:
           description: Optional intra-applier concurrency override
+          nullable: true
+          type: integer
+        source_task_size:
+          description: |
+            Optional number of source row ids per work item during expansion.
+            Bounds per-actor memory for chunker materialized views.
           nullable: true
           type: integer
         cluster:

--- a/java/lance-namespace-apache-client/docs/RefreshMaterializedViewRequest.md
+++ b/java/lance-namespace-apache-client/docs/RefreshMaterializedViewRequest.md
@@ -13,6 +13,7 @@
 |**maxRowsPerFragment** | **Integer** | Optional maximum rows per fragment |  [optional] |
 |**concurrency** | **Integer** | Optional concurrency override |  [optional] |
 |**intraApplierConcurrency** | **Integer** | Optional intra-applier concurrency override |  [optional] |
+|**sourceTaskSize** | **Integer** | Optional number of source row ids per work item during expansion. Bounds per-actor memory for chunker materialized views.  |  [optional] |
 |**cluster** | **String** | Optional cluster name (operational override) |  [optional] |
 |**outputLimit** | **Integer** | Post-trim cap on view row count after expansion. Valid only for chunker materialized views; returns 400 if set on other kinds.  |  [optional] |
 |**manifest** | **String** | Optional inline JSON-serialized GenevaManifest. Operational override for this refresh only; does not mutate the view&#39;s snapshotted manifest. When omitted, the manifest stored in the view&#39;s metadata is used.  |  [optional] |

--- a/java/lance-namespace-apache-client/src/main/java/org/lance/namespace/model/RefreshMaterializedViewRequest.java
+++ b/java/lance-namespace-apache-client/src/main/java/org/lance/namespace/model/RefreshMaterializedViewRequest.java
@@ -35,6 +35,7 @@ import java.util.StringJoiner;
   RefreshMaterializedViewRequest.JSON_PROPERTY_MAX_ROWS_PER_FRAGMENT,
   RefreshMaterializedViewRequest.JSON_PROPERTY_CONCURRENCY,
   RefreshMaterializedViewRequest.JSON_PROPERTY_INTRA_APPLIER_CONCURRENCY,
+  RefreshMaterializedViewRequest.JSON_PROPERTY_SOURCE_TASK_SIZE,
   RefreshMaterializedViewRequest.JSON_PROPERTY_CLUSTER,
   RefreshMaterializedViewRequest.JSON_PROPERTY_OUTPUT_LIMIT,
   RefreshMaterializedViewRequest.JSON_PROPERTY_MANIFEST
@@ -68,6 +69,11 @@ public class RefreshMaterializedViewRequest {
 
   @javax.annotation.Nullable
   private JsonNullable<Integer> intraApplierConcurrency = JsonNullable.<Integer>undefined();
+
+  public static final String JSON_PROPERTY_SOURCE_TASK_SIZE = "source_task_size";
+
+  @javax.annotation.Nullable
+  private JsonNullable<Integer> sourceTaskSize = JsonNullable.<Integer>undefined();
 
   public static final String JSON_PROPERTY_CLUSTER = "cluster";
 
@@ -275,6 +281,40 @@ public class RefreshMaterializedViewRequest {
     this.intraApplierConcurrency = JsonNullable.<Integer>of(intraApplierConcurrency);
   }
 
+  public RefreshMaterializedViewRequest sourceTaskSize(
+      @javax.annotation.Nullable Integer sourceTaskSize) {
+    this.sourceTaskSize = JsonNullable.<Integer>of(sourceTaskSize);
+
+    return this;
+  }
+
+  /**
+   * Optional number of source row ids per work item during expansion. Bounds per-actor memory for
+   * chunker materialized views.
+   *
+   * @return sourceTaskSize
+   */
+  @javax.annotation.Nullable
+  @JsonIgnore
+  public Integer getSourceTaskSize() {
+    return sourceTaskSize.orElse(null);
+  }
+
+  @JsonProperty(JSON_PROPERTY_SOURCE_TASK_SIZE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public JsonNullable<Integer> getSourceTaskSize_JsonNullable() {
+    return sourceTaskSize;
+  }
+
+  @JsonProperty(JSON_PROPERTY_SOURCE_TASK_SIZE)
+  public void setSourceTaskSize_JsonNullable(JsonNullable<Integer> sourceTaskSize) {
+    this.sourceTaskSize = sourceTaskSize;
+  }
+
+  public void setSourceTaskSize(@javax.annotation.Nullable Integer sourceTaskSize) {
+    this.sourceTaskSize = JsonNullable.<Integer>of(sourceTaskSize);
+  }
+
   public RefreshMaterializedViewRequest cluster(@javax.annotation.Nullable String cluster) {
     this.cluster = JsonNullable.<String>of(cluster);
 
@@ -393,6 +433,7 @@ public class RefreshMaterializedViewRequest {
         && equalsNullable(this.concurrency, refreshMaterializedViewRequest.concurrency)
         && equalsNullable(
             this.intraApplierConcurrency, refreshMaterializedViewRequest.intraApplierConcurrency)
+        && equalsNullable(this.sourceTaskSize, refreshMaterializedViewRequest.sourceTaskSize)
         && equalsNullable(this.cluster, refreshMaterializedViewRequest.cluster)
         && equalsNullable(this.outputLimit, refreshMaterializedViewRequest.outputLimit)
         && equalsNullable(this.manifest, refreshMaterializedViewRequest.manifest);
@@ -416,6 +457,7 @@ public class RefreshMaterializedViewRequest {
         hashCodeNullable(maxRowsPerFragment),
         hashCodeNullable(concurrency),
         hashCodeNullable(intraApplierConcurrency),
+        hashCodeNullable(sourceTaskSize),
         hashCodeNullable(cluster),
         hashCodeNullable(outputLimit),
         hashCodeNullable(manifest));
@@ -440,6 +482,7 @@ public class RefreshMaterializedViewRequest {
     sb.append("    intraApplierConcurrency: ")
         .append(toIndentedString(intraApplierConcurrency))
         .append("\n");
+    sb.append("    sourceTaskSize: ").append(toIndentedString(sourceTaskSize)).append("\n");
     sb.append("    cluster: ").append(toIndentedString(cluster)).append("\n");
     sb.append("    outputLimit: ").append(toIndentedString(outputLimit)).append("\n");
     sb.append("    manifest: ").append(toIndentedString(manifest)).append("\n");
@@ -572,6 +615,22 @@ public class RefreshMaterializedViewRequest {
                 prefix,
                 suffix,
                 URLEncoder.encode(String.valueOf(getIntraApplierConcurrency()), "UTF-8")
+                    .replaceAll("\\+", "%20")));
+      } catch (UnsupportedEncodingException e) {
+        // Should never happen, UTF-8 is always supported
+        throw new RuntimeException(e);
+      }
+    }
+
+    // add `source_task_size` to the URL query string
+    if (getSourceTaskSize() != null) {
+      try {
+        joiner.add(
+            String.format(
+                "%ssource_task_size%s=%s",
+                prefix,
+                suffix,
+                URLEncoder.encode(String.valueOf(getSourceTaskSize()), "UTF-8")
                     .replaceAll("\\+", "%20")));
       } catch (UnsupportedEncodingException e) {
         // Should never happen, UTF-8 is always supported

--- a/java/lance-namespace-async-client/api/openapi.yaml
+++ b/java/lance-namespace-async-client/api/openapi.yaml
@@ -8383,6 +8383,7 @@ components:
     RefreshMaterializedViewRequest:
       example:
         src_version: 0
+        source_task_size: 5
         cluster: cluster
         identity:
           api_key: api_key
@@ -8393,7 +8394,7 @@ components:
         - id
         max_rows_per_fragment: 6
         intra_applier_concurrency: 5
-        output_limit: 5
+        output_limit: 2
         concurrency: 1
       properties:
         identity:
@@ -8417,6 +8418,12 @@ components:
           type: integer
         intra_applier_concurrency:
           description: Optional intra-applier concurrency override
+          nullable: true
+          type: integer
+        source_task_size:
+          description: |
+            Optional number of source row ids per work item during expansion.
+            Bounds per-actor memory for chunker materialized views.
           nullable: true
           type: integer
         cluster:

--- a/java/lance-namespace-async-client/docs/RefreshMaterializedViewRequest.md
+++ b/java/lance-namespace-async-client/docs/RefreshMaterializedViewRequest.md
@@ -13,6 +13,7 @@
 |**maxRowsPerFragment** | **Integer** | Optional maximum rows per fragment |  [optional] |
 |**concurrency** | **Integer** | Optional concurrency override |  [optional] |
 |**intraApplierConcurrency** | **Integer** | Optional intra-applier concurrency override |  [optional] |
+|**sourceTaskSize** | **Integer** | Optional number of source row ids per work item during expansion. Bounds per-actor memory for chunker materialized views.  |  [optional] |
 |**cluster** | **String** | Optional cluster name (operational override) |  [optional] |
 |**outputLimit** | **Integer** | Post-trim cap on view row count after expansion. Valid only for chunker materialized views; returns 400 if set on other kinds.  |  [optional] |
 |**manifest** | **String** | Optional inline JSON-serialized GenevaManifest. Operational override for this refresh only; does not mutate the view&#39;s snapshotted manifest. When omitted, the manifest stored in the view&#39;s metadata is used.  |  [optional] |

--- a/java/lance-namespace-async-client/src/main/java/org/lance/namespace/model/RefreshMaterializedViewRequest.java
+++ b/java/lance-namespace-async-client/src/main/java/org/lance/namespace/model/RefreshMaterializedViewRequest.java
@@ -35,6 +35,7 @@ import java.util.StringJoiner;
   RefreshMaterializedViewRequest.JSON_PROPERTY_MAX_ROWS_PER_FRAGMENT,
   RefreshMaterializedViewRequest.JSON_PROPERTY_CONCURRENCY,
   RefreshMaterializedViewRequest.JSON_PROPERTY_INTRA_APPLIER_CONCURRENCY,
+  RefreshMaterializedViewRequest.JSON_PROPERTY_SOURCE_TASK_SIZE,
   RefreshMaterializedViewRequest.JSON_PROPERTY_CLUSTER,
   RefreshMaterializedViewRequest.JSON_PROPERTY_OUTPUT_LIMIT,
   RefreshMaterializedViewRequest.JSON_PROPERTY_MANIFEST
@@ -60,6 +61,9 @@ public class RefreshMaterializedViewRequest {
 
   public static final String JSON_PROPERTY_INTRA_APPLIER_CONCURRENCY = "intra_applier_concurrency";
   private JsonNullable<Integer> intraApplierConcurrency = JsonNullable.<Integer>undefined();
+
+  public static final String JSON_PROPERTY_SOURCE_TASK_SIZE = "source_task_size";
+  private JsonNullable<Integer> sourceTaskSize = JsonNullable.<Integer>undefined();
 
   public static final String JSON_PROPERTY_CLUSTER = "cluster";
   private JsonNullable<String> cluster = JsonNullable.<String>undefined();
@@ -255,6 +259,39 @@ public class RefreshMaterializedViewRequest {
     this.intraApplierConcurrency = JsonNullable.<Integer>of(intraApplierConcurrency);
   }
 
+  public RefreshMaterializedViewRequest sourceTaskSize(
+      @javax.annotation.Nullable Integer sourceTaskSize) {
+    this.sourceTaskSize = JsonNullable.<Integer>of(sourceTaskSize);
+    return this;
+  }
+
+  /**
+   * Optional number of source row ids per work item during expansion. Bounds per-actor memory for
+   * chunker materialized views.
+   *
+   * @return sourceTaskSize
+   */
+  @javax.annotation.Nullable
+  @JsonIgnore
+  public Integer getSourceTaskSize() {
+    return sourceTaskSize.orElse(null);
+  }
+
+  @JsonProperty(JSON_PROPERTY_SOURCE_TASK_SIZE)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public JsonNullable<Integer> getSourceTaskSize_JsonNullable() {
+    return sourceTaskSize;
+  }
+
+  @JsonProperty(JSON_PROPERTY_SOURCE_TASK_SIZE)
+  public void setSourceTaskSize_JsonNullable(JsonNullable<Integer> sourceTaskSize) {
+    this.sourceTaskSize = sourceTaskSize;
+  }
+
+  public void setSourceTaskSize(@javax.annotation.Nullable Integer sourceTaskSize) {
+    this.sourceTaskSize = JsonNullable.<Integer>of(sourceTaskSize);
+  }
+
   public RefreshMaterializedViewRequest cluster(@javax.annotation.Nullable String cluster) {
     this.cluster = JsonNullable.<String>of(cluster);
     return this;
@@ -371,6 +408,7 @@ public class RefreshMaterializedViewRequest {
         && equalsNullable(this.concurrency, refreshMaterializedViewRequest.concurrency)
         && equalsNullable(
             this.intraApplierConcurrency, refreshMaterializedViewRequest.intraApplierConcurrency)
+        && equalsNullable(this.sourceTaskSize, refreshMaterializedViewRequest.sourceTaskSize)
         && equalsNullable(this.cluster, refreshMaterializedViewRequest.cluster)
         && equalsNullable(this.outputLimit, refreshMaterializedViewRequest.outputLimit)
         && equalsNullable(this.manifest, refreshMaterializedViewRequest.manifest);
@@ -394,6 +432,7 @@ public class RefreshMaterializedViewRequest {
         hashCodeNullable(maxRowsPerFragment),
         hashCodeNullable(concurrency),
         hashCodeNullable(intraApplierConcurrency),
+        hashCodeNullable(sourceTaskSize),
         hashCodeNullable(cluster),
         hashCodeNullable(outputLimit),
         hashCodeNullable(manifest));
@@ -418,6 +457,7 @@ public class RefreshMaterializedViewRequest {
     sb.append("    intraApplierConcurrency: ")
         .append(toIndentedString(intraApplierConcurrency))
         .append("\n");
+    sb.append("    sourceTaskSize: ").append(toIndentedString(sourceTaskSize)).append("\n");
     sb.append("    cluster: ").append(toIndentedString(cluster)).append("\n");
     sb.append("    outputLimit: ").append(toIndentedString(outputLimit)).append("\n");
     sb.append("    manifest: ").append(toIndentedString(manifest)).append("\n");
@@ -521,6 +561,14 @@ public class RefreshMaterializedViewRequest {
               prefix,
               suffix,
               ApiClient.urlEncode(ApiClient.valueToString(getIntraApplierConcurrency()))));
+    }
+
+    // add `source_task_size` to the URL query string
+    if (getSourceTaskSize() != null) {
+      joiner.add(
+          String.format(
+              "%ssource_task_size%s=%s",
+              prefix, suffix, ApiClient.urlEncode(ApiClient.valueToString(getSourceTaskSize()))));
     }
 
     // add `cluster` to the URL query string

--- a/java/lance-namespace-springboot-server/src/main/java/org/lance/namespace/server/springboot/model/RefreshMaterializedViewRequest.java
+++ b/java/lance-namespace-springboot-server/src/main/java/org/lance/namespace/server/springboot/model/RefreshMaterializedViewRequest.java
@@ -42,6 +42,8 @@ public class RefreshMaterializedViewRequest {
 
   private Integer intraApplierConcurrency = null;
 
+  private Integer sourceTaskSize = null;
+
   private String cluster = null;
 
   private Integer outputLimit = null;
@@ -192,6 +194,31 @@ public class RefreshMaterializedViewRequest {
     this.intraApplierConcurrency = intraApplierConcurrency;
   }
 
+  public RefreshMaterializedViewRequest sourceTaskSize(Integer sourceTaskSize) {
+    this.sourceTaskSize = sourceTaskSize;
+    return this;
+  }
+
+  /**
+   * Optional number of source row ids per work item during expansion. Bounds per-actor memory for
+   * chunker materialized views.
+   *
+   * @return sourceTaskSize
+   */
+  @Schema(
+      name = "source_task_size",
+      description =
+          "Optional number of source row ids per work item during expansion. Bounds per-actor memory for chunker materialized views. ",
+      requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @JsonProperty("source_task_size")
+  public Integer getSourceTaskSize() {
+    return sourceTaskSize;
+  }
+
+  public void setSourceTaskSize(Integer sourceTaskSize) {
+    this.sourceTaskSize = sourceTaskSize;
+  }
+
   public RefreshMaterializedViewRequest cluster(String cluster) {
     this.cluster = cluster;
     return this;
@@ -284,6 +311,7 @@ public class RefreshMaterializedViewRequest {
         && Objects.equals(this.concurrency, refreshMaterializedViewRequest.concurrency)
         && Objects.equals(
             this.intraApplierConcurrency, refreshMaterializedViewRequest.intraApplierConcurrency)
+        && Objects.equals(this.sourceTaskSize, refreshMaterializedViewRequest.sourceTaskSize)
         && Objects.equals(this.cluster, refreshMaterializedViewRequest.cluster)
         && Objects.equals(this.outputLimit, refreshMaterializedViewRequest.outputLimit)
         && Objects.equals(this.manifest, refreshMaterializedViewRequest.manifest);
@@ -298,6 +326,7 @@ public class RefreshMaterializedViewRequest {
         maxRowsPerFragment,
         concurrency,
         intraApplierConcurrency,
+        sourceTaskSize,
         cluster,
         outputLimit,
         manifest);
@@ -315,6 +344,7 @@ public class RefreshMaterializedViewRequest {
     sb.append("    intraApplierConcurrency: ")
         .append(toIndentedString(intraApplierConcurrency))
         .append("\n");
+    sb.append("    sourceTaskSize: ").append(toIndentedString(sourceTaskSize)).append("\n");
     sb.append("    cluster: ").append(toIndentedString(cluster)).append("\n");
     sb.append("    outputLimit: ").append(toIndentedString(outputLimit)).append("\n");
     sb.append("    manifest: ").append(toIndentedString(manifest)).append("\n");

--- a/rust/lance-namespace-reqwest-client/docs/RefreshMaterializedViewRequest.md
+++ b/rust/lance-namespace-reqwest-client/docs/RefreshMaterializedViewRequest.md
@@ -10,7 +10,7 @@ Name | Type | Description | Notes
 **max_rows_per_fragment** | Option<**i32**> | Optional maximum rows per fragment | [optional]
 **concurrency** | Option<**i32**> | Optional concurrency override | [optional]
 **intra_applier_concurrency** | Option<**i32**> | Optional intra-applier concurrency override | [optional]
-**source_task_size** | Option<**i32**> | Optional number of source row ids per work item during expansion. Bounds per-actor memory for chunker materialized views. | [optional]
+**source_task_size** | Option<**i32**> | Optional number of source row ids per work item during expansion. Bounds per-actor memory for chunker materialized views.  | [optional]
 **cluster** | Option<**String**> | Optional cluster name (operational override) | [optional]
 **output_limit** | Option<**i32**> | Post-trim cap on view row count after expansion. Valid only for chunker materialized views; returns 400 if set on other kinds.  | [optional]
 **manifest** | Option<**String**> | Optional inline JSON-serialized GenevaManifest. Operational override for this refresh only; does not mutate the view's snapshotted manifest. When omitted, the manifest stored in the view's metadata is used.  | [optional]

--- a/rust/lance-namespace-reqwest-client/src/models/refresh_materialized_view_request.rs
+++ b/rust/lance-namespace-reqwest-client/src/models/refresh_materialized_view_request.rs
@@ -30,7 +30,7 @@ pub struct RefreshMaterializedViewRequest {
     /// Optional intra-applier concurrency override
     #[serde(rename = "intra_applier_concurrency", default, with = "::serde_with::rust::double_option", skip_serializing_if = "Option::is_none")]
     pub intra_applier_concurrency: Option<Option<i32>>,
-    /// Optional number of source row ids per work item during expansion. Bounds per-actor memory for chunker materialized views.
+    /// Optional number of source row ids per work item during expansion. Bounds per-actor memory for chunker materialized views. 
     #[serde(rename = "source_task_size", default, with = "::serde_with::rust::double_option", skip_serializing_if = "Option::is_none")]
     pub source_task_size: Option<Option<i32>>,
     /// Optional cluster name (operational override)


### PR DESCRIPTION
## Context

[#355](https://github.com/lance-format/lance-namespace/pull/355) added the optional `source_task_size` field to `RefreshMaterializedViewRequest` in the spec and regenerated only the Python (urllib3) and Rust (reqwest) clients.

The three generated **Java** modules were left out:

- `lance-namespace-apache-client`
- `lance-namespace-async-client`
- `lance-namespace-springboot-server`

As a result the field was silently dropped on the Java REST path, even though `docs/src/spec.yaml`, the Java-derived model doc (`docs/src/namespace/operations/models/RefreshMaterializedViewRequest.md`), and the Python/Rust clients all carry it. (Per CLAUDE.md the model doc is *generated from the Java Apache client*, so the doc and the Java source had drifted apart.)

## Change

Regenerated the Java modules from the spec via `make gen-java`, adding `sourceTaskSize` and its accessors to all three `RefreshMaterializedViewRequest` models (plus the embedded `api/openapi.yaml` copies). No hand edits — pure generator output.

## Test plan

- `make gen-java` → BUILD SUCCESS
- `./mvnw compile -pl lance-namespace-apache-client,lance-namespace-async-client,lance-namespace-springboot-server -am` → OK
- `./mvnw checkstyle:check spotless:check` on the same modules → exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)