### PR TITLE
fix(spec): add a concrete server URL so request examples render

### DIFF
--- a/docs/src/spec.yaml
+++ b/docs/src/spec.yaml
@@ -29,6 +29,11 @@ info:
     Lance REST Namespace implementation, which defines a complete REST server that can work with Lance datasets.
     See https://lance.org/format/namespace/rest for more details.
 servers:
+  # A concrete URL must come first. Documentation renderers and API consoles
+  # substitute no variables when every server is templated, so they cannot build
+  # a request URL and render an error in place of each endpoint's code samples.
+  - url: http://localhost:2333
+    description: Default local server
   - url: "{scheme}://{host}:{port}/{basePath}"
     description: Generic server URL with all parts configurable
     variables:

--- a/java/lance-namespace-apache-client/api/openapi.yaml
+++ b/java/lance-namespace-apache-client/api/openapi.yaml
@@ -16,6 +16,8 @@ info:
   title: Lance Namespace Specification
   version: 1.0.0
 servers:
+- description: Default local server
+  url: http://localhost:2333
 - description: Generic server URL with all parts configurable
   url: "{scheme}://{host}:{port}/{basePath}"
   variables:

--- a/java/lance-namespace-apache-client/src/main/java/org/lance/namespace/client/apache/ApiClient.java
+++ b/java/lance-namespace-apache-client/src/main/java/org/lance/namespace/client/apache/ApiClient.java
@@ -87,6 +87,10 @@ public class ApiClient extends JavaTimeFormatter {
       new ArrayList<ServerConfiguration>(
           Arrays.asList(
               new ServerConfiguration(
+                  "http://localhost:2333",
+                  "Default local server",
+                  new HashMap<String, ServerVariable>()),
+              new ServerConfiguration(
                   "{scheme}://{host}:{port}/{basePath}",
                   "Generic server URL with all parts configurable",
                   new HashMap<String, ServerVariable>() {

--- a/java/lance-namespace-async-client/api/openapi.yaml
+++ b/java/lance-namespace-async-client/api/openapi.yaml
@@ -16,6 +16,8 @@ info:
   title: Lance Namespace Specification
   version: 1.0.0
 servers:
+- description: Default local server
+  url: http://localhost:2333
 - description: Generic server URL with all parts configurable
   url: "{scheme}://{host}:{port}/{basePath}"
   variables:

--- a/python/lance_namespace_urllib3_client/lance_namespace_urllib3_client/configuration.py
+++ b/python/lance_namespace_urllib3_client/lance_namespace_urllib3_client/configuration.py
@@ -557,6 +557,10 @@ conf = lance_namespace_urllib3_client.Configuration(
         """
         return [
             {
+                'url': "http://localhost:2333",
+                'description': "Default local server",
+            },
+            {
                 'url': "{scheme}://{host}:{port}/{basePath}",
                 'description': "Generic server URL with all parts configurable",
                 'variables': {


### PR DESCRIPTION
Every entry in `servers` is templated (`{scheme}://{host}:{port}/{basePath}`). Documentation renderers and API consoles substitute no variables in that case, so they cannot construct a request URL and print an error where each endpoint's code samples belong.

On [docs.lancedb.com](https://docs.lancedb.com/api-reference/rest/table/list-all-tables) this currently leaves **43–48 of the 55 REST reference pages** showing *"A valid request URL is required to generate request examples"* instead of cURL/Python/JavaScript samples. Which pages fail varies between builds, and the pages that do render emit the unsubstituted template as the request URL:

```
curl --request GET --url {scheme}://{host}:{port}/{basePath}/v1/table
```

Adding a concrete server ahead of the templated ones resolves it. Verified end to end by building the docs site against the patched spec: **all 55 endpoint pages render examples**, with real URLs (`http://localhost:2333/v1/table`).

The templated entries are kept, so a configurable base URL remains available. `http://localhost:2333` matches what the first templated server already resolves to from its own defaults, so the effective default is unchanged apart from dropping a trailing slash that produced `//v1/...` in generated paths.

`make lint` (`openapi-spec-validator --errors all`) passes.