### PR TITLE
feat: declare and backfill expression-computed columns

### DIFF
--- a/docs/src/spec.yaml
+++ b/docs/src/spec.yaml
@@ -1579,7 +1579,8 @@ paths:
       operationId: AlterTableBackfillColumns
       description: |
         Trigger an asynchronous backfill job for a computed column on table `id`.
-        The column must be a virtual (UDF-backed) column. Returns a job ID for tracking.
+        The column must be a virtual (UDF-backed) column or a computed column
+        declared with an expression binding. Returns a job ID for tracking.
       requestBody:
         required: true
         content:
@@ -5258,12 +5259,27 @@ components:
           type:
             - string
             - "null"
-          description: SQL expression for the column (optional if virtual_column is specified)
+          description: |-
+            SQL expression for the column (optional if virtual_column or computed
+            is specified). Evaluated once over existing rows; nothing is stored,
+            so rows appended later read null.
+        computed:
+          type:
+            - string
+            - "null"
+          description: |-
+            SQL expression declaring a maintained computed column (optional if
+            expression or virtual_column is specified). The column is added
+            all-null with the expression persisted as its binding in field
+            metadata; its type and input columns are inferred from the
+            expression. Rows are filled by backfill, never at declaration.
         virtual_column:
           oneOf:
             - type: "null"
             - $ref: "#/components/schemas/AddVirtualColumnEntry"
-          description: Virtual column definition (optional if expression is specified)
+          description: |-
+            Virtual column definition (optional if expression or computed is
+            specified)
 
     AddVirtualColumnEntry:
       type: object

--- a/java/lance-namespace-apache-client/api/openapi.yaml
+++ b/java/lance-namespace-apache-client/api/openapi.yaml
@@ -1901,7 +1901,8 @@ paths:
     post:
       description: |
         Trigger an asynchronous backfill job for a computed column on table `id`.
-        The column must be a virtual (UDF-backed) column. Returns a job ID for tracking.
+        The column must be a virtual (UDF-backed) column or a computed column
+        declared with an expression binding. Returns a job ID for tracking.
       operationId: AlterTableBackfillColumns
       parameters:
       - $ref: '#/components/parameters/id'
@@ -9142,6 +9143,7 @@ components:
           auth_token: auth_token
         new_columns:
         - expression: expression
+          computed: computed
           name: name
           virtual_column:
             outputs:
@@ -9171,6 +9173,7 @@ components:
             auto_backfill: true
             udf_version: udf_version
         - expression: expression
+          computed: computed
           name: name
           virtual_column:
             outputs:
@@ -9246,6 +9249,7 @@ components:
     AddColumnsEntry:
       example:
         expression: expression
+        computed: computed
         name: name
         virtual_column:
           outputs:
@@ -9279,8 +9283,19 @@ components:
           description: Name of the new column
           type: string
         expression:
-          description: SQL expression for the column (optional if virtual_column is
-            specified)
+          description: |-
+            SQL expression for the column (optional if virtual_column or computed
+            is specified). Evaluated once over existing rows; nothing is stored,
+            so rows appended later read null.
+          nullable: true
+          type: string
+        computed:
+          description: |-
+            SQL expression declaring a maintained computed column (optional if
+            expression or virtual_column is specified). The column is added
+            all-null with the expression persisted as its binding in field
+            metadata; its type and input columns are inferred from the
+            expression. Rows are filled by backfill, never at declaration.
           nullable: true
           type: string
         virtual_column:

--- a/java/lance-namespace-apache-client/docs/AddColumnsEntry.md
+++ b/java/lance-namespace-apache-client/docs/AddColumnsEntry.md
@@ -8,7 +8,8 @@
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
 |**name** | **String** | Name of the new column |  |
-|**expression** | **String** | SQL expression for the column (optional if virtual_column is specified) |  [optional] |
+|**expression** | **String** | SQL expression for the column (optional if virtual_column or computed is specified). Evaluated once over existing rows; nothing is stored, so rows appended later read null. |  [optional] |
+|**computed** | **String** | SQL expression declaring a maintained computed column (optional if expression or virtual_column is specified). The column is added all-null with the expression persisted as its binding in field metadata; its type and input columns are inferred from the expression. Rows are filled by backfill, never at declaration. |  [optional] |
 |**virtualColumn** | [**AddVirtualColumnEntry**](AddVirtualColumnEntry.md) |  |  [optional] |
 
 

--- a/java/lance-namespace-apache-client/docs/DataApi.md
+++ b/java/lance-namespace-apache-client/docs/DataApi.md
@@ -117,7 +117,7 @@ public class Example {
 
 Trigger an async column backfill job
 
-Trigger an asynchronous backfill job for a computed column on table &#x60;id&#x60;. The column must be a virtual (UDF-backed) column. Returns a job ID for tracking. 
+Trigger an asynchronous backfill job for a computed column on table &#x60;id&#x60;. The column must be a virtual (UDF-backed) column or a computed column declared with an expression binding. Returns a job ID for tracking. 
 
 ### Example
 

--- a/java/lance-namespace-apache-client/docs/TableApi.md
+++ b/java/lance-namespace-apache-client/docs/TableApi.md
@@ -240,7 +240,7 @@ public class Example {
 
 Trigger an async column backfill job
 
-Trigger an asynchronous backfill job for a computed column on table &#x60;id&#x60;. The column must be a virtual (UDF-backed) column. Returns a job ID for tracking. 
+Trigger an asynchronous backfill job for a computed column on table &#x60;id&#x60;. The column must be a virtual (UDF-backed) column or a computed column declared with an expression binding. Returns a job ID for tracking. 
 
 ### Example
 

--- a/java/lance-namespace-apache-client/src/main/java/org/lance/namespace/client/apache/api/DataApi.java
+++ b/java/lance-namespace-apache-client/src/main/java/org/lance/namespace/client/apache/api/DataApi.java
@@ -165,8 +165,8 @@ public class DataApi extends BaseApi {
 
   /**
    * Trigger an async column backfill job Trigger an asynchronous backfill job for a computed column
-   * on table &#x60;id&#x60;. The column must be a virtual (UDF-backed) column. Returns a job ID for
-   * tracking.
+   * on table &#x60;id&#x60;. The column must be a virtual (UDF-backed) column or a computed column
+   * declared with an expression binding. Returns a job ID for tracking.
    *
    * @param id &#x60;string identifier&#x60; of an object in a namespace, following the Lance
    *     Namespace spec. When the value is equal to the delimiter, it represents the root namespace.
@@ -190,8 +190,8 @@ public class DataApi extends BaseApi {
 
   /**
    * Trigger an async column backfill job Trigger an asynchronous backfill job for a computed column
-   * on table &#x60;id&#x60;. The column must be a virtual (UDF-backed) column. Returns a job ID for
-   * tracking.
+   * on table &#x60;id&#x60;. The column must be a virtual (UDF-backed) column or a computed column
+   * declared with an expression binding. Returns a job ID for tracking.
    *
    * @param id &#x60;string identifier&#x60; of an object in a namespace, following the Lance
    *     Namespace spec. When the value is equal to the delimiter, it represents the root namespace.

--- a/java/lance-namespace-apache-client/src/main/java/org/lance/namespace/client/apache/api/TableApi.java
+++ b/java/lance-namespace-apache-client/src/main/java/org/lance/namespace/client/apache/api/TableApi.java
@@ -320,8 +320,8 @@ public class TableApi extends BaseApi {
 
   /**
    * Trigger an async column backfill job Trigger an asynchronous backfill job for a computed column
-   * on table &#x60;id&#x60;. The column must be a virtual (UDF-backed) column. Returns a job ID for
-   * tracking.
+   * on table &#x60;id&#x60;. The column must be a virtual (UDF-backed) column or a computed column
+   * declared with an expression binding. Returns a job ID for tracking.
    *
    * @param id &#x60;string identifier&#x60; of an object in a namespace, following the Lance
    *     Namespace spec. When the value is equal to the delimiter, it represents the root namespace.
@@ -345,8 +345,8 @@ public class TableApi extends BaseApi {
 
   /**
    * Trigger an async column backfill job Trigger an asynchronous backfill job for a computed column
-   * on table &#x60;id&#x60;. The column must be a virtual (UDF-backed) column. Returns a job ID for
-   * tracking.
+   * on table &#x60;id&#x60;. The column must be a virtual (UDF-backed) column or a computed column
+   * declared with an expression binding. Returns a job ID for tracking.
    *
    * @param id &#x60;string identifier&#x60; of an object in a namespace, following the Lance
    *     Namespace spec. When the value is equal to the delimiter, it represents the root namespace.

--- a/java/lance-namespace-apache-client/src/main/java/org/lance/namespace/model/AddColumnsEntry.java
+++ b/java/lance-namespace-apache-client/src/main/java/org/lance/namespace/model/AddColumnsEntry.java
@@ -29,6 +29,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   AddColumnsEntry.JSON_PROPERTY_NAME,
   AddColumnsEntry.JSON_PROPERTY_EXPRESSION,
+  AddColumnsEntry.JSON_PROPERTY_COMPUTED,
   AddColumnsEntry.JSON_PROPERTY_VIRTUAL_COLUMN
 })
 @javax.annotation.Generated(
@@ -42,6 +43,11 @@ public class AddColumnsEntry {
 
   @javax.annotation.Nullable
   private JsonNullable<String> expression = JsonNullable.<String>undefined();
+
+  public static final String JSON_PROPERTY_COMPUTED = "computed";
+
+  @javax.annotation.Nullable
+  private JsonNullable<String> computed = JsonNullable.<String>undefined();
 
   public static final String JSON_PROPERTY_VIRTUAL_COLUMN = "virtual_column";
 
@@ -82,7 +88,8 @@ public class AddColumnsEntry {
   }
 
   /**
-   * SQL expression for the column (optional if virtual_column is specified)
+   * SQL expression for the column (optional if virtual_column or computed is specified). Evaluated
+   * once over existing rows; nothing is stored, so rows appended later read null.
    *
    * @return expression
    */
@@ -105,6 +112,41 @@ public class AddColumnsEntry {
 
   public void setExpression(@javax.annotation.Nullable String expression) {
     this.expression = JsonNullable.<String>of(expression);
+  }
+
+  public AddColumnsEntry computed(@javax.annotation.Nullable String computed) {
+    this.computed = JsonNullable.<String>of(computed);
+
+    return this;
+  }
+
+  /**
+   * SQL expression declaring a maintained computed column (optional if expression or virtual_column
+   * is specified). The column is added all-null with the expression persisted as its binding in
+   * field metadata; its type and input columns are inferred from the expression. Rows are filled by
+   * backfill, never at declaration.
+   *
+   * @return computed
+   */
+  @javax.annotation.Nullable
+  @JsonIgnore
+  public String getComputed() {
+    return computed.orElse(null);
+  }
+
+  @JsonProperty(JSON_PROPERTY_COMPUTED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public JsonNullable<String> getComputed_JsonNullable() {
+    return computed;
+  }
+
+  @JsonProperty(JSON_PROPERTY_COMPUTED)
+  public void setComputed_JsonNullable(JsonNullable<String> computed) {
+    this.computed = computed;
+  }
+
+  public void setComputed(@javax.annotation.Nullable String computed) {
+    this.computed = JsonNullable.<String>of(computed);
   }
 
   public AddColumnsEntry virtualColumn(
@@ -151,6 +193,7 @@ public class AddColumnsEntry {
     AddColumnsEntry addColumnsEntry = (AddColumnsEntry) o;
     return Objects.equals(this.name, addColumnsEntry.name)
         && equalsNullable(this.expression, addColumnsEntry.expression)
+        && equalsNullable(this.computed, addColumnsEntry.computed)
         && equalsNullable(this.virtualColumn, addColumnsEntry.virtualColumn);
   }
 
@@ -165,7 +208,11 @@ public class AddColumnsEntry {
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, hashCodeNullable(expression), hashCodeNullable(virtualColumn));
+    return Objects.hash(
+        name,
+        hashCodeNullable(expression),
+        hashCodeNullable(computed),
+        hashCodeNullable(virtualColumn));
   }
 
   private static <T> int hashCodeNullable(JsonNullable<T> a) {
@@ -181,6 +228,7 @@ public class AddColumnsEntry {
     sb.append("class AddColumnsEntry {\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("    expression: ").append(toIndentedString(expression)).append("\n");
+    sb.append("    computed: ").append(toIndentedString(computed)).append("\n");
     sb.append("    virtualColumn: ").append(toIndentedString(virtualColumn)).append("\n");
     sb.append("}");
     return sb.toString();
@@ -252,6 +300,22 @@ public class AddColumnsEntry {
                 prefix,
                 suffix,
                 URLEncoder.encode(String.valueOf(getExpression()), "UTF-8")
+                    .replaceAll("\\+", "%20")));
+      } catch (UnsupportedEncodingException e) {
+        // Should never happen, UTF-8 is always supported
+        throw new RuntimeException(e);
+      }
+    }
+
+    // add `computed` to the URL query string
+    if (getComputed() != null) {
+      try {
+        joiner.add(
+            String.format(
+                "%scomputed%s=%s",
+                prefix,
+                suffix,
+                URLEncoder.encode(String.valueOf(getComputed()), "UTF-8")
                     .replaceAll("\\+", "%20")));
       } catch (UnsupportedEncodingException e) {
         // Should never happen, UTF-8 is always supported

--- a/java/lance-namespace-async-client/api/openapi.yaml
+++ b/java/lance-namespace-async-client/api/openapi.yaml
@@ -1901,7 +1901,8 @@ paths:
     post:
       description: |
         Trigger an asynchronous backfill job for a computed column on table `id`.
-        The column must be a virtual (UDF-backed) column. Returns a job ID for tracking.
+        The column must be a virtual (UDF-backed) column or a computed column
+        declared with an expression binding. Returns a job ID for tracking.
       operationId: AlterTableBackfillColumns
       parameters:
       - $ref: '#/components/parameters/id'
@@ -9142,6 +9143,7 @@ components:
           auth_token: auth_token
         new_columns:
         - expression: expression
+          computed: computed
           name: name
           virtual_column:
             outputs:
@@ -9171,6 +9173,7 @@ components:
             auto_backfill: true
             udf_version: udf_version
         - expression: expression
+          computed: computed
           name: name
           virtual_column:
             outputs:
@@ -9246,6 +9249,7 @@ components:
     AddColumnsEntry:
       example:
         expression: expression
+        computed: computed
         name: name
         virtual_column:
           outputs:
@@ -9279,8 +9283,19 @@ components:
           description: Name of the new column
           type: string
         expression:
-          description: SQL expression for the column (optional if virtual_column is
-            specified)
+          description: |-
+            SQL expression for the column (optional if virtual_column or computed
+            is specified). Evaluated once over existing rows; nothing is stored,
+            so rows appended later read null.
+          nullable: true
+          type: string
+        computed:
+          description: |-
+            SQL expression declaring a maintained computed column (optional if
+            expression or virtual_column is specified). The column is added
+            all-null with the expression persisted as its binding in field
+            metadata; its type and input columns are inferred from the
+            expression. Rows are filled by backfill, never at declaration.
           nullable: true
           type: string
         virtual_column:

--- a/java/lance-namespace-async-client/docs/AddColumnsEntry.md
+++ b/java/lance-namespace-async-client/docs/AddColumnsEntry.md
@@ -8,7 +8,8 @@
 | Name | Type | Description | Notes |
 |------------ | ------------- | ------------- | -------------|
 |**name** | **String** | Name of the new column |  |
-|**expression** | **String** | SQL expression for the column (optional if virtual_column is specified) |  [optional] |
+|**expression** | **String** | SQL expression for the column (optional if virtual_column or computed is specified). Evaluated once over existing rows; nothing is stored, so rows appended later read null. |  [optional] |
+|**computed** | **String** | SQL expression declaring a maintained computed column (optional if expression or virtual_column is specified). The column is added all-null with the expression persisted as its binding in field metadata; its type and input columns are inferred from the expression. Rows are filled by backfill, never at declaration. |  [optional] |
 |**virtualColumn** | [**AddVirtualColumnEntry**](AddVirtualColumnEntry.md) |  |  [optional] |
 
 

--- a/java/lance-namespace-async-client/docs/DataApi.md
+++ b/java/lance-namespace-async-client/docs/DataApi.md
@@ -232,7 +232,7 @@ CompletableFuture<ApiResponse<[**AlterTableAddColumnsResponse**](AlterTableAddCo
 
 Trigger an async column backfill job
 
-Trigger an asynchronous backfill job for a computed column on table &#x60;id&#x60;. The column must be a virtual (UDF-backed) column. Returns a job ID for tracking. 
+Trigger an asynchronous backfill job for a computed column on table &#x60;id&#x60;. The column must be a virtual (UDF-backed) column or a computed column declared with an expression binding. Returns a job ID for tracking. 
 
 ### Example
 
@@ -323,7 +323,7 @@ CompletableFuture<[**AlterTableBackfillColumnsResponse**](AlterTableBackfillColu
 
 Trigger an async column backfill job
 
-Trigger an asynchronous backfill job for a computed column on table &#x60;id&#x60;. The column must be a virtual (UDF-backed) column. Returns a job ID for tracking. 
+Trigger an asynchronous backfill job for a computed column on table &#x60;id&#x60;. The column must be a virtual (UDF-backed) column or a computed column declared with an expression binding. Returns a job ID for tracking. 
 
 ### Example
 

--- a/java/lance-namespace-async-client/docs/TableApi.md
+++ b/java/lance-namespace-async-client/docs/TableApi.md
@@ -489,7 +489,7 @@ CompletableFuture<ApiResponse<[**AlterTableAlterColumnsResponse**](AlterTableAlt
 
 Trigger an async column backfill job
 
-Trigger an asynchronous backfill job for a computed column on table &#x60;id&#x60;. The column must be a virtual (UDF-backed) column. Returns a job ID for tracking. 
+Trigger an asynchronous backfill job for a computed column on table &#x60;id&#x60;. The column must be a virtual (UDF-backed) column or a computed column declared with an expression binding. Returns a job ID for tracking. 
 
 ### Example
 
@@ -580,7 +580,7 @@ CompletableFuture<[**AlterTableBackfillColumnsResponse**](AlterTableBackfillColu
 
 Trigger an async column backfill job
 
-Trigger an asynchronous backfill job for a computed column on table &#x60;id&#x60;. The column must be a virtual (UDF-backed) column. Returns a job ID for tracking. 
+Trigger an asynchronous backfill job for a computed column on table &#x60;id&#x60;. The column must be a virtual (UDF-backed) column or a computed column declared with an expression binding. Returns a job ID for tracking. 
 
 ### Example
 

--- a/java/lance-namespace-async-client/src/main/java/org/lance/namespace/client/async/api/DataApi.java
+++ b/java/lance-namespace-async-client/src/main/java/org/lance/namespace/client/async/api/DataApi.java
@@ -250,8 +250,8 @@ public class DataApi {
 
   /**
    * Trigger an async column backfill job Trigger an asynchronous backfill job for a computed column
-   * on table &#x60;id&#x60;. The column must be a virtual (UDF-backed) column. Returns a job ID for
-   * tracking.
+   * on table &#x60;id&#x60;. The column must be a virtual (UDF-backed) column or a computed column
+   * declared with an expression binding. Returns a job ID for tracking.
    *
    * @param id &#x60;string identifier&#x60; of an object in a namespace, following the Lance
    *     Namespace spec. When the value is equal to the delimiter, it represents the root namespace.
@@ -299,8 +299,8 @@ public class DataApi {
 
   /**
    * Trigger an async column backfill job Trigger an asynchronous backfill job for a computed column
-   * on table &#x60;id&#x60;. The column must be a virtual (UDF-backed) column. Returns a job ID for
-   * tracking.
+   * on table &#x60;id&#x60;. The column must be a virtual (UDF-backed) column or a computed column
+   * declared with an expression binding. Returns a job ID for tracking.
    *
    * @param id &#x60;string identifier&#x60; of an object in a namespace, following the Lance
    *     Namespace spec. When the value is equal to the delimiter, it represents the root namespace.

--- a/java/lance-namespace-async-client/src/main/java/org/lance/namespace/client/async/api/TableApi.java
+++ b/java/lance-namespace-async-client/src/main/java/org/lance/namespace/client/async/api/TableApi.java
@@ -460,8 +460,8 @@ public class TableApi {
 
   /**
    * Trigger an async column backfill job Trigger an asynchronous backfill job for a computed column
-   * on table &#x60;id&#x60;. The column must be a virtual (UDF-backed) column. Returns a job ID for
-   * tracking.
+   * on table &#x60;id&#x60;. The column must be a virtual (UDF-backed) column or a computed column
+   * declared with an expression binding. Returns a job ID for tracking.
    *
    * @param id &#x60;string identifier&#x60; of an object in a namespace, following the Lance
    *     Namespace spec. When the value is equal to the delimiter, it represents the root namespace.
@@ -509,8 +509,8 @@ public class TableApi {
 
   /**
    * Trigger an async column backfill job Trigger an asynchronous backfill job for a computed column
-   * on table &#x60;id&#x60;. The column must be a virtual (UDF-backed) column. Returns a job ID for
-   * tracking.
+   * on table &#x60;id&#x60;. The column must be a virtual (UDF-backed) column or a computed column
+   * declared with an expression binding. Returns a job ID for tracking.
    *
    * @param id &#x60;string identifier&#x60; of an object in a namespace, following the Lance
    *     Namespace spec. When the value is equal to the delimiter, it represents the root namespace.

--- a/java/lance-namespace-async-client/src/main/java/org/lance/namespace/model/AddColumnsEntry.java
+++ b/java/lance-namespace-async-client/src/main/java/org/lance/namespace/model/AddColumnsEntry.java
@@ -29,6 +29,7 @@ import java.util.StringJoiner;
 @JsonPropertyOrder({
   AddColumnsEntry.JSON_PROPERTY_NAME,
   AddColumnsEntry.JSON_PROPERTY_EXPRESSION,
+  AddColumnsEntry.JSON_PROPERTY_COMPUTED,
   AddColumnsEntry.JSON_PROPERTY_VIRTUAL_COLUMN
 })
 @javax.annotation.Generated(
@@ -40,6 +41,9 @@ public class AddColumnsEntry {
 
   public static final String JSON_PROPERTY_EXPRESSION = "expression";
   private JsonNullable<String> expression = JsonNullable.<String>undefined();
+
+  public static final String JSON_PROPERTY_COMPUTED = "computed";
+  private JsonNullable<String> computed = JsonNullable.<String>undefined();
 
   public static final String JSON_PROPERTY_VIRTUAL_COLUMN = "virtual_column";
   private JsonNullable<AddVirtualColumnEntry> virtualColumn =
@@ -76,7 +80,8 @@ public class AddColumnsEntry {
   }
 
   /**
-   * SQL expression for the column (optional if virtual_column is specified)
+   * SQL expression for the column (optional if virtual_column or computed is specified). Evaluated
+   * once over existing rows; nothing is stored, so rows appended later read null.
    *
    * @return expression
    */
@@ -99,6 +104,40 @@ public class AddColumnsEntry {
 
   public void setExpression(@javax.annotation.Nullable String expression) {
     this.expression = JsonNullable.<String>of(expression);
+  }
+
+  public AddColumnsEntry computed(@javax.annotation.Nullable String computed) {
+    this.computed = JsonNullable.<String>of(computed);
+    return this;
+  }
+
+  /**
+   * SQL expression declaring a maintained computed column (optional if expression or virtual_column
+   * is specified). The column is added all-null with the expression persisted as its binding in
+   * field metadata; its type and input columns are inferred from the expression. Rows are filled by
+   * backfill, never at declaration.
+   *
+   * @return computed
+   */
+  @javax.annotation.Nullable
+  @JsonIgnore
+  public String getComputed() {
+    return computed.orElse(null);
+  }
+
+  @JsonProperty(JSON_PROPERTY_COMPUTED)
+  @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
+  public JsonNullable<String> getComputed_JsonNullable() {
+    return computed;
+  }
+
+  @JsonProperty(JSON_PROPERTY_COMPUTED)
+  public void setComputed_JsonNullable(JsonNullable<String> computed) {
+    this.computed = computed;
+  }
+
+  public void setComputed(@javax.annotation.Nullable String computed) {
+    this.computed = JsonNullable.<String>of(computed);
   }
 
   public AddColumnsEntry virtualColumn(
@@ -145,6 +184,7 @@ public class AddColumnsEntry {
     AddColumnsEntry addColumnsEntry = (AddColumnsEntry) o;
     return Objects.equals(this.name, addColumnsEntry.name)
         && equalsNullable(this.expression, addColumnsEntry.expression)
+        && equalsNullable(this.computed, addColumnsEntry.computed)
         && equalsNullable(this.virtualColumn, addColumnsEntry.virtualColumn);
   }
 
@@ -159,7 +199,11 @@ public class AddColumnsEntry {
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, hashCodeNullable(expression), hashCodeNullable(virtualColumn));
+    return Objects.hash(
+        name,
+        hashCodeNullable(expression),
+        hashCodeNullable(computed),
+        hashCodeNullable(virtualColumn));
   }
 
   private static <T> int hashCodeNullable(JsonNullable<T> a) {
@@ -175,6 +219,7 @@ public class AddColumnsEntry {
     sb.append("class AddColumnsEntry {\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("    expression: ").append(toIndentedString(expression)).append("\n");
+    sb.append("    computed: ").append(toIndentedString(computed)).append("\n");
     sb.append("    virtualColumn: ").append(toIndentedString(virtualColumn)).append("\n");
     sb.append("}");
     return sb.toString();
@@ -236,6 +281,14 @@ public class AddColumnsEntry {
           String.format(
               "%sexpression%s=%s",
               prefix, suffix, ApiClient.urlEncode(ApiClient.valueToString(getExpression()))));
+    }
+
+    // add `computed` to the URL query string
+    if (getComputed() != null) {
+      joiner.add(
+          String.format(
+              "%scomputed%s=%s",
+              prefix, suffix, ApiClient.urlEncode(ApiClient.valueToString(getComputed()))));
     }
 
     // add `virtual_column` to the URL query string

--- a/java/lance-namespace-springboot-server/src/main/java/org/lance/namespace/server/springboot/api/TableApi.java
+++ b/java/lance-namespace-springboot-server/src/main/java/org/lance/namespace/server/springboot/api/TableApi.java
@@ -470,7 +470,8 @@ public interface TableApi {
   /**
    * POST /v1/table/{id}/backfill_column : Trigger an async column backfill job Trigger an
    * asynchronous backfill job for a computed column on table &#x60;id&#x60;. The column must be a
-   * virtual (UDF-backed) column. Returns a job ID for tracking.
+   * virtual (UDF-backed) column or a computed column declared with an expression binding. Returns a
+   * job ID for tracking.
    *
    * @param id &#x60;string identifier&#x60; of an object in a namespace, following the Lance
    *     Namespace spec. When the value is equal to the delimiter, it represents the root namespace.
@@ -497,7 +498,7 @@ public interface TableApi {
       operationId = "alterTableBackfillColumns",
       summary = "Trigger an async column backfill job",
       description =
-          "Trigger an asynchronous backfill job for a computed column on table `id`. The column must be a virtual (UDF-backed) column. Returns a job ID for tracking. ",
+          "Trigger an asynchronous backfill job for a computed column on table `id`. The column must be a virtual (UDF-backed) column or a computed column declared with an expression binding. Returns a job ID for tracking. ",
       tags = {"Table", "Data"},
       responses = {
         @ApiResponse(

--- a/java/lance-namespace-springboot-server/src/main/java/org/lance/namespace/server/springboot/model/AddColumnsEntry.java
+++ b/java/lance-namespace-springboot-server/src/main/java/org/lance/namespace/server/springboot/model/AddColumnsEntry.java
@@ -32,6 +32,8 @@ public class AddColumnsEntry {
 
   private String expression = null;
 
+  private String computed = null;
+
   private AddVirtualColumnEntry virtualColumn = null;
 
   public AddColumnsEntry() {
@@ -73,13 +75,15 @@ public class AddColumnsEntry {
   }
 
   /**
-   * SQL expression for the column (optional if virtual_column is specified)
+   * SQL expression for the column (optional if virtual_column or computed is specified). Evaluated
+   * once over existing rows; nothing is stored, so rows appended later read null.
    *
    * @return expression
    */
   @Schema(
       name = "expression",
-      description = "SQL expression for the column (optional if virtual_column is specified)",
+      description =
+          "SQL expression for the column (optional if virtual_column or computed is specified). Evaluated once over existing rows; nothing is stored, so rows appended later read null.",
       requiredMode = Schema.RequiredMode.NOT_REQUIRED)
   @JsonProperty("expression")
   public String getExpression() {
@@ -88,6 +92,33 @@ public class AddColumnsEntry {
 
   public void setExpression(String expression) {
     this.expression = expression;
+  }
+
+  public AddColumnsEntry computed(String computed) {
+    this.computed = computed;
+    return this;
+  }
+
+  /**
+   * SQL expression declaring a maintained computed column (optional if expression or virtual_column
+   * is specified). The column is added all-null with the expression persisted as its binding in
+   * field metadata; its type and input columns are inferred from the expression. Rows are filled by
+   * backfill, never at declaration.
+   *
+   * @return computed
+   */
+  @Schema(
+      name = "computed",
+      description =
+          "SQL expression declaring a maintained computed column (optional if expression or virtual_column is specified). The column is added all-null with the expression persisted as its binding in field metadata; its type and input columns are inferred from the expression. Rows are filled by backfill, never at declaration.",
+      requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+  @JsonProperty("computed")
+  public String getComputed() {
+    return computed;
+  }
+
+  public void setComputed(String computed) {
+    this.computed = computed;
   }
 
   public AddColumnsEntry virtualColumn(AddVirtualColumnEntry virtualColumn) {
@@ -122,12 +153,13 @@ public class AddColumnsEntry {
     AddColumnsEntry addColumnsEntry = (AddColumnsEntry) o;
     return Objects.equals(this.name, addColumnsEntry.name)
         && Objects.equals(this.expression, addColumnsEntry.expression)
+        && Objects.equals(this.computed, addColumnsEntry.computed)
         && Objects.equals(this.virtualColumn, addColumnsEntry.virtualColumn);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(name, expression, virtualColumn);
+    return Objects.hash(name, expression, computed, virtualColumn);
   }
 
   @Override
@@ -136,6 +168,7 @@ public class AddColumnsEntry {
     sb.append("class AddColumnsEntry {\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("    expression: ").append(toIndentedString(expression)).append("\n");
+    sb.append("    computed: ").append(toIndentedString(computed)).append("\n");
     sb.append("    virtualColumn: ").append(toIndentedString(virtualColumn)).append("\n");
     sb.append("}");
     return sb.toString();

--- a/python/lance_namespace_urllib3_client/docs/AddColumnsEntry.md
+++ b/python/lance_namespace_urllib3_client/docs/AddColumnsEntry.md
@@ -6,7 +6,8 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **str** | Name of the new column | 
-**expression** | **str** | SQL expression for the column (optional if virtual_column is specified) | [optional] 
+**expression** | **str** | SQL expression for the column (optional if virtual_column or computed is specified). Evaluated once over existing rows; nothing is stored, so rows appended later read null. | [optional] 
+**computed** | **str** | SQL expression declaring a maintained computed column (optional if expression or virtual_column is specified). The column is added all-null with the expression persisted as its binding in field metadata; its type and input columns are inferred from the expression. Rows are filled by backfill, never at declaration. | [optional] 
 **virtual_column** | [**AddVirtualColumnEntry**](AddVirtualColumnEntry.md) |  | [optional] 
 
 ## Example

--- a/python/lance_namespace_urllib3_client/docs/DataApi.md
+++ b/python/lance_namespace_urllib3_client/docs/DataApi.md
@@ -125,7 +125,8 @@ Name | Type | Description  | Notes
 Trigger an async column backfill job
 
 Trigger an asynchronous backfill job for a computed column on table `id`.
-The column must be a virtual (UDF-backed) column. Returns a job ID for tracking.
+The column must be a virtual (UDF-backed) column or a computed column
+declared with an expression binding. Returns a job ID for tracking.
 
 
 ### Example

--- a/python/lance_namespace_urllib3_client/docs/TableApi.md
+++ b/python/lance_namespace_urllib3_client/docs/TableApi.md
@@ -257,7 +257,8 @@ Name | Type | Description  | Notes
 Trigger an async column backfill job
 
 Trigger an asynchronous backfill job for a computed column on table `id`.
-The column must be a virtual (UDF-backed) column. Returns a job ID for tracking.
+The column must be a virtual (UDF-backed) column or a computed column
+declared with an expression binding. Returns a job ID for tracking.
 
 
 ### Example

--- a/python/lance_namespace_urllib3_client/lance_namespace_urllib3_client/api/data_api.py
+++ b/python/lance_namespace_urllib3_client/lance_namespace_urllib3_client/api/data_api.py
@@ -404,7 +404,7 @@ class DataApi:
     ) -> AlterTableBackfillColumnsResponse:
         """Trigger an async column backfill job
 
-        Trigger an asynchronous backfill job for a computed column on table `id`. The column must be a virtual (UDF-backed) column. Returns a job ID for tracking. 
+        Trigger an asynchronous backfill job for a computed column on table `id`. The column must be a virtual (UDF-backed) column or a computed column declared with an expression binding. Returns a job ID for tracking. 
 
         :param id: `string identifier` of an object in a namespace, following the Lance Namespace spec. When the value is equal to the delimiter, it represents the root namespace. For example, `v1/namespace/$/list` performs a `ListNamespace` on the root namespace.  (required)
         :type id: str
@@ -485,7 +485,7 @@ class DataApi:
     ) -> ApiResponse[AlterTableBackfillColumnsResponse]:
         """Trigger an async column backfill job
 
-        Trigger an asynchronous backfill job for a computed column on table `id`. The column must be a virtual (UDF-backed) column. Returns a job ID for tracking. 
+        Trigger an asynchronous backfill job for a computed column on table `id`. The column must be a virtual (UDF-backed) column or a computed column declared with an expression binding. Returns a job ID for tracking. 
 
         :param id: `string identifier` of an object in a namespace, following the Lance Namespace spec. When the value is equal to the delimiter, it represents the root namespace. For example, `v1/namespace/$/list` performs a `ListNamespace` on the root namespace.  (required)
         :type id: str
@@ -566,7 +566,7 @@ class DataApi:
     ) -> RESTResponseType:
         """Trigger an async column backfill job
 
-        Trigger an asynchronous backfill job for a computed column on table `id`. The column must be a virtual (UDF-backed) column. Returns a job ID for tracking. 
+        Trigger an asynchronous backfill job for a computed column on table `id`. The column must be a virtual (UDF-backed) column or a computed column declared with an expression binding. Returns a job ID for tracking. 
 
         :param id: `string identifier` of an object in a namespace, following the Lance Namespace spec. When the value is equal to the delimiter, it represents the root namespace. For example, `v1/namespace/$/list` performs a `ListNamespace` on the root namespace.  (required)
         :type id: str

--- a/python/lance_namespace_urllib3_client/lance_namespace_urllib3_client/api/table_api.py
+++ b/python/lance_namespace_urllib3_client/lance_namespace_urllib3_client/api/table_api.py
@@ -782,7 +782,7 @@ class TableApi:
     ) -> AlterTableBackfillColumnsResponse:
         """Trigger an async column backfill job
 
-        Trigger an asynchronous backfill job for a computed column on table `id`. The column must be a virtual (UDF-backed) column. Returns a job ID for tracking. 
+        Trigger an asynchronous backfill job for a computed column on table `id`. The column must be a virtual (UDF-backed) column or a computed column declared with an expression binding. Returns a job ID for tracking. 
 
         :param id: `string identifier` of an object in a namespace, following the Lance Namespace spec. When the value is equal to the delimiter, it represents the root namespace. For example, `v1/namespace/$/list` performs a `ListNamespace` on the root namespace.  (required)
         :type id: str
@@ -863,7 +863,7 @@ class TableApi:
     ) -> ApiResponse[AlterTableBackfillColumnsResponse]:
         """Trigger an async column backfill job
 
-        Trigger an asynchronous backfill job for a computed column on table `id`. The column must be a virtual (UDF-backed) column. Returns a job ID for tracking. 
+        Trigger an asynchronous backfill job for a computed column on table `id`. The column must be a virtual (UDF-backed) column or a computed column declared with an expression binding. Returns a job ID for tracking. 
 
         :param id: `string identifier` of an object in a namespace, following the Lance Namespace spec. When the value is equal to the delimiter, it represents the root namespace. For example, `v1/namespace/$/list` performs a `ListNamespace` on the root namespace.  (required)
         :type id: str
@@ -944,7 +944,7 @@ class TableApi:
     ) -> RESTResponseType:
         """Trigger an async column backfill job
 
-        Trigger an asynchronous backfill job for a computed column on table `id`. The column must be a virtual (UDF-backed) column. Returns a job ID for tracking. 
+        Trigger an asynchronous backfill job for a computed column on table `id`. The column must be a virtual (UDF-backed) column or a computed column declared with an expression binding. Returns a job ID for tracking. 
 
         :param id: `string identifier` of an object in a namespace, following the Lance Namespace spec. When the value is equal to the delimiter, it represents the root namespace. For example, `v1/namespace/$/list` performs a `ListNamespace` on the root namespace.  (required)
         :type id: str

--- a/python/lance_namespace_urllib3_client/lance_namespace_urllib3_client/models/add_columns_entry.py
+++ b/python/lance_namespace_urllib3_client/lance_namespace_urllib3_client/models/add_columns_entry.py
@@ -28,9 +28,10 @@ class AddColumnsEntry(BaseModel):
     AddColumnsEntry
     """ # noqa: E501
     name: StrictStr = Field(description="Name of the new column")
-    expression: Optional[StrictStr] = Field(default=None, description="SQL expression for the column (optional if virtual_column is specified)")
+    expression: Optional[StrictStr] = Field(default=None, description="SQL expression for the column (optional if virtual_column or computed is specified). Evaluated once over existing rows; nothing is stored, so rows appended later read null.")
+    computed: Optional[StrictStr] = Field(default=None, description="SQL expression declaring a maintained computed column (optional if expression or virtual_column is specified). The column is added all-null with the expression persisted as its binding in field metadata; its type and input columns are inferred from the expression. Rows are filled by backfill, never at declaration.")
     virtual_column: Optional[AddVirtualColumnEntry] = None
-    __properties: ClassVar[List[str]] = ["name", "expression", "virtual_column"]
+    __properties: ClassVar[List[str]] = ["name", "expression", "computed", "virtual_column"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -79,6 +80,11 @@ class AddColumnsEntry(BaseModel):
         if self.expression is None and "expression" in self.model_fields_set:
             _dict['expression'] = None
 
+        # set to None if computed (nullable) is None
+        # and model_fields_set contains the field
+        if self.computed is None and "computed" in self.model_fields_set:
+            _dict['computed'] = None
+
         # set to None if virtual_column (nullable) is None
         # and model_fields_set contains the field
         if self.virtual_column is None and "virtual_column" in self.model_fields_set:
@@ -98,6 +104,7 @@ class AddColumnsEntry(BaseModel):
         _obj = cls.model_validate({
             "name": obj.get("name"),
             "expression": obj.get("expression"),
+            "computed": obj.get("computed"),
             "virtual_column": AddVirtualColumnEntry.from_dict(obj["virtual_column"]) if obj.get("virtual_column") is not None else None
         })
         return _obj

--- a/python/lance_namespace_urllib3_client/test/test_add_columns_entry.py
+++ b/python/lance_namespace_urllib3_client/test/test_add_columns_entry.py
@@ -37,6 +37,7 @@ class TestAddColumnsEntry(unittest.TestCase):
             return AddColumnsEntry(
                 name = '',
                 expression = '',
+                computed = '',
                 virtual_column = lance_namespace_urllib3_client.models.add_virtual_column_entry.AddVirtualColumnEntry(
                     input_columns = [
                         '0'

--- a/python/lance_namespace_urllib3_client/test/test_alter_table_add_columns_request.py
+++ b/python/lance_namespace_urllib3_client/test/test_alter_table_add_columns_request.py
@@ -49,6 +49,7 @@ class TestAlterTableAddColumnsRequest(unittest.TestCase):
                     lance_namespace_urllib3_client.models.add_columns_entry.AddColumnsEntry(
                         name = '', 
                         expression = '', 
+                        computed = '', 
                         virtual_column = lance_namespace_urllib3_client.models.add_virtual_column_entry.AddVirtualColumnEntry(
                             input_columns = [
                                 '0'
@@ -82,6 +83,7 @@ class TestAlterTableAddColumnsRequest(unittest.TestCase):
                     lance_namespace_urllib3_client.models.add_columns_entry.AddColumnsEntry(
                         name = '', 
                         expression = '', 
+                        computed = '', 
                         virtual_column = lance_namespace_urllib3_client.models.add_virtual_column_entry.AddVirtualColumnEntry(
                             input_columns = [
                                 '0'

--- a/rust/lance-namespace-reqwest-client/docs/AddColumnsEntry.md
+++ b/rust/lance-namespace-reqwest-client/docs/AddColumnsEntry.md
@@ -5,7 +5,8 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **name** | **String** | Name of the new column | 
-**expression** | Option<**String**> | SQL expression for the column (optional if virtual_column is specified) | [optional]
+**expression** | Option<**String**> | SQL expression for the column (optional if virtual_column or computed is specified). Evaluated once over existing rows; nothing is stored, so rows appended later read null. | [optional]
+**computed** | Option<**String**> | SQL expression declaring a maintained computed column (optional if expression or virtual_column is specified). The column is added all-null with the expression persisted as its binding in field metadata; its type and input columns are inferred from the expression. Rows are filled by backfill, never at declaration. | [optional]
 **virtual_column** | Option<[**models::AddVirtualColumnEntry**](AddVirtualColumnEntry.md)> |  | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/rust/lance-namespace-reqwest-client/docs/DataApi.md
+++ b/rust/lance-namespace-reqwest-client/docs/DataApi.md
@@ -57,7 +57,7 @@ Name | Type | Description  | Required | Notes
 > models::AlterTableBackfillColumnsResponse alter_table_backfill_columns(id, alter_table_backfill_columns_request, delimiter)
 Trigger an async column backfill job
 
-Trigger an asynchronous backfill job for a computed column on table `id`. The column must be a virtual (UDF-backed) column. Returns a job ID for tracking. 
+Trigger an asynchronous backfill job for a computed column on table `id`. The column must be a virtual (UDF-backed) column or a computed column declared with an expression binding. Returns a job ID for tracking. 
 
 ### Parameters
 

--- a/rust/lance-namespace-reqwest-client/docs/TableApi.md
+++ b/rust/lance-namespace-reqwest-client/docs/TableApi.md
@@ -121,7 +121,7 @@ Name | Type | Description  | Required | Notes
 > models::AlterTableBackfillColumnsResponse alter_table_backfill_columns(id, alter_table_backfill_columns_request, delimiter)
 Trigger an async column backfill job
 
-Trigger an asynchronous backfill job for a computed column on table `id`. The column must be a virtual (UDF-backed) column. Returns a job ID for tracking. 
+Trigger an asynchronous backfill job for a computed column on table `id`. The column must be a virtual (UDF-backed) column or a computed column declared with an expression binding. Returns a job ID for tracking. 
 
 ### Parameters
 

--- a/rust/lance-namespace-reqwest-client/src/apis/data_api.rs
+++ b/rust/lance-namespace-reqwest-client/src/apis/data_api.rs
@@ -244,7 +244,7 @@ pub async fn alter_table_add_columns(configuration: &configuration::Configuratio
     }
 }
 
-/// Trigger an asynchronous backfill job for a computed column on table `id`. The column must be a virtual (UDF-backed) column. Returns a job ID for tracking. 
+/// Trigger an asynchronous backfill job for a computed column on table `id`. The column must be a virtual (UDF-backed) column or a computed column declared with an expression binding. Returns a job ID for tracking. 
 pub async fn alter_table_backfill_columns(configuration: &configuration::Configuration, id: &str, alter_table_backfill_columns_request: models::AlterTableBackfillColumnsRequest, delimiter: Option<&str>) -> Result<models::AlterTableBackfillColumnsResponse, Error<AlterTableBackfillColumnsError>> {
     // add a prefix to parameters to efficiently prevent name collisions
     let p_id = id;

--- a/rust/lance-namespace-reqwest-client/src/apis/table_api.rs
+++ b/rust/lance-namespace-reqwest-client/src/apis/table_api.rs
@@ -725,7 +725,7 @@ pub async fn alter_table_alter_columns(configuration: &configuration::Configurat
     }
 }
 
-/// Trigger an asynchronous backfill job for a computed column on table `id`. The column must be a virtual (UDF-backed) column. Returns a job ID for tracking. 
+/// Trigger an asynchronous backfill job for a computed column on table `id`. The column must be a virtual (UDF-backed) column or a computed column declared with an expression binding. Returns a job ID for tracking. 
 pub async fn alter_table_backfill_columns(configuration: &configuration::Configuration, id: &str, alter_table_backfill_columns_request: models::AlterTableBackfillColumnsRequest, delimiter: Option<&str>) -> Result<models::AlterTableBackfillColumnsResponse, Error<AlterTableBackfillColumnsError>> {
     // add a prefix to parameters to efficiently prevent name collisions
     let p_id = id;

--- a/rust/lance-namespace-reqwest-client/src/models/add_columns_entry.rs
+++ b/rust/lance-namespace-reqwest-client/src/models/add_columns_entry.rs
@@ -16,9 +16,12 @@ pub struct AddColumnsEntry {
     /// Name of the new column
     #[serde(rename = "name")]
     pub name: String,
-    /// SQL expression for the column (optional if virtual_column is specified)
+    /// SQL expression for the column (optional if virtual_column or computed is specified). Evaluated once over existing rows; nothing is stored, so rows appended later read null.
     #[serde(rename = "expression", default, with = "::serde_with::rust::double_option", skip_serializing_if = "Option::is_none")]
     pub expression: Option<Option<String>>,
+    /// SQL expression declaring a maintained computed column (optional if expression or virtual_column is specified). The column is added all-null with the expression persisted as its binding in field metadata; its type and input columns are inferred from the expression. Rows are filled by backfill, never at declaration.
+    #[serde(rename = "computed", default, with = "::serde_with::rust::double_option", skip_serializing_if = "Option::is_none")]
+    pub computed: Option<Option<String>>,
     #[serde(rename = "virtual_column", default, with = "::serde_with::rust::double_option", skip_serializing_if = "Option::is_none")]
     pub virtual_column: Option<Option<Box<models::AddVirtualColumnEntry>>>,
 }
@@ -28,6 +31,7 @@ impl AddColumnsEntry {
         AddColumnsEntry {
             name,
             expression: None,
+            computed: None,
             virtual_column: None,
         }
     }


### PR DESCRIPTION
AddColumnsEntry gains a computed member for maintained SQL-expression
columns: declared all-null with the expression persisted as the binding,
type and inputs inferred server-side, filled by backfill rather than at
declaration. The backfill route description widens from UDF-backed columns
to cover expression-computed ones, matching the deployed server. Generated
clients regenerated.

